### PR TITLE
feat: warm pool — instance reuse for standard mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Warm pool** for `StandardMode`: set `warm_pool_size` (default `0`) to keep
+  completed EC2 instances alive and reuse them for subsequent jobs via AWS SSM
+  `SendCommand`, skipping the ~30–60 s `worker_init` cold-start cost.
+  - `warm_pool_size` — maximum number of idle instances to keep warm (0 = disabled).
+  - `warm_pool_ttl` — seconds a warm idle instance stays alive before eviction
+    (default 600).
+  - Requires `auto_create_instance_profile=True` or `iam_instance_profile_arn`
+    (SSM `SendCommand` needs an IAM role on the instance); a `ValueError` is raised
+    at construction time if neither is provided.
+  - Warm instances are tracked with `STATUS_WARM`; `_cleanup_resources()` handles
+    pool-full oldest-instance eviction and TTL-based termination.
+  - State (`_warm_instances` list) is persisted to the state file so warm instances
+    survive a provider restart with the same `state_file_path`.
+  - `status()` now short-circuits jobs already in a terminal state, preventing stale
+    re-queries when an instance has been reused for a different job.
+
 ### Fixed
 - `examples/parsl_aws_integration.py`: added `encrypted=False` to `HighThroughputExecutor`
   config. Parsl HTEX uses CurveZMQ encryption by default; the interchange generates TLS

--- a/parsl_ephemeral_aws/constants.py
+++ b/parsl_ephemeral_aws/constants.py
@@ -157,6 +157,11 @@ STATUS_CANCELED = "CANCELED"
 STATUS_CANCELLED = "CANCELED"  # British spelling alias
 STATUS_UNKNOWN = "UNKNOWN"
 STATUS_SUCCEEDED = "COMPLETED"  # Alias for compatibility
+STATUS_WARM = "WARM"  # instance running, job done, ready for reuse
+
+# Warm pool defaults
+DEFAULT_WARM_POOL_SIZE = 0  # 0 = disabled
+DEFAULT_WARM_POOL_TTL = 600  # seconds a warm idle instance stays alive
 
 # Lambda defaults (minimal for imports)
 DEFAULT_LAMBDA_TIMEOUT = 300

--- a/parsl_ephemeral_aws/modes/standard.py
+++ b/parsl_ephemeral_aws/modes/standard.py
@@ -35,6 +35,7 @@ from parsl_ephemeral_aws.constants import (
     STATUS_PENDING,
     STATUS_RUNNING,
     STATUS_UNKNOWN,
+    STATUS_WARM,
 )
 from parsl_ephemeral_aws.exceptions import (
     NetworkCreationError,
@@ -96,6 +97,9 @@ class StandardMode(OperatingMode):
         instance_types: Optional[List[str]] = None,
         nodes_per_block: int = 1,
         spot_max_price_percentage: Optional[int] = None,
+        warm_pool_size: int = 0,
+        warm_pool_ttl: int = 600,
+        iam_instance_profile_arn: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
         """Initialize the standard mode.
@@ -182,6 +186,13 @@ class StandardMode(OperatingMode):
         self.nodes_per_block = nodes_per_block
         self.spot_max_price_percentage = spot_max_price_percentage
 
+        # Warm pool attributes
+        self.warm_pool_size = warm_pool_size
+        self.warm_pool_ttl = warm_pool_ttl
+        self.iam_instance_profile_arn = iam_instance_profile_arn
+        # List of instance IDs currently in the warm pool (ready for reuse, FIFO)
+        self._warm_instances: List[str] = []
+
         # Initialize SpotFleetManager if using spot fleet
         self.spot_fleet_manager = None
         self.spot_interruption_monitor = None
@@ -251,6 +262,7 @@ class StandardMode(OperatingMode):
             "initialized": self.initialized,
             "use_spot_fleet": self.use_spot_fleet,
             "spot_interruption_handling": self.spot_interruption_handling,
+            "warm_instances": list(self._warm_instances),
         }
 
         # Include spot fleet state if applicable
@@ -292,6 +304,16 @@ class StandardMode(OperatingMode):
                     "security_group_id", self.security_group_id
                 )
                 self.initialized = state.get("initialized", False)
+                # Restore warm pool list; fall back to scanning resources for
+                # STATUS_WARM entries in case the key is absent (older state files)
+                if "warm_instances" in state:
+                    self._warm_instances = state["warm_instances"]
+                else:
+                    self._warm_instances = [
+                        rid
+                        for rid, r in self.resources.items()
+                        if r.get("warm_pool") and r.get("status") == STATUS_WARM
+                    ]
 
                 # Check if spot interruption handling was previously enabled
                 previous_spot_handling = state.get("spot_interruption_handling", False)
@@ -879,15 +901,38 @@ class StandardMode(OperatingMode):
         logger.info(f"Submitting job {job_id} ({job_name if job_name else 'unnamed'})")
 
         try:
-            # Prepare worker initialization script
-            init_script = self._prepare_init_script(command, job_id)
+            # --- Warm pool fast path: reuse an idle instance ---
+            if self.warm_pool_size > 0:
+                warm_instance_id = self._get_warm_instance()
+                if warm_instance_id is not None:
+                    logger.info(
+                        f"Reusing warm instance {warm_instance_id} for job {job_id}"
+                    )
+                    ssm_command_id = self._dispatch_ssm_command(
+                        warm_instance_id, command, job_id
+                    )
+                    # Update resource record in-place for the new job
+                    self.resources[warm_instance_id].update(
+                        {
+                            "job_id": job_id,
+                            "job_name": job_name or "unnamed",
+                            "status": STATUS_RUNNING,
+                            "command": command,
+                            "tasks_per_node": tasks_per_node,
+                            "ssm_command_id": ssm_command_id,
+                            "warm_since": None,
+                            "created_at": time.time(),
+                        }
+                    )
+                    self.save_state()
+                    return warm_instance_id
 
-            # Create EC2 instance
+            # --- Cold path: create a new EC2 instance ---
+            init_script = self._prepare_init_script(command, job_id)
             instance_id = self._create_instance(init_script, job_id, job_name)
 
             # Track the resource
             resource_type = RESOURCE_TYPE_EC2
-            # Check if this is actually a Spot Fleet block ID
             if (
                 self.use_spot_fleet
                 and self.spot_fleet_manager
@@ -895,7 +940,7 @@ class StandardMode(OperatingMode):
             ):
                 resource_type = RESOURCE_TYPE_SPOT_FLEET
 
-            self.resources[instance_id] = {
+            resource_data: Dict[str, Any] = {
                 "type": resource_type,
                 "job_id": job_id,
                 "job_name": job_name or "unnamed",
@@ -904,6 +949,29 @@ class StandardMode(OperatingMode):
                 "command": command,
                 "tasks_per_node": tasks_per_node,
             }
+
+            if self.warm_pool_size > 0:
+                # Warm pool cold start: wait for SSM then dispatch command
+                resource_data["warm_pool"] = True
+                self.resources[instance_id] = resource_data
+                try:
+                    self._wait_for_ssm_online(instance_id)
+                    self._wait_for_worker_ready(instance_id)
+                    ssm_command_id = self._dispatch_ssm_command(
+                        instance_id, command, job_id
+                    )
+                    self.resources[instance_id]["ssm_command_id"] = ssm_command_id
+                    self.resources[instance_id]["status"] = STATUS_RUNNING
+                    self.resources[instance_id]["warm_since"] = None
+                except Exception as ssm_err:
+                    logger.error(
+                        f"SSM setup failed for warm pool instance {instance_id}: "
+                        f"{ssm_err}. Falling back to UserData execution."
+                    )
+                    # Remove warm_pool flag so status is tracked via EC2 state
+                    self.resources[instance_id].pop("warm_pool", None)
+            else:
+                self.resources[instance_id] = resource_data
 
             # Save state
             self.save_state()
@@ -920,7 +988,7 @@ class StandardMode(OperatingMode):
         Parameters
         ----------
         command : str
-            Command to execute
+            Command to execute (ignored when warm_pool_size > 0; dispatched via SSM)
         job_id : str
             Job ID
 
@@ -934,7 +1002,15 @@ class StandardMode(OperatingMode):
         if self.worker_init:
             init_script += f"{self.worker_init}\n"
 
-        # Set environment variables
+        if self.warm_pool_size > 0:
+            # Warm pool: UserData only runs worker_init and drops a ready marker.
+            # The actual command is dispatched later via SSM SendCommand so the
+            # instance can be reused across multiple jobs without re-installing.
+            init_script += "mkdir -p /var/run/parsl\n"
+            init_script += "touch /var/run/parsl_worker_ready\n"
+            return init_script
+
+        # Non-warm-pool path: embed command and optional shutdown in UserData
         init_script += "\n# Set environment variables\n"
         init_script += f"export PARSL_JOB_ID={job_id}\n"
         init_script += f"export PARSL_PROVIDER_ID={self.provider_id}\n"
@@ -950,6 +1026,144 @@ class StandardMode(OperatingMode):
             init_script += "shutdown -h now\n"
 
         return init_script
+
+    # ------------------------------------------------------------------
+    # Warm pool helpers
+    # ------------------------------------------------------------------
+
+    def _get_warm_instance(self) -> Optional[str]:
+        """Pop the oldest available warm instance from the pool (FIFO).
+
+        Returns
+        -------
+        Optional[str]
+            Instance ID if a warm instance is available, otherwise None.
+            The returned instance's status is updated to STATUS_RUNNING.
+        """
+        if not self._warm_instances:
+            return None
+        instance_id = self._warm_instances.pop(0)
+        if instance_id in self.resources:
+            self.resources[instance_id]["status"] = STATUS_RUNNING
+            self.resources[instance_id]["warm_since"] = None
+        logger.debug(
+            f"Popped warm instance {instance_id} from pool "
+            f"({len(self._warm_instances)} remaining)"
+        )
+        return instance_id
+
+    def _wait_for_ssm_online(self, instance_id: str, timeout: int = 300) -> None:
+        """Wait for an EC2 instance to register with AWS Systems Manager.
+
+        Parameters
+        ----------
+        instance_id : str
+            EC2 instance ID to wait for.
+        timeout : int, optional
+            Maximum seconds to wait, by default 300.
+
+        Raises
+        ------
+        OperatingModeError
+            If the instance does not appear in SSM within *timeout* seconds.
+        """
+        ssm = self.session.client("ssm")
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            try:
+                resp = ssm.describe_instance_information(
+                    Filters=[{"Key": "InstanceIds", "Values": [instance_id]}]
+                )
+                if resp.get("InstanceInformationList"):
+                    logger.debug(f"Instance {instance_id} is online in SSM")
+                    return
+            except ClientError as e:
+                logger.debug(f"SSM describe_instance_information: {e}")
+            time.sleep(10)
+        raise OperatingModeError(
+            f"Instance {instance_id} did not become available in SSM "
+            f"within {timeout}s"
+        )
+
+    def _wait_for_worker_ready(self, instance_id: str, timeout: int = 600) -> None:
+        """Wait for the worker ready marker on an instance via SSM RunCommand.
+
+        The init script (UserData) touches ``/var/run/parsl_worker_ready`` once
+        worker_init completes.  This method polls until that file exists.
+
+        Parameters
+        ----------
+        instance_id : str
+            EC2 instance ID to check.
+        timeout : int, optional
+            Maximum seconds to wait, by default 600.
+
+        Raises
+        ------
+        OperatingModeError
+            If the ready marker is not found within *timeout* seconds.
+        """
+        ssm = self.session.client("ssm")
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            try:
+                resp = ssm.send_command(
+                    InstanceIds=[instance_id],
+                    DocumentName="AWS-RunShellScript",
+                    Parameters={"commands": ["test -f /var/run/parsl_worker_ready"]},
+                    Comment="Parsl worker ready check",
+                )
+                command_id = resp["Command"]["CommandId"]
+                # Brief wait then check the result
+                time.sleep(5)
+                invocation = ssm.get_command_invocation(
+                    CommandId=command_id,
+                    InstanceId=instance_id,
+                )
+                if invocation.get("StatusDetails") == "Success":
+                    logger.debug(f"Worker ready on {instance_id}")
+                    return
+            except ClientError as e:
+                logger.debug(f"SSM ready check: {e}")
+            time.sleep(15)
+        raise OperatingModeError(
+            f"Worker ready marker not found on {instance_id} within {timeout}s"
+        )
+
+    def _dispatch_ssm_command(self, instance_id: str, command: str, job_id: str) -> str:
+        """Dispatch a shell command to an EC2 instance via SSM SendCommand.
+
+        Parameters
+        ----------
+        instance_id : str
+            Target EC2 instance ID.
+        command : str
+            Shell command to execute.
+        job_id : str
+            Parsl job ID (used for environment variable export and comment).
+
+        Returns
+        -------
+        str
+            SSM CommandId for later status polling via ``get_command_invocation``.
+        """
+        ssm = self.session.client("ssm")
+        env_setup = (
+            f"export PARSL_JOB_ID={job_id}\n"
+            f"export PARSL_PROVIDER_ID={self.provider_id}\n"
+            "export PARSL_WORKER_ID=$(hostname)\n"
+        )
+        response = ssm.send_command(
+            InstanceIds=[instance_id],
+            DocumentName="AWS-RunShellScript",
+            Parameters={"commands": [env_setup + command]},
+            Comment=f"Parsl job {job_id[:16]}",
+        )
+        command_id = response["Command"]["CommandId"]
+        logger.debug(
+            f"Dispatched SSM command {command_id} to {instance_id} for job {job_id}"
+        )
+        return command_id
 
     def _create_instance(
         self, init_script: str, job_id: str, job_name: Optional[str] = None
@@ -1025,6 +1239,10 @@ class StandardMode(OperatingMode):
         # Add key pair if specified
         if self.key_name:
             run_args["KeyName"] = self.key_name
+
+        # Attach IAM instance profile when warm pool is enabled (SSM requires it)
+        if self.warm_pool_size > 0 and self.iam_instance_profile_arn:
+            run_args["IamInstanceProfile"] = {"Arn": self.iam_instance_profile_arn}
 
         # Use spot instances if requested
         if self.use_spot:
@@ -1269,9 +1487,10 @@ class StandardMode(OperatingMode):
         ec2 = self.session.client("ec2")
         status_map = {}
 
-        # Group IDs by resource type
+        # Group IDs by resource type / tracking method
         ec2_instances = []
         spot_fleet_blocks = []
+        warm_pool_instances = []  # tracked via SSM command invocation
 
         for resource_id in resource_ids:
             resource = self.resources.get(resource_id)
@@ -1279,12 +1498,52 @@ class StandardMode(OperatingMode):
                 status_map[resource_id] = STATUS_UNKNOWN
                 continue
 
-            if resource.get("type") == RESOURCE_TYPE_EC2:
+            if resource.get("warm_pool") and resource.get("ssm_command_id"):
+                warm_pool_instances.append(resource_id)
+            elif resource.get("type") == RESOURCE_TYPE_EC2:
                 ec2_instances.append(resource_id)
             elif resource.get("type") == RESOURCE_TYPE_SPOT_FLEET:
                 spot_fleet_blocks.append(resource_id)
             else:
                 status_map[resource_id] = STATUS_UNKNOWN
+
+        # --- Warm pool: poll SSM command invocation status ---
+        if warm_pool_instances:
+            ssm = self.session.client("ssm")
+            for instance_id in warm_pool_instances:
+                resource = self.resources[instance_id]
+                command_id = resource["ssm_command_id"]
+                try:
+                    response = ssm.get_command_invocation(
+                        CommandId=command_id,
+                        InstanceId=instance_id,
+                    )
+                    ssm_status = response.get("Status", "Unknown")
+                    if ssm_status == "Success":
+                        status = STATUS_COMPLETED
+                    elif ssm_status in (
+                        "Failed",
+                        "TimedOut",
+                        "Cancelled",
+                        "Undeliverable",
+                        "DeliveryTimedOut",
+                        "ExecutionTimedOut",
+                    ):
+                        status = STATUS_FAILED
+                    else:
+                        # InProgress, Pending, Delayed, etc.
+                        status = STATUS_RUNNING
+                    status_map[instance_id] = status
+                    self.resources[instance_id]["status"] = status
+                except ClientError as e:
+                    if "InvocationDoesNotExist" in str(e):
+                        # Command not yet received by the instance
+                        status_map[instance_id] = STATUS_RUNNING
+                    else:
+                        logger.error(
+                            f"Failed to get SSM command status for {instance_id}: {e}"
+                        )
+                        status_map[instance_id] = STATUS_UNKNOWN
 
         # Check EC2 instance status
         if ec2_instances:

--- a/parsl_ephemeral_aws/provider.py
+++ b/parsl_ephemeral_aws/provider.py
@@ -27,7 +27,10 @@ from parsl_ephemeral_aws.constants import (
     DEFAULT_MIN_BLOCKS,
     DEFAULT_MODE,
     DEFAULT_REGION,
+    DEFAULT_WARM_POOL_SIZE,
+    DEFAULT_WARM_POOL_TTL,
     DEFAULT_WORKER_INIT,
+    STATUS_WARM,
 )
 from parsl_ephemeral_aws.exceptions import (
     ProviderConfigurationError,
@@ -56,7 +59,15 @@ _STRING_TO_JOB_STATE: Dict[str, JobState] = {
     "CANCELED": JobState.CANCELLED,
     "CANCELLED": JobState.CANCELLED,
     "UNKNOWN": JobState.UNKNOWN,
+    # WARM = instance idle in warm pool; the JOB is done so Parsl sees RUNNING
+    # (prevents premature cancellation while we reuse the instance).
+    "WARM": JobState.RUNNING,
 }
+
+# Job states that are terminal (Parsl will not re-submit once in these states)
+_TERMINAL_STATES: frozenset = frozenset(
+    {"COMPLETED", "FAILED", "CANCELED", "CANCELLED"}
+)
 
 
 class OperatingModeType(str, Enum):
@@ -182,6 +193,15 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
     waiter_max_attempts : int, optional
         Maximum number of waiter attempts before raising an error.
         Default is 60 (5 minutes at the default delay).
+    warm_pool_size : int, optional
+        Maximum number of instances to keep warm after their job finishes,
+        ready for immediate reuse without re-running worker_init.
+        Requires ``auto_create_instance_profile=True`` or
+        ``iam_instance_profile_arn`` (SSM SendCommand needs an IAM role).
+        Default is 0 (disabled).
+    warm_pool_ttl : int, optional
+        Seconds a warm idle instance stays alive before being terminated.
+        Default is 600 (10 minutes).
     """
 
     @typechecked
@@ -230,6 +250,8 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
         status_polling_interval: int = 60,
         waiter_delay: int = 5,
         waiter_max_attempts: int = 60,
+        warm_pool_size: int = DEFAULT_WARM_POOL_SIZE,
+        warm_pool_ttl: int = DEFAULT_WARM_POOL_TTL,
         **kwargs: Any,
     ) -> None:
         """Initialize the Ephemeral AWS Provider."""
@@ -312,7 +334,20 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
         self._status_polling_interval = status_polling_interval
         self.waiter_delay = waiter_delay
         self.waiter_max_attempts = waiter_max_attempts
+        self.warm_pool_size = warm_pool_size
+        self.warm_pool_ttl = warm_pool_ttl
         self.kwargs = kwargs
+
+        # Guard: warm pool uses SSM SendCommand which requires an IAM instance profile
+        if (
+            warm_pool_size > 0
+            and not auto_create_instance_profile
+            and not iam_instance_profile_arn
+        ):
+            raise ValueError(
+                "warm_pool_size > 0 requires either auto_create_instance_profile=True "
+                "or iam_instance_profile_arn to be set (SSM SendCommand needs IAM permissions)"
+            )
 
         # Initialize state
         self.session = create_session(
@@ -465,7 +500,12 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
         }
 
         if self.mode_type == OperatingModeType.STANDARD:
-            return StandardMode(**common_params)
+            return StandardMode(
+                iam_instance_profile_arn=self.iam_instance_profile_arn,
+                warm_pool_size=self.warm_pool_size,
+                warm_pool_ttl=self.warm_pool_ttl,
+                **common_params,
+            )
         elif self.mode_type == OperatingModeType.DETACHED:
             return DetachedMode(
                 bastion_instance_type=self.bastion_instance_type, **common_params
@@ -533,6 +573,8 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
                     "command": command,
                     "timestamp": time.time(),
                 }
+                if self.warm_pool_size > 0:
+                    self.resources[resource_id]["warm_pool"] = True
 
                 self.job_map[job_id] = {
                     "resource_id": resource_id,
@@ -568,20 +610,33 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
         internal_statuses: Dict[str, str] = {}
 
         try:
-            # Read resource_ids under lock
+            # Short-circuit jobs already in a terminal state — avoids stale
+            # re-queries when an instance has been reused for a different job.
             with self._lock:
+                for job_id in job_ids:
+                    if job_id in self.job_map:
+                        cached = self.job_map[job_id].get("status", "UNKNOWN")
+                        if cached in _TERMINAL_STATES:
+                            internal_statuses[job_id] = cached
+
+                # Only poll for non-terminal jobs
                 resource_ids = [
                     self.job_map[job_id]["resource_id"]
                     for job_id in job_ids
                     if job_id in self.job_map
+                    and self.job_map[job_id].get("status") not in _TERMINAL_STATES
                 ]
 
             # Fetch status outside lock (may involve network calls)
-            status_map = self.operating_mode.get_job_status(resource_ids)
+            status_map = (
+                self.operating_mode.get_job_status(resource_ids) if resource_ids else {}
+            )
 
             # Update internal state under lock
             with self._lock:
                 for job_id in job_ids:
+                    if job_id in internal_statuses:
+                        continue  # already set by terminal short-circuit
                     if job_id in self.job_map:
                         resource_id = self.job_map[job_id]["resource_id"]
                         if resource_id in status_map:
@@ -603,6 +658,11 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
             logger.error(f"Failed to get status for jobs {job_ids}: {e}")
             for job_id in job_ids:
                 internal_statuses.setdefault(job_id, "UNKNOWN")
+
+        # Trigger cleanup to process warm-pool transitions and TTL evictions.
+        # _cleanup_resources() is idempotent and handles its own errors.
+        if self.warm_pool_size > 0:
+            self._cleanup_resources()
 
         return [
             JobStatus(
@@ -674,6 +734,9 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
                 "resources": dict(self.resources),
                 "job_map": dict(self.job_map),
                 "timestamp": time.time(),
+                "warm_instances": list(
+                    getattr(self.operating_mode, "_warm_instances", [])
+                ),
             }
 
         try:
@@ -690,18 +753,56 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
                 with self._lock:
                     self.resources = state.get("resources", {})
                     self.job_map = state.get("job_map", {})
+                    # Restore warm-pool instance list into the operating mode
+                    if self.warm_pool_size > 0 and hasattr(
+                        self.operating_mode, "_warm_instances"
+                    ):
+                        self.operating_mode._warm_instances = state.get(
+                            "warm_instances", []
+                        )
                 logger.info(f"Loaded state with {len(self.resources)} resources")
         except Exception as e:
             logger.error(f"Failed to load provider state: {e}")
 
     def _cleanup_resources(self) -> None:
-        """Clean up resources that are completed or failed."""
-        resources_to_cleanup = []
+        """Clean up resources that are completed or failed.
 
-        # Find resources to clean up (lock protects iteration over self.resources)
+        Also handles the warm-pool lifecycle: transitioning COMPLETED warm-pool
+        instances to WARM state (keeping them alive for reuse) and evicting
+        instances that have exceeded their TTL.
+        """
+        resources_to_cleanup: List[str] = []
+        warm_transitions: List[str] = []  # COMPLETED warm-pool → WARM
+
+        # Scan resources under lock to build action lists
         with self._lock:
             for resource_id, resource in self.resources.items():
                 status = resource.get("status", "UNKNOWN")
+
+                if resource.get("warm_pool"):
+                    if status == STATUS_WARM:
+                        # Check TTL for warm idle instances
+                        age = time.time() - resource.get("warm_since", 0)
+                        if age > self.warm_pool_ttl:
+                            logger.info(
+                                f"Warm instance {resource_id} TTL expired "
+                                f"({age:.0f}s > {self.warm_pool_ttl}s), terminating"
+                            )
+                            resources_to_cleanup.append(resource_id)
+                        continue  # don't apply normal cleanup logic
+
+                    elif status == "COMPLETED":
+                        warm_transitions.append(resource_id)
+                        continue  # decision made below
+
+                    elif status in ("FAILED", "CANCELED"):
+                        resources_to_cleanup.append(resource_id)
+                        continue
+
+                    else:
+                        continue  # PENDING/RUNNING — leave alone
+
+                # Normal (non-warm-pool) lifecycle
                 if status in ["COMPLETED", "FAILED", "CANCELED"]:
                     resources_to_cleanup.append(resource_id)
                 elif (
@@ -711,12 +812,74 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
                 ):
                     logger.info(
                         f"Resource {resource_id} has been idle for "
-                        f"{time.time() - resource.get('timestamp', 0)} seconds, "
+                        f"{time.time() - resource.get('timestamp', 0):.0f} seconds, "
                         f"exceeding max_idle_time {self.max_idle_time}"
                     )
                     resources_to_cleanup.append(resource_id)
 
-        # Clean up resources outside the lock (network calls)
+        # Process COMPLETED → WARM transitions
+        if warm_transitions:
+            with self._lock:
+                current_warm = [
+                    rid
+                    for rid, r in self.resources.items()
+                    if r.get("warm_pool") and r.get("status") == STATUS_WARM
+                ]
+                for resource_id in warm_transitions:
+                    if resource_id not in self.resources:
+                        continue
+                    if len(current_warm) < self.warm_pool_size:
+                        # Transition this instance into the warm pool
+                        self.resources[resource_id]["status"] = STATUS_WARM
+                        self.resources[resource_id]["warm_since"] = time.time()
+                        current_warm.append(resource_id)
+                        if hasattr(self.operating_mode, "_warm_instances"):
+                            self.operating_mode._warm_instances.append(resource_id)
+                        logger.info(
+                            f"Instance {resource_id} moved to warm pool "
+                            f"({len(current_warm)}/{self.warm_pool_size})"
+                        )
+                    else:
+                        # Pool full — evict the oldest warm instance to make room
+                        oldest = min(
+                            current_warm,
+                            key=lambda r: self.resources.get(r, {}).get(
+                                "warm_since", 0
+                            ),
+                        )
+                        current_warm.remove(oldest)
+                        resources_to_cleanup.append(oldest)
+                        if hasattr(self.operating_mode, "_warm_instances"):
+                            try:
+                                self.operating_mode._warm_instances.remove(oldest)
+                            except ValueError:
+                                pass
+                        logger.info(
+                            f"Warm pool full; evicting oldest instance {oldest}, "
+                            f"replacing with {resource_id}"
+                        )
+                        self.resources[resource_id]["status"] = STATUS_WARM
+                        self.resources[resource_id]["warm_since"] = time.time()
+                        current_warm.append(resource_id)
+                        if hasattr(self.operating_mode, "_warm_instances"):
+                            self.operating_mode._warm_instances.append(resource_id)
+
+        # Remove TTL-expired warm instances from the mode's reuse list before
+        # the network termination call (so they can't be dispatched to mid-flight)
+        if resources_to_cleanup and hasattr(self.operating_mode, "_warm_instances"):
+            with self._lock:
+                for resource_id in resources_to_cleanup:
+                    resource = self.resources.get(resource_id, {})
+                    if (
+                        resource.get("warm_pool")
+                        and resource.get("status") == STATUS_WARM
+                    ):
+                        try:
+                            self.operating_mode._warm_instances.remove(resource_id)
+                        except ValueError:
+                            pass
+
+        # Terminate and remove cleaned-up resources (network calls, outside lock)
         if resources_to_cleanup:
             try:
                 self.operating_mode.cleanup_resources(resources_to_cleanup)

--- a/tests/unit/test_provider_edge_cases.py
+++ b/tests/unit/test_provider_edge_cases.py
@@ -8,6 +8,7 @@ SPDX-FileCopyrightText: 2025 Scott Friedman and Project Contributors
 
 import os
 import tempfile
+import time
 import uuid
 from unittest.mock import MagicMock, patch
 
@@ -146,3 +147,161 @@ class TestProviderEdgeCases:
 
         assert provider.waiter_delay == 5
         assert provider.waiter_max_attempts == 60
+
+
+# ---------------------------------------------------------------------------
+# TestWarmPool
+# ---------------------------------------------------------------------------
+
+
+_FAKE_IAM_ARN = "arn:aws:iam::123456789012:instance-profile/ParslSSMProfile"
+
+
+@pytest.mark.unit
+class TestWarmPool:
+    """Unit tests for the warm pool instance-reuse feature."""
+
+    @pytest.fixture
+    def tmp_dir(self):
+        with tempfile.TemporaryDirectory() as d:
+            yield d
+
+    # --- parameter / guard tests ---
+
+    def test_warm_pool_disabled_by_default(self, tmp_dir):
+        """warm_pool_size defaults to 0 and warm_pool_ttl to 600."""
+        provider, _ = _make_provider(tmp_dir)
+
+        assert provider.warm_pool_size == 0
+        assert provider.warm_pool_ttl == 600
+
+    def test_warm_pool_iam_guard_raises(self, tmp_dir):
+        """warm_pool_size > 0 without an IAM profile raises ValueError."""
+        with pytest.raises(ValueError, match="iam_instance_profile_arn"):
+            _make_provider(tmp_dir, warm_pool_size=1)
+
+    def test_warm_pool_iam_guard_passes_with_arn(self, tmp_dir):
+        """warm_pool_size > 0 with iam_instance_profile_arn does not raise."""
+        provider, _ = _make_provider(
+            tmp_dir,
+            warm_pool_size=2,
+            iam_instance_profile_arn=_FAKE_IAM_ARN,
+        )
+
+        assert provider.warm_pool_size == 2
+
+    def test_warm_pool_iam_guard_passes_with_auto_create(self, tmp_dir):
+        """warm_pool_size > 0 with auto_create_instance_profile=True does not raise."""
+        provider, _ = _make_provider(
+            tmp_dir,
+            warm_pool_size=1,
+            auto_create_instance_profile=True,
+        )
+
+        assert provider.warm_pool_size == 1
+
+    # --- lifecycle: COMPLETED → WARM transition ---
+
+    def _make_warm_provider(self, tmp_dir, warm_pool_size=2, warm_pool_ttl=600):
+        """Create a provider with warm pool enabled and a mode mock with _warm_instances."""
+        provider, mode = _make_provider(
+            tmp_dir,
+            warm_pool_size=warm_pool_size,
+            warm_pool_ttl=warm_pool_ttl,
+            iam_instance_profile_arn=_FAKE_IAM_ARN,
+        )
+        mode._warm_instances = []
+        return provider, mode
+
+    def test_completed_warm_pool_instance_transitions_to_warm(self, tmp_dir):
+        """_cleanup_resources() moves a COMPLETED warm-pool resource to WARM state."""
+        provider, mode = self._make_warm_provider(tmp_dir)
+
+        provider.resources["i-001"] = {
+            "job_id": "j-001",
+            "status": "COMPLETED",
+            "warm_pool": True,
+            "timestamp": time.time(),
+        }
+        provider.job_map["j-001"] = {"resource_id": "i-001", "status": "COMPLETED"}
+
+        provider._cleanup_resources()
+
+        assert "i-001" in provider.resources
+        assert provider.resources["i-001"]["status"] == "WARM"
+        assert "warm_since" in provider.resources["i-001"]
+        assert "i-001" in mode._warm_instances
+
+    def test_warm_instance_not_cleaned_up_before_ttl(self, tmp_dir):
+        """A WARM instance within its TTL is not terminated."""
+        provider, mode = self._make_warm_provider(tmp_dir, warm_pool_ttl=600)
+        mode._warm_instances = ["i-001"]
+
+        provider.resources["i-001"] = {
+            "job_id": "j-001",
+            "status": "WARM",
+            "warm_pool": True,
+            "warm_since": time.time() - 60,  # 60s old, TTL is 600s
+        }
+        provider.job_map["j-001"] = {"resource_id": "i-001", "status": "COMPLETED"}
+
+        provider._cleanup_resources()
+
+        assert "i-001" in provider.resources  # still alive
+        assert mode.cleanup_resources.call_count == 0
+
+    # --- TTL eviction ---
+
+    def test_ttl_eviction_terminates_expired_warm_instance(self, tmp_dir):
+        """A WARM instance past its TTL is terminated by _cleanup_resources()."""
+        provider, mode = self._make_warm_provider(tmp_dir, warm_pool_ttl=60)
+        mode._warm_instances = ["i-001"]
+
+        provider.resources["i-001"] = {
+            "job_id": "j-001",
+            "status": "WARM",
+            "warm_pool": True,
+            "warm_since": time.time() - 120,  # 120s old > 60s TTL
+        }
+        provider.job_map["j-001"] = {"resource_id": "i-001", "status": "COMPLETED"}
+
+        provider._cleanup_resources()
+
+        assert "i-001" not in provider.resources
+        assert "i-001" not in mode._warm_instances
+        mode.cleanup_resources.assert_called_once_with(["i-001"])
+
+    # --- pool-full eviction ---
+
+    def test_pool_full_evicts_oldest_warm_instance(self, tmp_dir):
+        """When the pool is full, the oldest warm instance is evicted for the newcomer."""
+        provider, mode = self._make_warm_provider(tmp_dir, warm_pool_size=1)
+        now = time.time()
+
+        # Existing warm instance (old)
+        mode._warm_instances = ["i-old"]
+        provider.resources["i-old"] = {
+            "job_id": "j-old",
+            "status": "WARM",
+            "warm_pool": True,
+            "warm_since": now - 300,
+        }
+        provider.job_map["j-old"] = {"resource_id": "i-old", "status": "COMPLETED"}
+
+        # New instance whose job just completed
+        provider.resources["i-new"] = {
+            "job_id": "j-new",
+            "status": "COMPLETED",
+            "warm_pool": True,
+            "timestamp": now,
+        }
+        provider.job_map["j-new"] = {"resource_id": "i-new", "status": "COMPLETED"}
+
+        provider._cleanup_resources()
+
+        # Oldest evicted, newcomer kept
+        assert "i-old" not in provider.resources
+        assert "i-new" in provider.resources
+        assert provider.resources["i-new"]["status"] == "WARM"
+        assert "i-new" in mode._warm_instances
+        assert "i-old" not in mode._warm_instances


### PR DESCRIPTION
## Summary

Cold-starting a worker EC2 instance costs ~30–60 s because `worker_init` installs
python3.11 + parsl on a fresh Amazon Linux 2023 node. This PR adds a **warm pool**
that keeps instances running after their job finishes and reuses them for subsequent
submissions via AWS SSM `SendCommand`, skipping the cold-start cost entirely.

Closes #63

## New parameters

| Parameter | Type | Default | Description |
|-----------|------|---------|-------------|
| `warm_pool_size` | `int` | `0` | Max instances to keep warm (0 = disabled) |
| `warm_pool_ttl` | `int` | `600` | Seconds a warm idle instance stays alive |

**IAM guard**: `warm_pool_size > 0` requires `auto_create_instance_profile=True` or
`iam_instance_profile_arn`; a `ValueError` is raised at construction time otherwise.

## How it works

**Warm fast path** (reuse):
1. `submit_job()` pops the oldest idle instance from `_warm_instances` (FIFO)
2. Dispatches command via SSM `SendCommand` — no new EC2 instance created
3. Log line: `"Reusing warm instance i-xxx for job <job_id>"`

**Cold path** (first job on a new instance):
1. UserData = `worker_init` + `touch /var/run/parsl_worker_ready` (no command embedded)
2. After boot: `_wait_for_ssm_online` → `_wait_for_worker_ready` → `_dispatch_ssm_command`
3. Instance kept alive after job completes (no `shutdown -h now`)

**Status polling**: warm-pool instances are polled via `ssm.get_command_invocation`
instead of EC2 instance state. SSM statuses map to: Success→COMPLETED, Failed/TimedOut/Cancelled→FAILED, InProgress/Pending→RUNNING.

**Lifecycle** (`provider._cleanup_resources()`):
- `COMPLETED` + `warm_pool` → transition to `WARM`, add to `_warm_instances`
- Pool full → evict oldest warm instance, accept new one
- `WARM` + TTL expired → terminate

`provider.status()` now short-circuits jobs already in a terminal state to prevent stale re-queries when an instance has been reused for a different job.

Warm instance list is persisted to the state file and restored on restart.

## Files changed

| File | Changes |
|------|---------|
| `parsl_ephemeral_aws/constants.py` | `STATUS_WARM`, `DEFAULT_WARM_POOL_SIZE`, `DEFAULT_WARM_POOL_TTL` |
| `parsl_ephemeral_aws/provider.py` | Params, IAM guard, warm-pool resource flag, `_cleanup_resources()` lifecycle, terminal-state short-circuit in `status()`, state persistence |
| `parsl_ephemeral_aws/modes/standard.py` | `_prepare_init_script`, `submit_job`, `get_job_status`, `_create_instance` (IAM profile), `save/load_state`, 4 new SSM helpers |
| `tests/unit/test_provider_edge_cases.py` | 8 new unit tests |
| `CHANGELOG.md` | `[Unreleased]` entry |

## Test plan

- [x] `uv run --python 3.11 pytest tests/unit/ -m unit --no-cov -q` — 83 tests pass, zero regressions
- [ ] Smoke test: set `warm_pool_size=1` in `examples/parsl_aws_integration.py`, submit 2 tasks — second task log should show `"Reusing warm instance i-xxx"` and complete ~30–50 s faster