### PR TITLE
Phase 1: correctness — repair all three operating modes, the state layer, and one-shot dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,11 +34,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in #69 the explicit-subnet branch always ran, so the line always raised. It
   also overwrote the caller's explicit subnet with every subnet discovered in the
   VPC (closes #71).
+- `ServerlessMode` could never be constructed. `LambdaManager` and `ECSManager`
+  were written against `EphemeralAWSProvider` but are handed the mode as their
+  `provider`, and the mode defined none of the attributes they read — so
+  `_initialize_compute_managers()` raised
+  `AttributeError: 'ServerlessMode' object has no attribute 'workflow_id'`.
+  Since `EphemeralAWSProvider.__init__` calls `initialize()` unconditionally,
+  `EphemeralAWSProvider(mode="serverless")` always raised. The mode now defines
+  `workflow_id`, `subnet_ids`, `use_spot_instances`, `security_config`, and the
+  four credential attributes (closes #72).
+- `compute_type`, `memory_size`, and `timeout` were forwarded by the provider but
+  accepted by no `ServerlessMode` parameter, so they vanished into `**kwargs`:
+  `worker_type` was always `auto` regardless of `compute_type`, and Lambda memory
+  and timeout were always the defaults (closes #73).
+- `ServerlessMode.initialize()` never set `self.initialized`, so every
+  `submit_job()` re-ran `ensure_initialized()` and rebuilt both compute managers
+  (closes #73).
+- `LambdaManager._generate_lambda_code()` raised
+  `ValueError: Invalid format specifier` on every call. The generated handler was
+  built as an f-string whose literal dict braces were read as replacement fields,
+  so no Lambda job could ever be submitted. All six test call sites patch the
+  method with a stub, so the real body had never run. It is now a plain template
+  with a single JSON-encoded substitution for the command (closes #96).
+- `LambdaManager._create_credential_config_from_provider()` raised
+  `TypeError: CredentialConfiguration.__init__() got an unexpected keyword
+  argument 'aws_access_key_id'` on every construction — none of the three
+  `aws_*` kwargs it passed are fields on the dataclass. It now matches the
+  `EC2Manager`/`ECSManager`/`SpotFleetManager` implementations, and no longer
+  defaults `use_profile` to a profile literally named `aws` (closes #95).
 
 ### Added
 - `tests/unit/test_ecs_manager.py` — 6 tests covering explicit `subnet_id`,
   explicit `subnet_ids` precedence, subnet discovery, default-VPC fallback, and
   both empty-result error paths.
+- `tests/unit/test_serverless_mode_contract.py` — 30 tests covering the
+  compute-manager attribute contract, the conditional network guard, provider
+  parameter plumbing, and the absence of the network-creation helpers.
+- `tests/unit/test_lambda_manager.py` — 13 tests that execute the real
+  `_generate_lambda_code()` body and compile its output.
+
+### Changed
+- `vpc_id`, `subnet_id`, and `security_group_id` are no longer required for
+  Lambda-only serverless mode. `compute/lambda_func.py` references none of them
+  and `create_function` passes no `VpcConfig`, so functions run in the
+  Lambda-managed VPC. ECS/Fargate still requires them — `awsvpcConfiguration` is
+  mandatory — so the guard now keys off the resolved worker type in both
+  `EphemeralAWSProvider` and `OperatingMode` (new `require_network_resources`
+  flag) (closes #74).
+- `EphemeralAWSProvider` now passes `region` explicitly to the operating mode
+  rather than letting it fall back to `session.region_name`.
 
 ### Removed
 - `SpotFleetManager._create_vpc()`, `_create_subnet()`, `_create_security_group()`,
@@ -50,6 +94,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `_create_vpc()`, `_create_subnet()`, `_create_security_group()`, and
   `_find_available_vpc_cidr()` helpers deleted from `StandardMode` and
   `DetachedMode`.
+- `ServerlessMode._create_vpc()`, `_create_subnet()`, and
+  `_create_security_group()` (182 LOC). These built the VPC through
+  CloudFormation rather than direct EC2 calls, which is why #69's pass missed
+  them; `create_vpc` is gone from `ServerlessMode` as well (closes #73).
 
 ### Changed
 - `vpc_id`, `subnet_id`, and `security_group_id` are now **required** constructor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `initialize()`, on both the fresh and resumed paths (the ARN is not persisted
   in state). A failure to create the profile is logged, not fatal: dispatch
   degrades to UserData rather than the provider failing to start (closes #75).
+- One-shot instances stopped instead of terminating, leaving a billed EBS volume.
+  `StandardMode._create_instance()` never set
+  `InstanceInitiatedShutdownBehavior`, and EC2 defaults an instance-initiated
+  shutdown to *stop* — so the `shutdown -h now` appended by
+  `_prepare_init_script()` stopped the instance. Because `EC2_STATUS_MAPPING`
+  maps `stopped` to `COMPLETED`, the provider then dropped the tracking record,
+  orphaning the volume as well as billing for it. `DetachedMode` had set
+  `terminate` on all three of its launch paths since v0.2.0 (closes #76).
+- One-shot command failures reported `COMPLETED`. #66 specified "command exits
+  non-zero → FAILED", but status was derived purely from EC2 instance state,
+  which is identical whether the command succeeded or failed. One-shot dispatch
+  now goes through the same SSM `SendCommand` path the warm pool uses, so the
+  exit code is reported; it is also recorded on the resource as `exit_code`, and
+  a failure logs the command's stderr (closes #76).
+- `StandardMode._create_spot_instance()` raised
+  `ParamValidationError: Unknown parameter in LaunchSpecification: "MinCount"`
+  on every call. `run_args` is built for `run_instances` and reused as the spot
+  `LaunchSpecification`, which expresses count as the top-level `InstanceCount`;
+  boto3 validates parameter names client-side, so `use_spot=True` could never
+  submit a job unless `use_spot_fleet=True` routed around it. The
+  `RunInstances`-only keys are now stripped (closes #97).
 - Instance-profile resolution no longer leaves a profile permanently empty. The
   previous implementation returned early when `get_instance_profile` succeeded,
   so a profile whose role attachment had failed midway kept being reused with no
@@ -78,6 +99,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   paths (pre-existing profile, freshly created, and lost creation race).
 
 ### Added
+- **One-shot mode** for `StandardMode`: set `one_shot=True` to declare that each
+  EC2 instance runs a single command and then terminates, regardless of the
+  `auto_shutdown` setting (closes #66).
+  - The command is dispatched over SSM `SendCommand` after the instance reports
+    ready, so its exit code determines the job status. UserData carries only
+    `worker_init` and the readiness marker.
+  - The instance is terminated by `_cleanup_resources()` once the command
+    reaches a terminal state; a detached `shutdown -h now` in the dispatched
+    script bounds the cost if the driver process dies first. It is scheduled
+    after the exit code is captured, so it cannot mask a non-zero exit.
+  - Raises `ValueError` at construction time if combined with
+    `warm_pool_size > 0` (one-shot instances are terminated and cannot be
+    reused), or if no instance profile is available.
+  - `one_shot=False` (default): zero code-path changes for existing users.
+- `tests/aws/test_one_shot_e2e.py` — 8 real-AWS tests covering exit-code
+  propagation (`exit 0` → COMPLETED, `exit 1` → FAILED, `exit 42` recorded),
+  termination rather than stopping, no leftover billable EBS volume, the
+  instance-profile guard, and the absence of the command from UserData.
+  Specified in #66 and never written.
+- 8 tests in `TestOneShotMode` covering SSM dispatch, the shutdown backstop,
+  `InstanceInitiatedShutdownBehavior`, the spot `LaunchSpecification` key
+  stripping, exit-code-derived status, dispatch-failure termination, and the
+  instance-profile guard.
+- `docs/network-prerequisites.md` with Terraform and CloudFormation snippets for
+  provisioning the required network resources.
 - `tests/unit/test_ecs_manager.py` — 6 tests covering explicit `subnet_id`,
   explicit `subnet_ids` precedence, subnet discovery, default-VPC fallback, and
   both empty-result error paths.
@@ -108,6 +154,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   it too, and an unused profile costs nothing.
 - `EC2Manager._get_or_create_instance_profile()` now delegates to
   `utils.aws.get_or_create_ssm_instance_profile()`.
+- One-shot mode now requires `auto_create_instance_profile=True` or
+  `iam_instance_profile_arn`, because its command is delivered by SSM
+  `SendCommand`. The requirement was previously warm-pool-only.
+- A failed SSM dispatch now terminates the instance and re-raises instead of
+  logging "falling back to UserData execution". There was nothing to fall back
+  to — the command is not in the UserData, so the instance would have idled
+  until `max_idle_time` while reporting `RUNNING`.
+- `EphemeralAWSProvider.status()` runs `_cleanup_resources()` when `one_shot` is
+  set, not only when a warm pool is configured; a one-shot instance has no
+  UserData shutdown to end it.
+- `vpc_id`, `subnet_id`, and `security_group_id` are now **required** constructor
+  arguments; a `ValueError` is raised at init if any are missing.
+- `cleanup_infrastructure()` no longer destroys network resources — VPC,
+  subnet, and security group are now the caller's responsibility.
+- E2E tests read `AWS_TEST_VPC_ID`, `AWS_TEST_SUBNET_ID`, and `AWS_TEST_SG_ID`
+  from the environment; tests are skipped (not failed) when these are unset.
 
 ### Removed
 - `SpotFleetManager._create_vpc()`, `_create_subnet()`, `_create_security_group()`,
@@ -123,26 +185,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `_create_security_group()` (182 LOC). These built the VPC through
   CloudFormation rather than direct EC2 calls, which is why #69's pass missed
   them; `create_vpc` is gone from `ServerlessMode` as well (closes #73).
-
-### Changed
-- `vpc_id`, `subnet_id`, and `security_group_id` are now **required** constructor
-  arguments; a `ValueError` is raised at init if any are missing.
-- `cleanup_infrastructure()` no longer destroys network resources — VPC,
-  subnet, and security group are now the caller's responsibility.
-- E2E tests read `AWS_TEST_VPC_ID`, `AWS_TEST_SUBNET_ID`, and `AWS_TEST_SG_ID`
-  from the environment; tests are skipped (not failed) when these are unset.
-- Added `docs/network-prerequisites.md` with Terraform and CloudFormation
-  snippets for provisioning the required network resources.
-
-### Added
-- **One-shot mode** for `StandardMode`: set `one_shot=True` to explicitly declare
-  that each EC2 instance runs a single command then terminates, regardless of the
-  `auto_shutdown` setting (closes #66).
-  - `one_shot=True` unconditionally appends `shutdown -h now` to the UserData
-    init script even when `auto_shutdown=False`.
-  - Raises `ValueError` at construction time if combined with `warm_pool_size > 0`
-    (incompatible: one-shot instances are terminated immediately and cannot be reused).
-  - `one_shot=False` (default): zero code-path changes for existing users.
 
 ## [0.6.0] - 2026-03-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   so a profile whose role attachment had failed midway kept being reused with no
   role attached and SSM never came online. The role is now attached on all three
   paths (pre-existing profile, freshly created, and lost creation race).
+- `state_store_type="s3"` and `"parameter_store"` could not be constructed at
+  all — three stacked defects, each hidden behind the previous one. The provider
+  passed `session=`/`path=`/`bucket=`/`key=`/`provider_id=`, none of which are
+  parameters of `S3State` or `ParameterStoreState` (`TypeError`); the AWS stores
+  implement a *keyed* three-method interface while the provider and
+  `FileStateStore` used an unkeyed one; and both stores unguardedly read six
+  credential attributes that `EphemeralAWSProvider` does not define, building
+  their own `boto3.Session` and ignoring `provider.session` entirely
+  (`AttributeError`). The `session=` kwarg exists nowhere else in the codebase —
+  this path had never been executed. The stores' provider-object contract is
+  kept; the provider and `FileStateStore` were adapted to it (closes #57, #77).
+- The provider and its operating mode no longer overwrite each other's state.
+  Both wrote full-document overwrites, with different field sets, into the same
+  slot, so whichever wrote last erased the other's fields. Losing the mode's
+  `baked_ami_id`/`owns_baked_ami` meant `cleanup_infrastructure()` could no
+  longer see the AMI it owned — **leaking the AMI and its EBS snapshots**, and
+  silently re-baking on restart. Losing the provider's `job_map` lost the
+  job-to-resource mapping. State is now addressed by key, one per writer
+  (closes #78).
+- Auto-created IAM instance profiles were handed to `RunInstances` before EC2
+  could see them, failing every launch with `InvalidParameterValue: Invalid IAM
+  Instance Profile ARN`. IAM is eventually consistent with respect to EC2:
+  measured against real AWS, `create_instance_profile` returned the ARN at
+  t+4.1s but `RunInstances` did not accept it until t+14.5s. This was
+  unreachable until `auto_create_instance_profile` began to take effect (#75).
+  `get_or_create_ssm_instance_profile()` now waits for the profile to become
+  visible on both its create and creation-race paths, polling a dry-run
+  `RunInstances` — `get_instance_profile` succeeds immediately and so proves
+  nothing about the path that matters. A timeout warns rather than raising, since
+  the launch that follows reports any real error (closes #98).
+- The provider never restored persisted state, so nothing survived a restart on
+  any backend. Two independent defects: `_load_state()` was not called from
+  `__init__` at all (only tests called it), and it refuses a document whose
+  `provider_id` differs from its own — while `provider_id` defaults to a fresh
+  UUID and does **not** affect where state is stored (only `state_file_path` /
+  `parameter_store_path` / `s3_key` do). A successor therefore generated a new
+  ID and discarded the very document it was pointed at. `__init__` now loads
+  state, and adopts the `provider_id` recorded at that location unless the caller
+  supplied one explicitly. Wiring this up was only safe once the provider and its
+  mode stopped sharing a slot (#78) (closes #100).
+- `shutdown()` saved an **empty** state document instead of deleting it, so SSM
+  parameters and S3 objects survived every shutdown and accumulated per run
+  (Parameter Store has an account quota). On any backend the surviving document
+  described network IDs — and, for the mode, a baked AMI — that shutdown had just
+  released. `delete_state` was implemented in all three stores and declared on
+  the ABC, but called from nowhere in the package (closes #99).
 
 ### Added
 - **One-shot mode** for `StandardMode`: set `one_shot=True` to declare that each
@@ -134,6 +180,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `_generate_lambda_code()` body and compile its output.
 - `tests/unit/test_instance_profile.py` — 10 tests covering SSM instance-profile
   resolution against moto and `StandardMode`'s resolution behaviour.
+- `STATE_KEY_PROVIDER` and `STATE_KEY_MODE` in `state/base.py`, and
+  `OperatingMode.delete_state()` — one state document per writer.
+- `FileStateStore` keyed layout: a single file holding one sub-document per key
+  under `_states`, versioned with `_version`, read-modify-written under the
+  existing `fcntl.flock`. A flat pre-v0.7.0 document is still readable under any
+  key and is seeded into both keys on first write.
+- `resolve_session(provider)` in `state/base.py` — prefers `provider.session`
+  before assembling one from credential fields, so the AWS stores stop
+  duplicating the credential plumbing the provider already does via
+  `create_session()`.
+- 8 tests in `TestFileStateStoreKeying` and 5 in `TestStateKeySeparation`
+  covering key isolation, per-key deletion, flat-document upgrade, serialization
+  failure leaving prior state intact, and shutdown deleting both documents. The
+  key-isolation tests were mutation-checked: collapsing `STATE_KEY_MODE` onto the
+  provider's key fails all three separation tests.
+- 5 tests in `TestWaitForInstanceProfile` covering the IAM propagation wait —
+  including a fake clock driven through `sleep` so the retry-then-give-up path
+  genuinely iterates.
+- The `tests/aws` `network_ids` fixture now validates the supplied IDs against
+  `AWS_TEST_REGION` before any test runs. IDs from another region were not an
+  error until a launch was attempted, surfacing minutes in as
+  `InvalidSubnetID.NotFound` from inside `RunInstances` — after real instances had
+  been billed. `AWS_TEST_REGION` defaults to `us-west-2`, so supplying the IDs
+  alone is easy to get wrong; the check now fails in seconds with the region named.
 - `get_or_create_ssm_instance_profile()` in `utils/aws.py` — promoted from
   `EC2Manager._get_or_create_instance_profile()` so `StandardMode` and
   `EC2Manager` share one implementation. Resolution order is explicit ARN, then
@@ -149,6 +219,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   flag) (closes #74).
 - `EphemeralAWSProvider` now passes `region` explicitly to the operating mode
   rather than letting it fall back to `session.region_name`.
+- **`StateStore` is now a keyed interface**: `save_state(state_key, state_data)`,
+  `load_state(state_key)`, `delete_state(state_key)`. `FileStateStore` gained the
+  key parameter; the two AWS stores already had it and now call
+  `super().__init__()`. Callers holding a store directly must pass a key.
+- `OperatingMode.load_state()` no longer restores a `None` network ID over a
+  validated constructor value. A state document written before these IDs became
+  required can carry nulls, which previously surfaced much later as an opaque
+  boto3 `InvalidParameterValue` at launch.
 - `StandardMode._create_instance()` attaches the IAM instance profile whenever
   one is available, not only when `warm_pool_size > 0`. One-shot dispatch needs
   it too, and an unused profile costs nothing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- `ServerlessMode.cleanup_infrastructure()` no longer deletes the caller's
+  security group. The code was guarded only by a comment claiming "if we created
+  it directly" — nothing verified ownership, and after #69 the ID is always
+  user-supplied. It was reached from the `except` handler on every failed
+  `initialize()`. The unconditional `parsl-vpc-<provider_id[:8]}` CloudFormation
+  stack deletion (whose 8-character truncated IDs can collide across providers)
+  was removed with it (closes #70).
+- `SpotFleetManager._cleanup_network_resources()` removed. It unconditionally
+  deleted the caller's security group, subnet, **every internet gateway attached
+  to the VPC**, every non-main route table, and the VPC itself — with no
+  ownership check, on IDs that `_setup_network_resources()` had adopted from the
+  provider. It ran as the last step of `cleanup_all_resources()`, so with
+  `use_spot_fleet=True` every normal provider shutdown attempted to destroy the
+  caller's pre-provisioned network; a second path invoked it from the setup
+  `except` handler. `delete_vpc`/`delete_subnet` usually failed with
+  `DependencyViolation`, but the internet-gateway detach could succeed against a
+  live VPC and blackhole egress for unrelated workloads (closes #94).
+
 ### Removed
+- `SpotFleetManager._create_vpc()`, `_create_subnet()`, `_create_security_group()`,
+  and `_cleanup_network_resources()`. `_setup_network_resources()` now only
+  resolves the caller-supplied IDs and raises `ResourceCreationError` if any are
+  missing (closes #94).
 - `create_vpc` parameter — VPC/subnet/security-group creation removed from the
   provider entirely (closes #69).
 - `_create_vpc()`, `_create_subnet()`, `_create_security_group()`, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `DependencyViolation`, but the internet-gateway detach could succeed against a
   live VPC and blackhole egress for unrelated workloads (closes #94).
 
+### Fixed
+- `ECSManager._get_or_create_network_resources()` raised
+  `UnboundLocalError: cannot access local variable 'subnet_response'` on every
+  ECS/Fargate submission. A leftover line dereferenced `subnet_response`, which
+  is bound only in the subnet-discovery branch; once `subnet_id` became required
+  in #69 the explicit-subnet branch always ran, so the line always raised. It
+  also overwrote the caller's explicit subnet with every subnet discovered in the
+  VPC (closes #71).
+
+### Added
+- `tests/unit/test_ecs_manager.py` — 6 tests covering explicit `subnet_id`,
+  explicit `subnet_ids` precedence, subnet discovery, default-VPC fallback, and
+  both empty-result error paths.
+
 ### Removed
 - `SpotFleetManager._create_vpc()`, `_create_subnet()`, `_create_security_group()`,
   and `_cleanup_network_resources()`. `_setup_network_resources()` now only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   state, and adopts the `provider_id` recorded at that location unless the caller
   supplied one explicitly. Wiring this up was only safe once the provider and its
   mode stopped sharing a slot (#78) (closes #100).
+- Provider-ID adoption consulted only the provider's own state key, which does not
+  exist until a job has been submitted — the provider writes it from
+  `_save_state()`, on submit/status/cancel. A provider that constructed and
+  exited without submitting therefore left *only* the mode document behind, the
+  successor kept its fresh UUID, and `OperatingMode.load_state()` rejected that
+  document on the ID gate. Both keys are now consulted, provider key first. The
+  mode document is the one that matters here: it holds the network IDs and the
+  baked-AMI ownership flag. Found against real AWS while probing #79 — a resumed
+  provider silently took the create path and never noticed its security group had
+  been deleted (closes #101).
+- Real-AWS E2E tests read `provider.status(...)[0]["status"]` in 14 places, but
+  `status()` has returned `List[JobStatus]` since v0.5.0 and `JobStatus` is not
+  subscriptable, so each raised `TypeError`. The pattern dates to when the suite
+  was written, against the old `List[Dict[str, str]]`. This mattered more than
+  the three visible failures suggest: a polling helper that raises on its first
+  call cannot time out — it aborts the test — so no spot, detached, serverless,
+  or Globus lifecycle assertion downstream of a `_poll_until` had ever run. All
+  call sites now compare `statuses[0].state` against `JobState` (closes #102).
+- `_verify_resources()` nulled the network ID it had just found missing instead of
+  reporting it. The nulling is a leftover from the create-on-demand era — since
+  #69 nothing creates a replacement, so the `None` reached `run_instances` as an
+  opaque `InvalidParameterValue` far from the missing resource, and in serverless
+  mode re-entered a guard that read a `create_vpc` attribute which no longer
+  exists. It now raises `ResourceNotFoundError` naming the offending ID.
+  `load_state()` also no longer restores a `None` from a pre-#69 state document
+  over a validated ID. The network half of the method was byte-identical in all
+  three modes — the condition that let them drift — and now lives once on
+  `OperatingMode`; `DetachedMode` still adds its bastion check on top, where a
+  missing bastion is correctly *not* an error, since that resource is one the
+  mode does create (closes #79).
+- Network resources were verified only when resuming from state, so a first-run
+  provider — the common case — never checked its IDs at all. `initialize()` now
+  verifies on both paths in all three modes. Found by probing #79's fix against
+  real AWS: the expected `ResourceNotFoundError` never fired.
+- A syntactically invalid network ID escaped as a raw `ClientError`. EC2 answers
+  a malformed ID with a distinct code rather than `NotFound` — verified against
+  real AWS, where `sg-00000000000000000` yields `InvalidGroupId.Malformed` while
+  a subnet or VPC ID of the same shape yields `NotFound`, and the suffix casing
+  differs per resource. All six codes are now matched, on the `Error.Code` field
+  rather than the rendered message.
+- `DetachedMode.initialize()` returned unconditionally when it loaded state, so a
+  resumed provider whose bastion had been terminated never rebuilt it — every job
+  was dispatched into an SSM path nothing was reading. It also ran its bastion
+  check before `load_state()`, which is where `bastion_id` comes from, so on a
+  fresh process there was nothing to check.
 - `shutdown()` saved an **empty** state document instead of deleting it, so SSM
   parameters and S3 objects survived every shutdown and accumulated per run
   (Parameter Store has an account quota). On any backend the surviving document

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `aws_*` kwargs it passed are fields on the dataclass. It now matches the
   `EC2Manager`/`ECSManager`/`SpotFleetManager` implementations, and no longer
   defaults `use_profile` to a profile literally named `aws` (closes #95).
+- `auto_create_instance_profile` was accepted by `EphemeralAWSProvider` but never
+  forwarded to `StandardMode`, so the documented warm-pool configuration could
+  never work. Instances launched with no IAM instance profile, SSM never came
+  online, `_wait_for_ssm_online()` timed out, and every submission silently fell
+  back to UserData dispatch — losing both instance reuse and exit-code
+  reporting. `StandardMode` now accepts the flag and resolves an ARN in
+  `initialize()`, on both the fresh and resumed paths (the ARN is not persisted
+  in state). A failure to create the profile is logged, not fatal: dispatch
+  degrades to UserData rather than the provider failing to start (closes #75).
+- Instance-profile resolution no longer leaves a profile permanently empty. The
+  previous implementation returned early when `get_instance_profile` succeeded,
+  so a profile whose role attachment had failed midway kept being reused with no
+  role attached and SSM never came online. The role is now attached on all three
+  paths (pre-existing profile, freshly created, and lost creation race).
 
 ### Added
 - `tests/unit/test_ecs_manager.py` — 6 tests covering explicit `subnet_id`,
@@ -72,6 +86,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   parameter plumbing, and the absence of the network-creation helpers.
 - `tests/unit/test_lambda_manager.py` — 13 tests that execute the real
   `_generate_lambda_code()` body and compile its output.
+- `tests/unit/test_instance_profile.py` — 10 tests covering SSM instance-profile
+  resolution against moto and `StandardMode`'s resolution behaviour.
+- `get_or_create_ssm_instance_profile()` in `utils/aws.py` — promoted from
+  `EC2Manager._get_or_create_instance_profile()` so `StandardMode` and
+  `EC2Manager` share one implementation. Resolution order is explicit ARN, then
+  auto-creation, then `None`.
 
 ### Changed
 - `vpc_id`, `subnet_id`, and `security_group_id` are no longer required for
@@ -83,6 +103,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   flag) (closes #74).
 - `EphemeralAWSProvider` now passes `region` explicitly to the operating mode
   rather than letting it fall back to `session.region_name`.
+- `StandardMode._create_instance()` attaches the IAM instance profile whenever
+  one is available, not only when `warm_pool_size > 0`. One-shot dispatch needs
+  it too, and an unused profile costs nothing.
+- `EC2Manager._get_or_create_instance_profile()` now delegates to
+  `utils.aws.get_or_create_ssm_instance_profile()`.
 
 ### Removed
 - `SpotFleetManager._create_vpc()`, `_create_subnet()`, `_create_security_group()`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   baked-AMI ownership flag. Found against real AWS while probing #79 — a resumed
   provider silently took the create path and never noticed its security group had
   been deleted (closes #101).
+- `warm_pool_size`, `warm_pool_ttl`, `bake_ami`, `baked_ami_id`, and `one_shot`
+  are implemented only by `StandardMode`, and were forwarded only on that branch
+  — but the provider acted on them regardless of mode, which made the mismatch
+  leak rather than merely no-op. With `mode="detached", warm_pool_size=2` every
+  resource was tagged `warm_pool=True`, `_cleanup_resources()` took the warm-pool
+  branch, and jobs were set to `STATUS_WARM` — a status no other mode's
+  `get_job_status()` recognises — so those instances were **never cleaned up** and
+  leaked with no error or warning. `__init__` now raises
+  `ProviderConfigurationError` naming every offending option and the mode asked
+  for. It is ordered before the SSM instance-profile guard, which would otherwise
+  answer `one_shot=True` on detached mode by advising
+  `auto_create_instance_profile` — advice that cannot help, since detached mode
+  does not implement one-shot at all (closes #80).
 - Real-AWS E2E tests read `provider.status(...)[0]["status"]` in 14 places, but
   `status()` has returned `List[JobStatus]` since v0.5.0 and `JobStatus` is not
   subscriptable, so each raised `TypeError`. The pattern dates to when the suite
@@ -240,6 +253,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   failure leaving prior state intact, and shutdown deleting both documents. The
   key-isolation tests were mutation-checked: collapsing `STATE_KEY_MODE` onto the
   provider's key fails all three separation tests.
+- 23 tests in `TestStandardOnlyOptionGuard` covering each StandardMode-only
+  option against each mode that cannot honour it, acceptance on standard mode,
+  explicitly-passed defaults, multi-option messages, and guard ordering.
+  Mutation-checked: disabling the guard fails 14, comparing presence instead of
+  the default fails 4, and reordering it after the IAM guard fails 2.
+- `one_shot` is now documented on `EphemeralAWSProvider`; it had been accepted
+  but absent from the docstring. The four warm-pool and AMI-baking parameters
+  are now marked `mode="standard"` only.
 - 5 tests in `TestWaitForInstanceProfile` covering the IAM propagation wait —
   including a fake clock driven through `sleep` so the retry-then-give-up path
   genuinely iterates.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,16 @@ All work tracking for this project uses GitHub. **Do not create standalone plann
   - A milestone assignment (`v0.1.0`, `v0.2.0`, or `v0.3.0`)
 - Reference issues in commit messages: `fix: correct spot fleet instance type generation (closes #N)`
 
+### Branches and Pull Requests
+- **All work goes on a feature branch and merges via a PR. Never commit directly
+  to `main`.**
+- Branch per phase or task group, named for the work: `fix/phase-1-correctness`,
+  `feat/launch-templates`.
+- Open the PR with `gh pr create`; the PR body should summarise the defects fixed
+  and how each was verified.
+- `closes #N` only closes the issue once the commit reaches `main`, so issues stay
+  open until the PR merges. That is intended — don't close them by hand.
+
 ### Milestones
 - **v0.1.0** — Critical bugs and broken functionality; minimum viable provider
 - **v0.2.0** — Stability: race conditions, resource leaks, error handling, core test coverage

--- a/parsl_ephemeral_aws/compute/ec2.py
+++ b/parsl_ephemeral_aws/compute/ec2.py
@@ -137,77 +137,19 @@ class EC2Manager:
     def _get_or_create_instance_profile(self) -> Optional[str]:
         """Return an IAM instance profile ARN for SSM access, or None.
 
-        Resolution order:
-        1. ``provider.iam_instance_profile_arn`` if set → use directly.
-        2. ``provider.auto_create_instance_profile`` → get-or-create a
-           profile that has the AmazonSSMManagedInstanceCore policy.
-        3. Otherwise → return None (EC2 instances launch without a profile).
+        Thin wrapper over ``utils.aws.get_or_create_ssm_instance_profile``, which
+        the operating modes call directly.
         """
-        profile_arn: Optional[str] = getattr(
-            self.provider, "iam_instance_profile_arn", None
+        from ..utils.aws import get_or_create_ssm_instance_profile
+
+        return get_or_create_ssm_instance_profile(
+            session=self.aws_session,
+            name_suffix=self.provider.workflow_id,
+            iam_instance_profile_arn=getattr(
+                self.provider, "iam_instance_profile_arn", None
+            ),
+            auto_create=getattr(self.provider, "auto_create_instance_profile", False),
         )
-        if profile_arn:
-            return profile_arn
-
-        if not getattr(self.provider, "auto_create_instance_profile", False):
-            return None
-
-        iam = self.aws_session.client("iam")
-        workflow_id = self.provider.workflow_id
-        role_name = f"parsl-ephemeral-ssm-role-{workflow_id}"
-        profile_name = f"parsl-ephemeral-ssm-profile-{workflow_id}"
-
-        # Ensure the IAM role exists
-        from ..utils.aws import get_or_create_iam_role
-
-        get_or_create_iam_role(
-            iam_client=iam,
-            role_name=role_name,
-            assume_role_policy={
-                "Version": "2012-10-17",
-                "Statement": [
-                    {
-                        "Effect": "Allow",
-                        "Principal": {"Service": "ec2.amazonaws.com"},
-                        "Action": "sts:AssumeRole",
-                    }
-                ],
-            },
-            policy_arns=["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"],
-            description=f"SSM instance role for Parsl ({workflow_id})",
-        )
-
-        # Ensure the instance profile exists and has the role attached
-        try:
-            response = iam.get_instance_profile(InstanceProfileName=profile_name)
-            return response["InstanceProfile"]["Arn"]
-        except ClientError as e:
-            if e.response["Error"]["Code"] not in (
-                "NoSuchEntity",
-                "NoSuchEntityException",
-            ):
-                raise ResourceCreationError(
-                    f"Failed to check instance profile {profile_name}: {e}"
-                ) from e
-
-        try:
-            response = iam.create_instance_profile(
-                InstanceProfileName=profile_name,
-            )
-            arn: str = response["InstanceProfile"]["Arn"]
-            iam.add_role_to_instance_profile(
-                InstanceProfileName=profile_name,
-                RoleName=role_name,
-            )
-            logger.info(f"Created IAM instance profile: {profile_name}")
-            return arn
-        except ClientError as e:
-            if e.response["Error"]["Code"] in ("EntityAlreadyExists",):
-                response = iam.get_instance_profile(InstanceProfileName=profile_name)
-                return response["InstanceProfile"]["Arn"]
-            raise ResourceCreationError(
-                f"Failed to create instance profile {profile_name}: {e}"
-            ) from e
 
     def _setup_security_config(self) -> None:
         """Set up security configuration from provider settings."""

--- a/parsl_ephemeral_aws/compute/ecs.py
+++ b/parsl_ephemeral_aws/compute/ecs.py
@@ -482,8 +482,6 @@ class ECSManager:
                     subnet["SubnetId"] for subnet in subnet_response["Subnets"]
                 ]
 
-            subnet_ids = [subnet["SubnetId"] for subnet in subnet_response["Subnets"]]
-
             # Get or create security group
             sg_name = f"{TAG_PREFIX}-ecs-sg-{self.provider.workflow_id}"
 

--- a/parsl_ephemeral_aws/compute/lambda_func.py
+++ b/parsl_ephemeral_aws/compute/lambda_func.py
@@ -174,15 +174,43 @@ class LambdaManager:
                 )
 
     def _create_credential_config_from_provider(self) -> CredentialConfiguration:
-        """Create credential configuration from provider settings."""
-        return CredentialConfiguration(
-            aws_access_key_id=getattr(self.provider, "aws_access_key_id", None),
-            aws_secret_access_key=getattr(self.provider, "aws_secret_access_key", None),
-            aws_session_token=getattr(self.provider, "aws_session_token", None),
-            use_profile=getattr(self.provider, "aws_profile", "aws"),
+        """Create credential configuration from provider settings.
+
+        Returns
+        -------
+        CredentialConfiguration
+            Credential configuration based on provider settings
+        """
+        # Extract credential settings from provider
+        role_arn = getattr(self.provider, "role_arn", None)
+        aws_profile = getattr(self.provider, "aws_profile", None)
+        use_env_vars = (
+            hasattr(self.provider, "aws_access_key_id")
+            and self.provider.aws_access_key_id is not None
+        )
+
+        # Create credential configuration
+        config = CredentialConfiguration(
+            role_arn=role_arn,
             enable_sanitization=True,
             sanitize_logs=True,
+            use_environment_variables=use_env_vars,
+            use_profile=aws_profile,
+            auto_refresh_tokens=True,
         )
+
+        # Set security-based defaults
+        if self.security_config.environment.value == "production":
+            config.use_environment_variables = False
+            config.use_profile = None
+            config.require_mfa = False
+
+        logger.info(
+            f"Lambda Created credential config: role_arn={bool(role_arn)}, "
+            f"profile={aws_profile}, use_env={use_env_vars}"
+        )
+
+        return config
 
     def _create_lambda_execution_role(self) -> str:
         """Get or create an IAM role for Lambda execution (idempotent).
@@ -328,28 +356,30 @@ class LambdaManager:
         bytes
             Zip file content containing the Lambda function code
         """
-        # For a real implementation, this would generate a proper Lambda function
-        # that can execute the command and return the results.
-        # For now, we'll create a simple function that logs the command and returns success.
-
         import io
         import zipfile
 
-        # Create a Python module to handle the job
-        handler_code = f"""
+        # A plain template, not an f-string: the handler is full of dict literals
+        # whose braces an f-string would read as replacement fields. The command
+        # is the only substitution, and it goes in as a JSON literal so any
+        # quoting in it survives.
+        handler_template = """
 import json
 import subprocess
 import sys
 import os
 import traceback
 
+DEFAULT_COMMAND = __COMMAND__
+
+
 def main(event, context):
     print("Starting Parsl job execution")
 
     try:
         # Get command from event or use the baked-in command
-        command = event.get('command', {json.dumps(command)})
-        print(f"Executing command: {{command}}")
+        command = event.get('command', DEFAULT_COMMAND)
+        print(f"Executing command: {command}")
 
         # Execute the command
         result = subprocess.run(
@@ -370,8 +400,8 @@ def main(event, context):
 
         # Log results
         print(f"Command completed with return code: {result.returncode}")
-        print(f"STDOUT: {result.stdout[:1000]}{'...' if len(result.stdout) > 1000 else ''}")
-        print(f"STDERR: {result.stderr[:1000]}{'...' if len(result.stderr) > 1000 else ''}")
+        print(f"STDOUT: {result.stdout[:1000]}")
+        print(f"STDERR: {result.stderr[:1000]}")
 
         return response
 
@@ -387,6 +417,7 @@ def main(event, context):
             'traceback': traceback.format_exc()
         }
 """
+        handler_code = handler_template.replace("__COMMAND__", json.dumps(command))
 
         # Create a ZIP file in memory
         zip_buffer = io.BytesIO()

--- a/parsl_ephemeral_aws/compute/spot_fleet.py
+++ b/parsl_ephemeral_aws/compute/spot_fleet.py
@@ -235,483 +235,53 @@ class SpotFleetManager:
 
         return config
 
-    @retry_with_backoff()
     def _setup_network_resources(self) -> Dict[str, str]:
-        """Set up VPC, subnet, and security group for Spot Fleet instances.
+        """Resolve the caller-supplied VPC, subnet, and security group.
 
-        This method creates or gets existing network infrastructure for the Spot Fleet.
+        Network resources are pre-provisioned by the caller and passed in via
+        the provider; this manager never creates or deletes them.
 
         Returns
         -------
         Dict[str, str]
             Dictionary containing VPC ID, subnet ID, and security group ID
-        """
-        # Check if we already have network resources
-        if self.vpc_id and self.subnet_id and self.security_group_id:
-            return {
-                "vpc_id": self.vpc_id,
-                "subnet_id": self.subnet_id,
-                "security_group_id": self.security_group_id,
-            }
 
-        context = ErrorContext(
-            operation="setup_network_resources",
-            resource_type="spot_fleet_network",
-            resource_id=f"workflow-{self.provider.workflow_id}",
-            region=self.provider.region,
+        Raises
+        ------
+        ResourceCreationError
+            If the provider is missing any of the three required IDs
+        """
+        self.vpc_id = self.vpc_id or self.provider.vpc_id
+        self.subnet_id = self.subnet_id or self.provider.subnet_id
+        self.security_group_id = (
+            self.security_group_id or self.provider.security_group_id
         )
 
-        try:
-            # Use existing network resources from provider if available
-            if self.provider.vpc_id:
-                self.vpc_id = self.provider.vpc_id
-                logger.info(f"Using existing VPC: {self.vpc_id}")
-
-                if self.provider.subnet_id:
-                    self.subnet_id = self.provider.subnet_id
-                    logger.info(f"Using existing subnet: {self.subnet_id}")
-                else:
-                    # Find a suitable subnet in the VPC
-                    response = self.ec2_client.describe_subnets(
-                        Filters=[{"Name": "vpc-id", "Values": [self.vpc_id]}]
-                    )
-
-                    if response["Subnets"]:
-                        self.subnet_id = response["Subnets"][0]["SubnetId"]
-                        logger.info(
-                            f"Found existing subnet {self.subnet_id} in VPC {self.vpc_id}"
-                        )
-                    else:
-                        # Create a new subnet
-                        self.subnet_id = self._create_subnet()
-
-                if self.provider.security_group_id:
-                    self.security_group_id = self.provider.security_group_id
-                    logger.info(
-                        f"Using existing security group: {self.security_group_id}"
-                    )
-                else:
-                    # Create a new security group
-                    self.security_group_id = self._create_security_group()
-            else:
-                # Create new VPC and associated resources
-                self.vpc_id = self._create_vpc()
-                self.subnet_id = self._create_subnet()
-                self.security_group_id = self._create_security_group()
-
-            return {
-                "vpc_id": self.vpc_id,
-                "subnet_id": self.subnet_id,
-                "security_group_id": self.security_group_id,
-            }
-
-        except Exception as e:
-            # Record error for analysis
-            error_record = self.error_handler.handle_error(e, context)
-            logger.error(f"Error setting up network resources: {e}")
-
-            # Attempt to clean up any created resources
-            self._cleanup_network_resources()
-
-            raise ResourceCreationError(f"Failed to set up network resources: {e}")
-
-    def _create_vpc(self) -> str:
-        """Create a VPC for the Spot Fleet instances.
-
-        Returns
-        -------
-        str
-            VPC ID
-        """
-        try:
-            # Create VPC with configured CIDR
-            response = self.ec2_client.create_vpc(
-                CidrBlock=self.security_config.vpc_cidr,
-                TagSpecifications=[
-                    {
-                        "ResourceType": "vpc",
-                        "Tags": [
-                            {
-                                "Key": "Name",
-                                "Value": f"{TAG_PREFIX}-vpc-{self.provider.workflow_id}",
-                            },
-                            {"Key": TAG_NAME, "Value": "true"},
-                            {
-                                "Key": TAG_WORKFLOW_ID,
-                                "Value": self.provider.workflow_id,
-                            },
-                        ],
-                    }
-                ],
+        missing = [
+            name
+            for name, value in (
+                ("vpc_id", self.vpc_id),
+                ("subnet_id", self.subnet_id),
+                ("security_group_id", self.security_group_id),
+            )
+            if not value
+        ]
+        if missing:
+            raise ResourceCreationError(
+                "Spot Fleet requires pre-provisioned network resources; "
+                f"missing: {', '.join(missing)}"
             )
 
-            vpc_id = response["Vpc"]["VpcId"]
-            logger.info(f"Created VPC: {vpc_id}")
+        logger.info(
+            f"Using network resources: vpc={self.vpc_id}, subnet={self.subnet_id}, "
+            f"sg={self.security_group_id}"
+        )
 
-            # Wait for VPC to be available
-            self.ec2_client.get_waiter("vpc_available").wait(VpcIds=[vpc_id])
-
-            # Enable DNS hostnames in VPC
-            self.ec2_client.modify_vpc_attribute(
-                VpcId=vpc_id, EnableDnsHostnames={"Value": True}
-            )
-
-            # Create and attach internet gateway
-            igw_response = self.ec2_client.create_internet_gateway(
-                TagSpecifications=[
-                    {
-                        "ResourceType": "internet-gateway",
-                        "Tags": [
-                            {
-                                "Key": "Name",
-                                "Value": f"{TAG_PREFIX}-igw-{self.provider.workflow_id}",
-                            },
-                            {"Key": TAG_NAME, "Value": "true"},
-                            {
-                                "Key": TAG_WORKFLOW_ID,
-                                "Value": self.provider.workflow_id,
-                            },
-                        ],
-                    }
-                ]
-            )
-
-            igw_id = igw_response["InternetGateway"]["InternetGatewayId"]
-
-            self.ec2_client.attach_internet_gateway(
-                InternetGatewayId=igw_id, VpcId=vpc_id
-            )
-
-            logger.info(f"Created and attached internet gateway: {igw_id}")
-
-            return vpc_id
-
-        except ClientError as e:
-            logger.error(f"Error creating VPC: {e}")
-            raise ResourceCreationError(f"Failed to create VPC: {e}")
-
-    def _create_subnet(self) -> str:
-        """Create a subnet for the Spot Fleet instances.
-
-        Returns
-        -------
-        str
-            Subnet ID
-        """
-        if not self.vpc_id:
-            raise ResourceCreationError("VPC ID required to create subnet")
-
-        try:
-            # Create subnet in the first availability zone
-            az_response = self.ec2_client.describe_availability_zones()
-            first_az = az_response["AvailabilityZones"][0]["ZoneName"]
-
-            # Create subnet using CIDR manager
-            from ..security.cidr_manager import CIDRManager
-
-            cidr_manager = CIDRManager()
-            subnet_cidrs = cidr_manager.get_subnet_cidrs(
-                self.security_config.vpc_cidr, 1
-            )
-
-            response = self.ec2_client.create_subnet(
-                VpcId=self.vpc_id,
-                CidrBlock=subnet_cidrs[0],
-                AvailabilityZone=first_az,
-                TagSpecifications=[
-                    {
-                        "ResourceType": "subnet",
-                        "Tags": [
-                            {
-                                "Key": "Name",
-                                "Value": f"{TAG_PREFIX}-subnet-{self.provider.workflow_id}",
-                            },
-                            {"Key": TAG_NAME, "Value": "true"},
-                            {
-                                "Key": TAG_WORKFLOW_ID,
-                                "Value": self.provider.workflow_id,
-                            },
-                        ],
-                    }
-                ],
-            )
-
-            subnet_id = response["Subnet"]["SubnetId"]
-            logger.info(f"Created subnet: {subnet_id} in AZ: {first_az}")
-
-            # Create route table
-            rt_response = self.ec2_client.create_route_table(
-                VpcId=self.vpc_id,
-                TagSpecifications=[
-                    {
-                        "ResourceType": "route-table",
-                        "Tags": [
-                            {
-                                "Key": "Name",
-                                "Value": f"{TAG_PREFIX}-rt-{self.provider.workflow_id}",
-                            },
-                            {"Key": TAG_NAME, "Value": "true"},
-                            {
-                                "Key": TAG_WORKFLOW_ID,
-                                "Value": self.provider.workflow_id,
-                            },
-                        ],
-                    }
-                ],
-            )
-
-            route_table_id = rt_response["RouteTable"]["RouteTableId"]
-
-            # Associate route table with subnet
-            self.ec2_client.associate_route_table(
-                RouteTableId=route_table_id, SubnetId=subnet_id
-            )
-
-            # Add route to internet via internet gateway
-            igw_response = self.ec2_client.describe_internet_gateways(
-                Filters=[{"Name": "attachment.vpc-id", "Values": [self.vpc_id]}]
-            )
-
-            if igw_response["InternetGateways"]:
-                igw_id = igw_response["InternetGateways"][0]["InternetGatewayId"]
-
-                self.ec2_client.create_route(
-                    RouteTableId=route_table_id,
-                    DestinationCidrBlock="0.0.0.0/0",
-                    GatewayId=igw_id,
-                )
-
-                logger.info(f"Created route to internet via gateway {igw_id}")
-
-            # Enable public IP assignment if requested
-            if self.provider.use_public_ips:
-                self.ec2_client.modify_subnet_attribute(
-                    SubnetId=subnet_id, MapPublicIpOnLaunch={"Value": True}
-                )
-                logger.info(f"Enabled public IP assignment for subnet: {subnet_id}")
-
-            return subnet_id
-
-        except ClientError as e:
-            logger.error(f"Error creating subnet: {e}")
-            raise ResourceCreationError(f"Failed to create subnet: {e}")
-
-    def _create_security_group(self) -> str:
-        """Create a security group for the Spot Fleet instances.
-
-        Returns
-        -------
-        str
-            Security group ID
-        """
-        if not self.vpc_id:
-            raise ResourceCreationError("VPC ID required to create security group")
-
-        try:
-            # Create security group
-            response = self.ec2_client.create_security_group(
-                GroupName=f"{TAG_PREFIX}-sg-{self.provider.workflow_id[:8]}",
-                Description=f"Security group for Parsl Spot Fleet ({self.provider.workflow_id})",
-                VpcId=self.vpc_id,
-                TagSpecifications=[
-                    {
-                        "ResourceType": "security-group",
-                        "Tags": [
-                            {
-                                "Key": "Name",
-                                "Value": f"{TAG_PREFIX}-sg-{self.provider.workflow_id}",
-                            },
-                            {"Key": TAG_NAME, "Value": "true"},
-                            {
-                                "Key": TAG_WORKFLOW_ID,
-                                "Value": self.provider.workflow_id,
-                            },
-                        ],
-                    }
-                ],
-            )
-
-            security_group_id = response["GroupId"]
-            logger.info(f"Created security group: {security_group_id}")
-
-            # Add inbound rules using security configuration
-            security_rules = self.security_config.get_security_group_rules(
-                "compute_worker"
-            )
-
-            # Convert to EC2 IpPermissions format
-            ip_permissions = []
-            for rule in security_rules:
-                ip_permission = {
-                    "IpProtocol": rule["IpProtocol"],
-                    "FromPort": rule["FromPort"],
-                    "ToPort": rule["ToPort"],
-                    "IpRanges": rule["IpRanges"],
-                }
-                if "Description" in rule:
-                    # Note: Description goes in IpRanges for ingress rules
-                    for ip_range in ip_permission["IpRanges"]:
-                        ip_range["Description"] = rule["Description"]
-
-                ip_permissions.append(ip_permission)
-
-            # Add self-referencing rule for internal communication
-            ip_permissions.append(
-                {
-                    "IpProtocol": "-1",
-                    "UserIdGroupPairs": [
-                        {
-                            "GroupId": security_group_id,
-                            "Description": "Allow all traffic within security group",
-                        }
-                    ],
-                }
-            )
-
-            if ip_permissions:
-                self.ec2_client.authorize_security_group_ingress(
-                    GroupId=security_group_id, IpPermissions=ip_permissions
-                )
-                logger.info(
-                    f"Configured Spot Fleet security group rules: {security_group_id} "
-                    f"({len(ip_permissions)} rules)"
-                )
-
-                # Log security rule summary
-                for rule in security_rules:
-                    logger.debug(
-                        f"Applied Spot Fleet security rule: {rule['IpProtocol']}:"
-                        f"{rule['FromPort']}-{rule['ToPort']} from "
-                        f"{[r['CidrIp'] for r in rule['IpRanges']]}"
-                    )
-            else:
-                logger.warning(
-                    "No Spot Fleet security rules configured - instances may be unreachable"
-                )
-
-            # Add outbound rule
-            self.ec2_client.authorize_security_group_egress(
-                GroupId=security_group_id,
-                IpPermissions=[
-                    {
-                        "IpProtocol": "-1",  # All protocols
-                        "FromPort": -1,  # All ports
-                        "ToPort": -1,  # All ports
-                        "IpRanges": [{"CidrIp": "0.0.0.0/0"}],  # All destinations
-                    }
-                ],
-            )
-
-            logger.info(f"Configured security group rules: {security_group_id}")
-
-            return security_group_id
-
-        except ClientError as e:
-            logger.error(f"Error creating security group: {e}")
-            raise ResourceCreationError(f"Failed to create security group: {e}")
-
-    def _cleanup_network_resources(self) -> None:
-        """Clean up VPC, subnet, and security group."""
-        try:
-            # Delete security group
-            if self.security_group_id:
-                try:
-                    self.ec2_client.delete_security_group(
-                        GroupId=self.security_group_id
-                    )
-                    logger.info(f"Deleted security group: {self.security_group_id}")
-                except ClientError as e:
-                    logger.error(
-                        f"Error deleting security group {self.security_group_id}: {e}"
-                    )
-                self.security_group_id = None
-
-            # Delete subnet
-            if self.subnet_id:
-                try:
-                    self.ec2_client.delete_subnet(SubnetId=self.subnet_id)
-                    logger.info(f"Deleted subnet: {self.subnet_id}")
-                except ClientError as e:
-                    logger.error(f"Error deleting subnet {self.subnet_id}: {e}")
-                self.subnet_id = None
-
-            # Detach and delete internet gateways
-            if self.vpc_id:
-                try:
-                    # Find internet gateways attached to VPC
-                    igws = self.ec2_client.describe_internet_gateways(
-                        Filters=[{"Name": "attachment.vpc-id", "Values": [self.vpc_id]}]
-                    )
-
-                    # Detach and delete each internet gateway
-                    for igw in igws.get("InternetGateways", []):
-                        igw_id = igw["InternetGatewayId"]
-                        try:
-                            self.ec2_client.detach_internet_gateway(
-                                InternetGatewayId=igw_id, VpcId=self.vpc_id
-                            )
-                            self.ec2_client.delete_internet_gateway(
-                                InternetGatewayId=igw_id
-                            )
-                            logger.info(f"Deleted internet gateway: {igw_id}")
-                        except ClientError as e:
-                            logger.error(
-                                f"Error deleting internet gateway {igw_id}: {e}"
-                            )
-                except ClientError as e:
-                    logger.error(
-                        f"Error finding internet gateways for VPC {self.vpc_id}: {e}"
-                    )
-
-            # Delete route tables
-            if self.vpc_id:
-                try:
-                    # Find route tables associated with VPC
-                    route_tables = self.ec2_client.describe_route_tables(
-                        Filters=[{"Name": "vpc-id", "Values": [self.vpc_id]}]
-                    )
-
-                    # Delete each custom route table (skip main route table)
-                    for rt in route_tables.get("RouteTables", []):
-                        rt_id = rt["RouteTableId"]
-                        # Skip main route table
-                        if any(
-                            assoc.get("Main", False)
-                            for assoc in rt.get("Associations", [])
-                        ):
-                            continue
-
-                        # Delete route table
-                        try:
-                            # First disassociate all subnets
-                            for assoc in rt.get("Associations", []):
-                                if "SubnetId" in assoc:
-                                    self.ec2_client.disassociate_route_table(
-                                        AssociationId=assoc["RouteTableAssociationId"]
-                                    )
-
-                            # Then delete the route table
-                            self.ec2_client.delete_route_table(RouteTableId=rt_id)
-                            logger.info(f"Deleted route table: {rt_id}")
-                        except ClientError as e:
-                            logger.error(f"Error deleting route table {rt_id}: {e}")
-                except ClientError as e:
-                    logger.error(
-                        f"Error finding route tables for VPC {self.vpc_id}: {e}"
-                    )
-
-            # Delete VPC
-            if self.vpc_id:
-                try:
-                    self.ec2_client.delete_vpc(VpcId=self.vpc_id)
-                    logger.info(f"Deleted VPC: {self.vpc_id}")
-                except ClientError as e:
-                    logger.error(f"Error deleting VPC {self.vpc_id}: {e}")
-                self.vpc_id = None
-
-        except Exception as e:
-            logger.error(f"Error cleaning up network resources: {e}")
-            raise ResourceCleanupError(f"Failed to clean up network resources: {e}")
+        return {
+            "vpc_id": self.vpc_id,
+            "subnet_id": self.subnet_id,
+            "security_group_id": self.security_group_id,
+        }
 
     def _get_iam_fleet_role(self) -> str:
         """Get or create an IAM role for the Spot Fleet.
@@ -1623,8 +1193,8 @@ class SpotFleetManager:
                 except Exception as e:
                     logger.error(f"Error cleaning up IAM role {role_name}: {e}")
 
-            # Clean up network resources (this will handle VPC, subnets, security groups, etc.)
-            self._cleanup_network_resources()
+            # The VPC, subnet, and security group are supplied by the caller and
+            # are deliberately left untouched.
 
         except Exception as e:
             logger.error(f"Error cleaning up resources: {e}")

--- a/parsl_ephemeral_aws/modes/base.py
+++ b/parsl_ephemeral_aws/modes/base.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, List, Optional
 import boto3
 
 from parsl_ephemeral_aws.exceptions import OperatingModeError
-from parsl_ephemeral_aws.state.base import StateStore
+from parsl_ephemeral_aws.state.base import STATE_KEY_MODE, StateStore
 
 
 logger = logging.getLogger(__name__)
@@ -337,7 +337,11 @@ class OperatingMode(abc.ABC):
                 raise OperatingModeError(f"Initialization failed: {e}") from e
 
     def save_state(self) -> None:
-        """Save the current state to the state store."""
+        """Save the current state under the mode's own state key.
+
+        The provider writes ``STATE_KEY_PROVIDER`` separately; see
+        ``EphemeralAWSProvider._save_state``.
+        """
         state = {
             "resources": self.resources,
             "provider_id": self.provider_id,
@@ -349,12 +353,41 @@ class OperatingMode(abc.ABC):
         }
 
         try:
-            self.state_store.save_state(state)
+            self.state_store.save_state(STATE_KEY_MODE, state)
         except Exception as e:
             logger.error(f"Failed to save state: {e}")
 
+    def delete_state(self) -> None:
+        """Delete the state stored under the mode's own state key.
+
+        Called on provider shutdown. The provider deletes its own key
+        separately; leaving either behind strands a document that describes
+        resources which no longer exist.
+        """
+        try:
+            self.state_store.delete_state(STATE_KEY_MODE)
+        except Exception as e:
+            logger.error(f"Failed to delete state: {e}")
+
+    def _restore_network_ids(self, state: Dict[str, Any]) -> None:
+        """Restore network IDs from *state*, never overwriting one with None.
+
+        A state document from before these IDs became required can carry
+        ``None`` for any of them. The constructor value was validated; a null
+        from an old file has not been, and would surface later as an opaque
+        boto3 ``InvalidParameterValue`` at launch.
+        """
+        for attribute in ("vpc_id", "subnet_id", "security_group_id"):
+            saved = state.get(attribute)
+            if saved:
+                setattr(self, attribute, saved)
+            elif getattr(self, attribute, None):
+                logger.debug(
+                    f"Keeping configured {attribute} — saved state has no value"
+                )
+
     def load_state(self) -> bool:
-        """Load state from the state store.
+        """Load state from the mode's own state key.
 
         Returns
         -------
@@ -362,14 +395,10 @@ class OperatingMode(abc.ABC):
             True if state was loaded successfully, False otherwise
         """
         try:
-            state = self.state_store.load_state()
+            state = self.state_store.load_state(STATE_KEY_MODE)
             if state and state.get("provider_id") == self.provider_id:
                 self.resources = state.get("resources", {})
-                self.vpc_id = state.get("vpc_id", self.vpc_id)
-                self.subnet_id = state.get("subnet_id", self.subnet_id)
-                self.security_group_id = state.get(
-                    "security_group_id", self.security_group_id
-                )
+                self._restore_network_ids(state)
                 self.initialized = state.get("initialized", False)
                 logger.debug(f"Loaded state with {len(self.resources)} resources")
                 return True

--- a/parsl_ephemeral_aws/modes/base.py
+++ b/parsl_ephemeral_aws/modes/base.py
@@ -11,7 +11,9 @@ from typing import Any, Dict, List, Optional
 
 import boto3
 
-from parsl_ephemeral_aws.exceptions import OperatingModeError
+from botocore.exceptions import ClientError
+
+from parsl_ephemeral_aws.exceptions import OperatingModeError, ResourceNotFoundError
 from parsl_ephemeral_aws.state.base import STATE_KEY_MODE, StateStore
 
 
@@ -368,6 +370,75 @@ class OperatingMode(abc.ABC):
             self.state_store.delete_state(STATE_KEY_MODE)
         except Exception as e:
             logger.error(f"Failed to delete state: {e}")
+
+    #: EC2 error codes and describe call for each network ID, in the order they
+    #: are checked. VPC first, so a wholly deleted VPC is reported as such
+    #: rather than as three unrelated missing children.
+    #:
+    #: Both ``NotFound`` and ``Malformed`` are treated as "unusable ID". EC2
+    #: returns the latter for a syntactically invalid ID — verified against real
+    #: AWS, where ``sg-00000000000000000`` yields ``InvalidGroupId.Malformed``
+    #: while the same shape of subnet or VPC ID yields ``NotFound``. To the
+    #: caller both mean the same thing: the ID they supplied cannot be used.
+    _NETWORK_RESOURCES = (
+        (
+            "vpc_id",
+            "describe_vpcs",
+            "VpcIds",
+            ("InvalidVpcID.NotFound", "InvalidVpcID.Malformed"),
+        ),
+        (
+            "subnet_id",
+            "describe_subnets",
+            "SubnetIds",
+            ("InvalidSubnetID.NotFound", "InvalidSubnetId.Malformed"),
+        ),
+        (
+            "security_group_id",
+            "describe_security_groups",
+            "GroupIds",
+            ("InvalidGroup.NotFound", "InvalidGroupId.Malformed"),
+        ),
+    )
+
+    def _verify_resources(self) -> None:
+        """Confirm the caller-supplied network resources still exist.
+
+        Raises
+        ------
+        ResourceNotFoundError
+            If a configured VPC, subnet, or security group is missing or its ID
+            is malformed.
+
+        Notes
+        -----
+        Every mode used to null the attribute out here instead of raising, so
+        that ``initialize()`` would create a replacement. Since #69 nothing
+        creates one: the ``None`` propagates to ``run_instances`` and surfaces as
+        an opaque ``InvalidParameterValue`` far from the missing resource, or —
+        in serverless mode — re-entered a guard that read a ``create_vpc``
+        attribute which no longer exists. Naming the resource here is the whole
+        point of verifying it.
+        """
+        ec2 = self.session.client("ec2")
+
+        for attribute, describe, id_param, bad_id_codes in self._NETWORK_RESOURCES:
+            resource_id = getattr(self, attribute, None)
+            if not resource_id:
+                continue
+
+            try:
+                getattr(ec2, describe)(**{id_param: [resource_id]})
+                logger.debug(f"Verified {attribute} {resource_id} exists")
+            except ClientError as e:
+                if e.response.get("Error", {}).get("Code") in bad_id_codes:
+                    raise ResourceNotFoundError(
+                        f"{attribute} {resource_id} is not usable. It is "
+                        "malformed, was deleted, or belongs to a different "
+                        "region or account; pre-provision the network resources "
+                        "and pass their IDs."
+                    ) from e
+                raise
 
     def _restore_network_ids(self, state: Dict[str, Any]) -> None:
         """Restore network IDs from *state*, never overwriting one with None.

--- a/parsl_ephemeral_aws/modes/base.py
+++ b/parsl_ephemeral_aws/modes/base.py
@@ -101,6 +101,7 @@ class OperatingMode(abc.ABC):
         custom_ami: bool = False,
         debug: bool = False,
         region: Optional[str] = None,
+        require_network_resources: bool = True,
         **kwargs: Any,
     ) -> None:
         """Initialize the operating mode.
@@ -153,6 +154,10 @@ class OperatingMode(abc.ABC):
             Whether image_id refers to a custom AMI, by default False
         debug : bool, optional
             Whether to enable debug logging, by default False
+        require_network_resources : bool, optional
+            Whether vpc_id, subnet_id, and security_group_id are mandatory, by
+            default True. Subclasses whose compute backend supplies its own
+            networking (e.g. Lambda-only serverless mode) pass False.
         """
         self.provider_id = provider_id
         self.session = session
@@ -188,7 +193,11 @@ class OperatingMode(abc.ABC):
         self.resources: Dict[str, Dict[str, Any]] = {}
         self.initialized = False
 
-        if not self.vpc_id or not self.subnet_id or not self.security_group_id:
+        self.require_network_resources = require_network_resources
+
+        if require_network_resources and (
+            not self.vpc_id or not self.subnet_id or not self.security_group_id
+        ):
             raise ValueError(
                 "vpc_id, subnet_id, and security_group_id are required. "
                 "Pre-provision network resources and pass their IDs."

--- a/parsl_ephemeral_aws/modes/detached.py
+++ b/parsl_ephemeral_aws/modes/detached.py
@@ -34,7 +34,7 @@ from parsl_ephemeral_aws.exceptions import (
     ResourceCreationError,
 )
 from parsl_ephemeral_aws.modes.base import OperatingMode
-from parsl_ephemeral_aws.state.base import StateStore
+from parsl_ephemeral_aws.state.base import STATE_KEY_MODE, StateStore
 from parsl_ephemeral_aws.utils.aws import (
     get_default_ami,
     wait_for_resource,
@@ -2091,7 +2091,7 @@ if __name__ == '__main__':
         }
 
         try:
-            self.state_store.save_state(state)
+            self.state_store.save_state(STATE_KEY_MODE, state)
         except Exception as e:
             logger.error(f"Failed to save state: {e}")
 
@@ -2104,14 +2104,10 @@ if __name__ == '__main__':
             True if state was loaded successfully, False otherwise
         """
         try:
-            state = self.state_store.load_state()
+            state = self.state_store.load_state(STATE_KEY_MODE)
             if state and state.get("provider_id") == self.provider_id:
                 self.resources = state.get("resources", {})
-                self.vpc_id = state.get("vpc_id", self.vpc_id)
-                self.subnet_id = state.get("subnet_id", self.subnet_id)
-                self.security_group_id = state.get(
-                    "security_group_id", self.security_group_id
-                )
+                self._restore_network_ids(state)
                 self.initialized = state.get("initialized", False)
                 self.workflow_id = state.get("workflow_id", self.workflow_id)
                 self.bastion_id = state.get("bastion_id", self.bastion_id)

--- a/parsl_ephemeral_aws/modes/detached.py
+++ b/parsl_ephemeral_aws/modes/detached.py
@@ -182,12 +182,28 @@ class DetachedMode(OperatingMode):
         if self.initialized:
             return
 
-        # Try to load state first
-        if self.load_state():
-            logger.debug("Loaded state, checking resources")
-            # Verify that the loaded resources exist
-            self._verify_resources()
-            return
+        # Try to load state first — bastion_id comes from it, so the bastion
+        # check below has to run afterwards.
+        loaded = self.load_state()
+
+        # Confirm the caller-supplied network resources exist, then the bastion.
+        # Verification used to sit inside the resume branch only, so a first-run
+        # provider — the common case — never checked at all, and a mistyped or
+        # cross-region ID surfaced much later as an opaque InvalidParameterValue
+        # from inside run_instances.
+        self._verify_resources()
+
+        if loaded:
+            logger.debug("Loaded state, resources verified")
+            # _verify_resources() clears bastion_id if the bastion is gone, so
+            # that the block below can rebuild it. Returning unconditionally
+            # skipped that, leaving a resumed provider with no bastion and no
+            # way to submit — every job dispatched into an SSM path nothing was
+            # reading.
+            if self.bastion_id:
+                return
+
+            logger.info("Bastion host is gone; recreating it")
 
         logger.debug("Initializing detached mode infrastructure")
 
@@ -220,52 +236,22 @@ class DetachedMode(OperatingMode):
             ) from e
 
     def _verify_resources(self) -> None:
-        """Verify that the required resources exist.
+        """Verify the network resources, then the bastion host.
 
         Raises
         ------
         ResourceNotFoundError
-            If a required resource does not exist
+            If a configured VPC, subnet, or security group is gone.
+
+        Notes
+        -----
+        A missing bastion is *not* an error: unlike the network resources it is
+        created by this mode, so ``initialize()`` can and does build a
+        replacement. Clearing ``bastion_id`` is what tells it to.
         """
+        super()._verify_resources()
+
         ec2 = self.session.client("ec2")
-
-        # Verify VPC
-        if self.vpc_id:
-            try:
-                ec2.describe_vpcs(VpcIds=[self.vpc_id])
-                logger.debug(f"Verified VPC {self.vpc_id} exists")
-            except ClientError as e:
-                if "InvalidVpcID.NotFound" in str(e):
-                    logger.warning(f"VPC {self.vpc_id} does not exist")
-                    self.vpc_id = None
-                else:
-                    raise
-
-        # Verify subnet
-        if self.subnet_id:
-            try:
-                ec2.describe_subnets(SubnetIds=[self.subnet_id])
-                logger.debug(f"Verified subnet {self.subnet_id} exists")
-            except ClientError as e:
-                if "InvalidSubnetID.NotFound" in str(e):
-                    logger.warning(f"Subnet {self.subnet_id} does not exist")
-                    self.subnet_id = None
-                else:
-                    raise
-
-        # Verify security group
-        if self.security_group_id:
-            try:
-                ec2.describe_security_groups(GroupIds=[self.security_group_id])
-                logger.debug(f"Verified security group {self.security_group_id} exists")
-            except ClientError as e:
-                if "InvalidGroup.NotFound" in str(e):
-                    logger.warning(
-                        f"Security group {self.security_group_id} does not exist"
-                    )
-                    self.security_group_id = None
-                else:
-                    raise
 
         # Verify bastion host
         if self.bastion_id:

--- a/parsl_ephemeral_aws/modes/serverless.py
+++ b/parsl_ephemeral_aws/modes/serverless.py
@@ -18,9 +18,6 @@ import boto3
 from botocore.exceptions import ClientError
 
 from parsl_ephemeral_aws.constants import (
-    DEFAULT_SECURITY_GROUP_DESCRIPTION,
-    DEFAULT_SECURITY_GROUP_NAME,
-    DEFAULT_OUTBOUND_RULES,
     RESOURCE_TYPE_LAMBDA_FUNCTION,
     RESOURCE_TYPE_ECS_TASK,
     WORKER_TYPE_LAMBDA,
@@ -44,7 +41,6 @@ from parsl_ephemeral_aws.constants import (
 from parsl_ephemeral_aws.exceptions import (
     ConfigurationError,
     JobSubmissionError,
-    NetworkCreationError,
     OperatingModeError,
     ResourceCreationError,
 )
@@ -54,10 +50,6 @@ from parsl_ephemeral_aws.compute.ecs import ECSManager
 from parsl_ephemeral_aws.compute.spot_interruption import (
     SpotInterruptionMonitor,
     ParslSpotInterruptionHandler,
-)
-from parsl_ephemeral_aws.utils.aws import (
-    create_tags,
-    wait_for_resource,
 )
 
 
@@ -118,7 +110,6 @@ class ServerlessMode(OperatingMode):
         subnet_id: Optional[str] = None,
         security_group_id: Optional[str] = None,
         use_public_ips: bool = True,
-        create_vpc: bool = True,
         use_spot: bool = False,
         use_spot_fleet: bool = False,
         instance_types: Optional[List[str]] = None,
@@ -126,6 +117,9 @@ class ServerlessMode(OperatingMode):
         spot_max_price_percentage: Optional[float] = None,
         additional_tags: Optional[Dict[str, str]] = None,
         debug: bool = False,
+        compute_type: Optional[str] = None,
+        memory_size: Optional[int] = None,
+        timeout: Optional[int] = None,
         **kwargs: Any,
     ) -> None:
         """Initialize the serverless mode.
@@ -160,8 +154,6 @@ class ServerlessMode(OperatingMode):
             Existing security group ID to use, by default None
         use_public_ips : bool, optional
             Whether to assign public IPs to ECS tasks, by default True
-        create_vpc : bool, optional
-            Whether to create a new VPC if vpc_id is not provided, by default True
         use_spot : bool, optional
             Whether to use spot instances for ECS tasks (Fargate Spot), by default False
         use_spot_fleet : bool, optional
@@ -181,7 +173,40 @@ class ServerlessMode(OperatingMode):
             Tags to apply to created resources, by default None
         debug : bool, optional
             Whether to enable debug logging, by default False
+        compute_type : Optional[str], optional
+            Compute type forwarded by ``EphemeralAWSProvider`` ("lambda" or "ecs").
+            When supplied it takes precedence over ``worker_type``; "ec2" is
+            treated as unset since it has no meaning for serverless mode.
+        memory_size : Optional[int], optional
+            Lambda memory in MB, forwarded by ``EphemeralAWSProvider``. Overrides
+            ``lambda_memory`` when supplied.
+        timeout : Optional[int], optional
+            Lambda timeout in seconds, forwarded by ``EphemeralAWSProvider``.
+            Overrides ``lambda_timeout`` when supplied.
         """
+        # compute_type is the provider-facing name for worker_type. Map it before
+        # validating so an invalid value is reported against the real input.
+        # It arrives as a ComputeType enum member, whose str() is the qualified
+        # name rather than the value — read .value when present.
+        if compute_type is not None:
+            compute_type = str(getattr(compute_type, "value", compute_type)).lower()
+            if compute_type != "ec2":
+                worker_type = compute_type
+
+        # Validate worker type before calling super(), so a bad value is reported
+        # even when the network guard below would also have failed.
+        if worker_type not in [WORKER_TYPE_LAMBDA, WORKER_TYPE_ECS, WORKER_TYPE_AUTO]:
+            raise ConfigurationError(
+                f"Serverless mode requires worker_type to be '{WORKER_TYPE_LAMBDA}', "
+                f"'{WORKER_TYPE_ECS}', or '{WORKER_TYPE_AUTO}'"
+            )
+
+        # Lambda runs in the Lambda-managed VPC and needs none of the three
+        # network IDs; ECS/Fargate requires a subnet and security group for its
+        # mandatory awsvpcConfiguration. Only enforce the base-class requirement
+        # when ECS is reachable.
+        requires_network = worker_type in [WORKER_TYPE_ECS, WORKER_TYPE_AUTO]
+
         super().__init__(
             provider_id=provider_id,
             session=session,
@@ -190,23 +215,16 @@ class ServerlessMode(OperatingMode):
             subnet_id=subnet_id,
             security_group_id=security_group_id,
             use_public_ips=use_public_ips,
-            create_vpc=create_vpc,
             additional_tags=additional_tags,
             debug=debug,
+            require_network_resources=requires_network,
             **kwargs,
         )
 
-        # Validate worker type
-        if worker_type not in [WORKER_TYPE_LAMBDA, WORKER_TYPE_ECS, WORKER_TYPE_AUTO]:
-            raise ConfigurationError(
-                f"Serverless mode requires worker_type to be '{WORKER_TYPE_LAMBDA}', "
-                f"'{WORKER_TYPE_ECS}', or '{WORKER_TYPE_AUTO}'"
-            )
-
         # Set serverless mode specific attributes
         self.worker_type = worker_type
-        self.lambda_timeout = lambda_timeout
-        self.lambda_memory = lambda_memory
+        self.lambda_timeout = timeout if timeout is not None else lambda_timeout
+        self.lambda_memory = memory_size if memory_size is not None else lambda_memory
         self.lambda_runtime = lambda_runtime
         self.ecs_task_cpu = ecs_task_cpu
         self.ecs_task_memory = ecs_task_memory
@@ -228,9 +246,27 @@ class ServerlessMode(OperatingMode):
         self.nodes_per_block = nodes_per_block
         self.spot_max_price_percentage = spot_max_price_percentage
 
+        # LambdaManager and ECSManager were written against EphemeralAWSProvider
+        # and are handed this mode as their `provider`. Define the attributes they
+        # read so the contract is satisfied without duplicating the mode.
+        #
+        # Credentials are deliberately left as None: self.session is already
+        # fully authenticated by the provider via create_session(), and the
+        # managers fall back to the ambient credential chain when these are unset.
+        self.workflow_id = self.provider_id
+        self.aws_access_key_id: Optional[str] = None
+        self.aws_secret_access_key: Optional[str] = None
+        self.aws_session_token: Optional[str] = None
+        self.aws_profile: Optional[str] = None
+        self.security_config: Optional[Any] = None
+        # ECSManager reads this to decide whether to request Fargate Spot.
+        self.use_spot_instances = use_spot
+        # ECSManager prefers a subnet_ids list and falls back to subnet_id.
+        self.subnet_ids = [self.subnet_id] if self.subnet_id else None
+
         # Initialize compute managers
-        self.lambda_manager = None
-        self.ecs_manager = None
+        self.lambda_manager: Optional[LambdaManager] = None
+        self.ecs_manager: Optional[ECSManager] = None
         self.cf_client = self.session.client("cloudformation")
 
         # Initialize spot interruption handling if enabled
@@ -255,15 +291,16 @@ class ServerlessMode(OperatingMode):
                 self.spot_interruption_monitor.start_monitoring()
 
     def initialize(self) -> None:
-        """Initialize serverless mode infrastructure.
+        """Initialize serverless mode.
 
-        Creates the necessary network resources if they don't already exist.
-        Initializes Lambda and/or ECS managers based on the worker type.
+        Verifies the caller-supplied network resources (when the worker type
+        needs them) and initializes the Lambda and/or ECS managers. Network
+        resources are never created by this mode.
 
         Raises
         ------
         ResourceCreationError
-            If resource creation fails
+            If initialization fails
         """
         # Idempotent: if already initialized, do nothing.
         if self.initialized:
@@ -276,54 +313,37 @@ class ServerlessMode(OperatingMode):
             self._verify_resources()
             # Initialize compute managers
             self._initialize_compute_managers()
+            self.initialized = True
             return
 
-        logger.debug("Initializing serverless mode infrastructure")
+        logger.debug("Initializing serverless mode")
 
-        # Create AWS resources
         try:
-            # Create VPC if needed (for ECS tasks)
-            if (
-                not self.vpc_id
-                and self.create_vpc
-                and (self.worker_type in [WORKER_TYPE_ECS, WORKER_TYPE_AUTO])
-            ):
-                self.vpc_id = self._create_vpc()
-
-            # Create subnet if needed (for ECS tasks)
-            if (
-                not self.subnet_id
-                and self.vpc_id
-                and (self.worker_type in [WORKER_TYPE_ECS, WORKER_TYPE_AUTO])
-            ):
-                self.subnet_id = self._create_subnet()
-
-            # Create security group if needed (for ECS tasks)
-            if (
-                not self.security_group_id
-                and self.vpc_id
-                and (self.worker_type in [WORKER_TYPE_ECS, WORKER_TYPE_AUTO])
-            ):
-                self.security_group_id = self._create_security_group()
+            # Confirm the caller-supplied network resources exist before we rely
+            # on them. Lambda-only deployments have nothing to verify.
+            self._verify_resources()
 
             # Initialize compute managers
             self._initialize_compute_managers()
+
+            self.initialized = True
 
             # Save state
             self.save_state()
 
             logger.info(
-                f"Initialized serverless mode infrastructure: "
+                f"Initialized serverless mode: "
                 f"worker_type={self.worker_type}, "
                 f"vpc_id={self.vpc_id}, subnet_id={self.subnet_id}, "
                 f"security_group_id={self.security_group_id}"
             )
         except Exception as e:
-            logger.error(f"Failed to initialize serverless mode infrastructure: {e}")
-            # Try to clean up any resources we created
+            logger.error(f"Failed to initialize serverless mode: {e}")
+            # Release anything we did stand up. Network resources belong to the
+            # caller and are left untouched.
             self.cleanup_infrastructure()
             raise ResourceCreationError(
-                f"Failed to initialize serverless mode infrastructure: {e}"
+                f"Failed to initialize serverless mode: {e}"
             ) from e
 
     def _initialize_compute_managers(self) -> None:
@@ -383,188 +403,6 @@ class ServerlessMode(OperatingMode):
                     self.security_group_id = None
                 else:
                     raise
-
-    def _create_vpc(self) -> str:
-        """Create a VPC for ECS tasks.
-
-        Returns
-        -------
-        str
-            VPC ID
-
-        Raises
-        ------
-        NetworkCreationError
-            If VPC creation fails
-        """
-        logger.info("Creating VPC for serverless resources")
-
-        try:
-            # Create CloudFormation stack with VPC
-            stack_name = f"parsl-vpc-{self.provider_id[:8]}"
-            template_path = os.path.join(
-                os.path.dirname(os.path.dirname(__file__)),
-                "templates/cloudformation/vpc.yml",
-            )
-
-            with open(template_path, "r") as f:
-                template_body = f.read()
-
-            # Create stack
-            self.cf_client.create_stack(
-                StackName=stack_name,
-                TemplateBody=template_body,
-                Parameters=[
-                    {"ParameterKey": "VpcCidr", "ParameterValue": "10.0.0.0/16"},
-                    {
-                        "ParameterKey": "PublicSubnetCidr",
-                        "ParameterValue": "10.0.0.0/24",
-                    },
-                    {"ParameterKey": "WorkflowId", "ParameterValue": self.provider_id},
-                ],
-                Tags=[
-                    {"Key": "CreatedBy", "Value": "ParslEphemeralAWSProvider"},
-                    {"Key": "ProviderId", "Value": self.provider_id},
-                ],
-            )
-
-            # Wait for stack creation to complete
-            logger.debug(f"Waiting for VPC stack {stack_name} to complete")
-            waiter = self.cf_client.get_waiter("stack_create_complete")
-            waiter.wait(
-                StackName=stack_name, WaiterConfig={"Delay": 5, "MaxAttempts": 60}
-            )
-
-            # Get VPC ID from stack outputs
-            response = self.cf_client.describe_stacks(StackName=stack_name)
-            outputs = response["Stacks"][0]["Outputs"]
-            vpc_id = None
-
-            for output in outputs:
-                if output["OutputKey"] == "VpcId":
-                    vpc_id = output["OutputValue"]
-                    break
-
-            if not vpc_id:
-                raise NetworkCreationError("VPC ID not found in stack outputs")
-
-            logger.info(f"Created VPC {vpc_id} using CloudFormation stack")
-            return vpc_id
-
-        except ClientError as e:
-            logger.error(f"Failed to create VPC: {e}")
-            raise NetworkCreationError(f"Failed to create VPC: {e}") from e
-
-    def _create_subnet(self) -> str:
-        """Create a subnet for ECS tasks.
-
-        Returns
-        -------
-        str
-            Subnet ID
-
-        Raises
-        ------
-        NetworkCreationError
-            If subnet creation fails
-        """
-        # When using CloudFormation for VPC creation, subnet is already created
-        # We just need to get it from the stack outputs
-        logger.info("Getting subnet from VPC stack")
-
-        try:
-            stack_name = f"parsl-vpc-{self.provider_id[:8]}"
-            response = self.cf_client.describe_stacks(StackName=stack_name)
-            outputs = response["Stacks"][0]["Outputs"]
-            subnet_id = None
-
-            for output in outputs:
-                if output["OutputKey"] == "PublicSubnetId":
-                    subnet_id = output["OutputValue"]
-                    break
-
-            if not subnet_id:
-                raise NetworkCreationError("Subnet ID not found in stack outputs")
-
-            logger.info(f"Found subnet {subnet_id} from CloudFormation stack")
-            return subnet_id
-
-        except ClientError as e:
-            logger.error(f"Failed to get subnet: {e}")
-            raise NetworkCreationError(f"Failed to get subnet: {e}") from e
-
-    def _create_security_group(self) -> str:
-        """Create a security group for ECS tasks.
-
-        Returns
-        -------
-        str
-            Security group ID
-
-        Raises
-        ------
-        NetworkCreationError
-            If security group creation fails
-        """
-        if not self.vpc_id:
-            raise NetworkCreationError("VPC ID is required to create a security group")
-
-        logger.info(f"Creating security group in VPC {self.vpc_id}")
-        ec2 = self.session.client("ec2")
-
-        try:
-            # Create security group
-            response = ec2.create_security_group(
-                GroupName=f"{DEFAULT_SECURITY_GROUP_NAME}-{self.provider_id[:8]}",
-                Description=f"{DEFAULT_SECURITY_GROUP_DESCRIPTION} (Serverless)",
-                VpcId=self.vpc_id,
-                TagSpecifications=[
-                    {
-                        "ResourceType": "security-group",
-                        "Tags": [
-                            {
-                                "Key": "Name",
-                                "Value": f"parsl-ephemeral-sg-{self.provider_id[:8]}",
-                            },
-                            {"Key": "CreatedBy", "Value": "ParslEphemeralAWSProvider"},
-                            {"Key": "ProviderId", "Value": self.provider_id},
-                        ],
-                    }
-                ],
-            )
-
-            security_group_id = response["GroupId"]
-            logger.debug(
-                f"Created security group {security_group_id} in VPC {self.vpc_id}"
-            )
-
-            # Add outbound rules (allow all outbound traffic)
-            if DEFAULT_OUTBOUND_RULES:
-                ec2.authorize_security_group_egress(
-                    GroupId=security_group_id, IpPermissions=DEFAULT_OUTBOUND_RULES
-                )
-                logger.debug(
-                    f"Added outbound rules to security group {security_group_id}"
-                )
-
-            # Add tags
-            if self.additional_tags:
-                create_tags(security_group_id, self.additional_tags, self.session)
-
-            # Wait for security group to be available
-            wait_for_resource(
-                security_group_id,
-                "security_group_exists",
-                ec2,
-                resource_name="security group",
-            )
-
-            return security_group_id
-        except Exception as e:
-            logger.error(f"Failed to create security group in VPC {self.vpc_id}: {e}")
-            raise NetworkCreationError(
-                f"Failed to create security group in VPC {self.vpc_id}: {e}"
-            ) from e
 
     def _select_worker_type(self, command: str, tasks_per_node: int) -> str:
         """Select the appropriate worker type for a job.

--- a/parsl_ephemeral_aws/modes/serverless.py
+++ b/parsl_ephemeral_aws/modes/serverless.py
@@ -45,6 +45,7 @@ from parsl_ephemeral_aws.exceptions import (
     ResourceCreationError,
 )
 from parsl_ephemeral_aws.modes.base import OperatingMode
+from parsl_ephemeral_aws.state.base import STATE_KEY_MODE
 from parsl_ephemeral_aws.compute.lambda_func import LambdaManager
 from parsl_ephemeral_aws.compute.ecs import ECSManager
 from parsl_ephemeral_aws.compute.spot_interruption import (
@@ -1509,7 +1510,7 @@ class ServerlessMode(OperatingMode):
         }
 
         try:
-            self.state_store.save_state(state)
+            self.state_store.save_state(STATE_KEY_MODE, state)
         except Exception as e:
             logger.error(f"Failed to save state: {e}")
 
@@ -1522,14 +1523,10 @@ class ServerlessMode(OperatingMode):
             True if state was loaded successfully, False otherwise
         """
         try:
-            state = self.state_store.load_state()
+            state = self.state_store.load_state(STATE_KEY_MODE)
             if state and state.get("provider_id") == self.provider_id:
                 self.resources = state.get("resources", {})
-                self.vpc_id = state.get("vpc_id", self.vpc_id)
-                self.subnet_id = state.get("subnet_id", self.subnet_id)
-                self.security_group_id = state.get(
-                    "security_group_id", self.security_group_id
-                )
+                self._restore_network_ids(state)
                 self.initialized = state.get("initialized", False)
 
                 # Check if spot interruption handling was previously enabled

--- a/parsl_ephemeral_aws/modes/serverless.py
+++ b/parsl_ephemeral_aws/modes/serverless.py
@@ -357,54 +357,6 @@ class ServerlessMode(OperatingMode):
             logger.debug("Initializing ECS manager")
             self.ecs_manager = ECSManager(self)
 
-    def _verify_resources(self) -> None:
-        """Verify that the required resources exist.
-
-        Raises
-        ------
-        ResourceNotFoundError
-            If a required resource does not exist
-        """
-        ec2 = self.session.client("ec2")
-
-        # Verify VPC (if needed)
-        if self.vpc_id:
-            try:
-                ec2.describe_vpcs(VpcIds=[self.vpc_id])
-                logger.debug(f"Verified VPC {self.vpc_id} exists")
-            except ClientError as e:
-                if "InvalidVpcID.NotFound" in str(e):
-                    logger.warning(f"VPC {self.vpc_id} does not exist")
-                    self.vpc_id = None
-                else:
-                    raise
-
-        # Verify subnet (if needed)
-        if self.subnet_id:
-            try:
-                ec2.describe_subnets(SubnetIds=[self.subnet_id])
-                logger.debug(f"Verified subnet {self.subnet_id} exists")
-            except ClientError as e:
-                if "InvalidSubnetID.NotFound" in str(e):
-                    logger.warning(f"Subnet {self.subnet_id} does not exist")
-                    self.subnet_id = None
-                else:
-                    raise
-
-        # Verify security group (if needed)
-        if self.security_group_id:
-            try:
-                ec2.describe_security_groups(GroupIds=[self.security_group_id])
-                logger.debug(f"Verified security group {self.security_group_id} exists")
-            except ClientError as e:
-                if "InvalidGroup.NotFound" in str(e):
-                    logger.warning(
-                        f"Security group {self.security_group_id} does not exist"
-                    )
-                    self.security_group_id = None
-                else:
-                    raise
-
     def _select_worker_type(self, command: str, tasks_per_node: int) -> str:
         """Select the appropriate worker type for a job.
 

--- a/parsl_ephemeral_aws/modes/serverless.py
+++ b/parsl_ephemeral_aws/modes/serverless.py
@@ -1480,7 +1480,9 @@ class ServerlessMode(OperatingMode):
     def cleanup_infrastructure(self) -> None:
         """Clean up infrastructure created by this mode.
 
-        This cleans up the VPC, subnet, and security group if they were created by the provider.
+        The VPC, subnet, and security group are supplied by the caller and are
+        never created — or deleted — by this mode.  Only the Lambda functions,
+        ECS tasks, and Spot Fleet resources created here are removed.
         """
         logger.info("Cleaning up serverless mode infrastructure")
 
@@ -1497,59 +1499,6 @@ class ServerlessMode(OperatingMode):
                 logger.error(f"Failed to stop spot interruption monitoring: {e}")
             self.spot_interruption_monitor = None
             self.spot_interruption_handler = None
-
-        # Check if we created a VPC using CloudFormation
-        stack_name = f"parsl-vpc-{self.provider_id[:8]}"
-        try:
-            self.cf_client.describe_stacks(StackName=stack_name)
-
-            # Stack exists, delete it
-            logger.info(f"Deleting VPC stack {stack_name}")
-            self.cf_client.delete_stack(StackName=stack_name)
-
-            # Wait for deletion to complete (with timeout)
-            start_time = time.time()
-            while time.time() - start_time < 300:  # 5 minute timeout
-                try:
-                    response = self.cf_client.describe_stacks(StackName=stack_name)
-                    status = response["Stacks"][0]["StackStatus"]
-
-                    if status == "DELETE_COMPLETE":
-                        logger.info(f"VPC stack {stack_name} deleted successfully")
-                        break
-                    elif status == "DELETE_FAILED":
-                        logger.error(f"Failed to delete VPC stack {stack_name}")
-                        break
-
-                    time.sleep(10)
-                except ClientError as e:
-                    if "does not exist" in str(e):
-                        logger.info(f"VPC stack {stack_name} deleted successfully")
-                        break
-                    raise
-
-            # Reset IDs
-            self.vpc_id = None
-            self.subnet_id = None
-
-        except ClientError as e:
-            # If stack doesn't exist, that's fine
-            if "does not exist" not in str(e):
-                logger.error(f"Error checking VPC stack {stack_name}: {e}")
-
-        # Delete security group if we created it directly
-        if self.security_group_id:
-            try:
-                ec2 = self.session.client("ec2")
-                ec2.delete_security_group(GroupId=self.security_group_id)
-                logger.info(f"Deleted security group {self.security_group_id}")
-                self.security_group_id = None
-            except ClientError as e:
-                if "InvalidGroup.NotFound" not in str(e):
-                    logger.error(
-                        f"Failed to delete security group {self.security_group_id}: {e}"
-                    )
-                self.security_group_id = None
 
         # Clean up compute managers
         if self.lambda_manager:

--- a/parsl_ephemeral_aws/modes/standard.py
+++ b/parsl_ephemeral_aws/modes/standard.py
@@ -617,11 +617,16 @@ class StandardMode(OperatingMode):
         # resumed provider gets an ARN too — it is not persisted in state.
         self._resolve_instance_profile()
 
+        # Confirm the caller-supplied network resources exist. This runs on both
+        # paths: verification used to sit inside the resume branch only, so a
+        # first-run provider — the common case — never checked at all, and a
+        # mistyped or cross-region ID surfaced much later as an opaque
+        # InvalidParameterValue from inside run_instances.
+        self._verify_resources()
+
         # Try to load state first
         if self.load_state():
-            logger.debug("Loaded state, checking resources")
-            # Verify that the loaded resources exist
-            self._verify_resources()
+            logger.debug("Loaded state, resources already verified")
             return
 
         logger.debug("Initializing standard mode infrastructure")
@@ -710,54 +715,6 @@ class StandardMode(OperatingMode):
                 f"Failed to create IAM instance profile: {e}. SSM command "
                 "dispatch will not be available."
             )
-
-    def _verify_resources(self) -> None:
-        """Verify that the required resources exist.
-
-        Raises
-        ------
-        ResourceNotFoundError
-            If a required resource does not exist
-        """
-        ec2 = self.session.client("ec2")
-
-        # Verify VPC
-        if self.vpc_id:
-            try:
-                ec2.describe_vpcs(VpcIds=[self.vpc_id])
-                logger.debug(f"Verified VPC {self.vpc_id} exists")
-            except ClientError as e:
-                if "InvalidVpcID.NotFound" in str(e):
-                    logger.warning(f"VPC {self.vpc_id} does not exist")
-                    self.vpc_id = None
-                else:
-                    raise
-
-        # Verify subnet
-        if self.subnet_id:
-            try:
-                ec2.describe_subnets(SubnetIds=[self.subnet_id])
-                logger.debug(f"Verified subnet {self.subnet_id} exists")
-            except ClientError as e:
-                if "InvalidSubnetID.NotFound" in str(e):
-                    logger.warning(f"Subnet {self.subnet_id} does not exist")
-                    self.subnet_id = None
-                else:
-                    raise
-
-        # Verify security group
-        if self.security_group_id:
-            try:
-                ec2.describe_security_groups(GroupIds=[self.security_group_id])
-                logger.debug(f"Verified security group {self.security_group_id} exists")
-            except ClientError as e:
-                if "InvalidGroup.NotFound" in str(e):
-                    logger.warning(
-                        f"Security group {self.security_group_id} does not exist"
-                    )
-                    self.security_group_id = None
-                else:
-                    raise
 
     def submit_job(
         self,

--- a/parsl_ephemeral_aws/modes/standard.py
+++ b/parsl_ephemeral_aws/modes/standard.py
@@ -41,6 +41,7 @@ from parsl_ephemeral_aws.compute.spot_interruption import (
 )
 from parsl_ephemeral_aws.utils.aws import (
     get_default_ami,
+    get_or_create_ssm_instance_profile,
     wait_for_resource,
 )
 
@@ -86,6 +87,7 @@ class StandardMode(OperatingMode):
         warm_pool_size: int = 0,
         warm_pool_ttl: int = 600,
         iam_instance_profile_arn: Optional[str] = None,
+        auto_create_instance_profile: bool = False,
         bake_ami: bool = False,
         baked_ami_id: Optional[str] = None,
         one_shot: bool = False,
@@ -141,6 +143,24 @@ class StandardMode(OperatingMode):
             Number of nodes per block, by default 1
         spot_max_price_percentage : Optional[int], optional
             Maximum spot price as a percentage of on-demand price, by default None
+        warm_pool_size : int, optional
+            Number of idle instances to keep for reuse, by default 0 (disabled)
+        warm_pool_ttl : int, optional
+            Seconds a warm instance is kept before termination, by default 600
+        iam_instance_profile_arn : Optional[str], optional
+            Instance profile ARN granting SSM access, by default None
+        auto_create_instance_profile : bool, optional
+            Whether to create an instance profile with the
+            ``AmazonSSMManagedInstanceCore`` policy when
+            ``iam_instance_profile_arn`` is not supplied, by default False.
+            SSM ``SendCommand`` dispatch cannot work without one of the two.
+        bake_ami : bool, optional
+            Whether to pre-install ``worker_init`` into a custom AMI, by default False
+        baked_ami_id : Optional[str], optional
+            Pre-baked AMI to use instead of baking one, by default None
+        one_shot : bool, optional
+            Whether to dispatch a single command per instance and terminate,
+            by default False
         """
         # Call parent __init__ with standard params
         super().__init__(
@@ -176,6 +196,7 @@ class StandardMode(OperatingMode):
         self.warm_pool_size = warm_pool_size
         self.warm_pool_ttl = warm_pool_ttl
         self.iam_instance_profile_arn = iam_instance_profile_arn
+        self.auto_create_instance_profile = auto_create_instance_profile
         # List of instance IDs currently in the warm pool (ready for reuse, FIFO)
         self._warm_instances: List[str] = []
 
@@ -595,6 +616,10 @@ class StandardMode(OperatingMode):
         if self.initialized:
             return
 
+        # Resolve the SSM instance profile before either path below, so a
+        # resumed provider gets an ARN too — it is not persisted in state.
+        self._resolve_instance_profile()
+
         # Try to load state first
         if self.load_state():
             logger.debug("Loaded state, checking resources")
@@ -657,6 +682,37 @@ class StandardMode(OperatingMode):
             raise ResourceCreationError(
                 f"Failed to initialize standard mode infrastructure: {e}"
             ) from e
+
+    def _resolve_instance_profile(self) -> None:
+        """Resolve ``iam_instance_profile_arn``, creating a profile if asked.
+
+        Warm-pool and one-shot dispatch both go through SSM ``SendCommand``,
+        which only works if the instance carries a profile holding the
+        ``AmazonSSMManagedInstanceCore`` policy. With no ARN, ``_create_instance``
+        attaches no profile, the SSM agent never registers, and every dispatch
+        times out and silently falls back to UserData.
+
+        A failure here is not fatal: dispatch degrades to UserData rather than
+        the whole provider failing to start.
+        """
+        if self.iam_instance_profile_arn or not self.auto_create_instance_profile:
+            return
+
+        try:
+            self.iam_instance_profile_arn = get_or_create_ssm_instance_profile(
+                session=self.session,
+                name_suffix=self.provider_id,
+                auto_create=True,
+            )
+            logger.info(
+                f"Resolved IAM instance profile {self.iam_instance_profile_arn} "
+                "for SSM command dispatch"
+            )
+        except Exception as e:
+            logger.error(
+                f"Failed to create IAM instance profile: {e}. SSM command "
+                "dispatch will not be available."
+            )
 
     def _verify_resources(self) -> None:
         """Verify that the required resources exist.
@@ -932,8 +988,7 @@ class StandardMode(OperatingMode):
                 logger.debug(f"SSM describe_instance_information: {e}")
             time.sleep(10)
         raise OperatingModeError(
-            f"Instance {instance_id} did not become available in SSM "
-            f"within {timeout}s"
+            f"Instance {instance_id} did not become available in SSM within {timeout}s"
         )
 
     def _wait_for_worker_ready(self, instance_id: str, timeout: int = 600) -> None:
@@ -1091,8 +1146,9 @@ class StandardMode(OperatingMode):
         if self.key_name:
             run_args["KeyName"] = self.key_name
 
-        # Attach IAM instance profile when warm pool is enabled (SSM requires it)
-        if self.warm_pool_size > 0 and self.iam_instance_profile_arn:
+        # Attach the IAM instance profile whenever one is available. SSM
+        # SendCommand needs it, and an unused profile costs nothing.
+        if self.iam_instance_profile_arn:
             run_args["IamInstanceProfile"] = {"Arn": self.iam_instance_profile_arn}
 
         # Use spot instances if requested

--- a/parsl_ephemeral_aws/modes/standard.py
+++ b/parsl_ephemeral_aws/modes/standard.py
@@ -857,9 +857,13 @@ class StandardMode(OperatingMode):
                 "tasks_per_node": tasks_per_node,
             }
 
-            if self.warm_pool_size > 0:
-                # Warm pool cold start: wait for SSM then dispatch command
-                resource_data["warm_pool"] = True
+            if self._uses_ssm_dispatch():
+                # Cold start for the SSM paths: wait for SSM, then dispatch. The
+                # UserData carries no command, so this is the only way the job runs.
+                if self.warm_pool_size > 0:
+                    resource_data["warm_pool"] = True
+                else:
+                    resource_data["one_shot"] = True
                 self.resources[instance_id] = resource_data
                 try:
                     self._wait_for_ssm_online(instance_id)
@@ -871,12 +875,17 @@ class StandardMode(OperatingMode):
                     self.resources[instance_id]["status"] = STATUS_RUNNING
                     self.resources[instance_id]["warm_since"] = None
                 except Exception as ssm_err:
+                    # The command is not in the UserData, so there is nothing to
+                    # fall back to — the instance would idle until max_idle_time
+                    # while reporting RUNNING. Terminate it and fail the submit.
                     logger.error(
-                        f"SSM setup failed for warm pool instance {instance_id}: "
-                        f"{ssm_err}. Falling back to UserData execution."
+                        f"SSM dispatch failed for instance {instance_id}: {ssm_err}. "
+                        "Terminating it; the command was never delivered."
                     )
-                    # Remove warm_pool flag so status is tracked via EC2 state
-                    self.resources[instance_id].pop("warm_pool", None)
+                    self._force_terminate(instance_id)
+                    self.resources.pop(instance_id, None)
+                    self.save_state()
+                    raise
             else:
                 self.resources[instance_id] = resource_data
 
@@ -895,7 +904,8 @@ class StandardMode(OperatingMode):
         Parameters
         ----------
         command : str
-            Command to execute (ignored when warm_pool_size > 0; dispatched via SSM)
+            Command to execute. Ignored when the command is dispatched over SSM
+            instead — see :meth:`_uses_ssm_dispatch`.
         job_id : str
             Job ID
 
@@ -909,10 +919,13 @@ class StandardMode(OperatingMode):
         if self.worker_init:
             init_script += f"{self.worker_init}\n"
 
-        if self.warm_pool_size > 0:
-            # Warm pool: UserData only runs worker_init and drops a ready marker.
-            # The actual command is dispatched later via SSM SendCommand so the
-            # instance can be reused across multiple jobs without re-installing.
+        if self._uses_ssm_dispatch():
+            # UserData only runs worker_init and drops a ready marker. The command
+            # is dispatched later via SSM SendCommand, which reports its exit code
+            # — and for the warm pool, lets the instance serve several jobs without
+            # re-running worker_init. No shutdown is appended: the provider
+            # terminates the instance through cleanup_resources() once the command
+            # reaches a terminal state.
             init_script += "mkdir -p /var/run/parsl\n"
             init_script += "touch /var/run/parsl_worker_ready\n"
             return init_script
@@ -935,8 +948,36 @@ class StandardMode(OperatingMode):
         return init_script
 
     # ------------------------------------------------------------------
-    # Warm pool helpers
+    # SSM dispatch helpers (shared by the warm pool and one-shot mode)
     # ------------------------------------------------------------------
+
+    def _uses_ssm_dispatch(self) -> bool:
+        """Whether the command is delivered by SSM rather than embedded in UserData.
+
+        Both the warm pool and one-shot mode need the command's exit code, which
+        UserData cannot report — the instance state is identical whether the
+        command succeeded or failed. SSM ``SendCommand`` reports it, so both
+        launch with a marker-only UserData and dispatch afterwards.
+        """
+        return self.warm_pool_size > 0 or self.one_shot
+
+    def _force_terminate(self, instance_id: str) -> None:
+        """Terminate an instance best-effort, swallowing any error.
+
+        Used on the SSM-dispatch failure path, where the caller is already
+        raising and must not have that exception masked by a cleanup failure.
+        The provider's ``cleanup_stray_instances`` safety net and the
+        ``ProviderId`` tag both cover the case where this does not succeed.
+        """
+        try:
+            self.session.client("ec2").terminate_instances(InstanceIds=[instance_id])
+            logger.info(f"Terminated instance {instance_id} after failed dispatch")
+        except Exception as e:
+            logger.error(
+                f"Could not terminate instance {instance_id} after failed "
+                f"dispatch: {e}. It may still be running — check the "
+                f"ProviderId={self.provider_id} tag."
+            )
 
     def _get_warm_instance(self) -> Optional[str]:
         """Pop the oldest available warm instance from the pool (FIFO).
@@ -1052,6 +1093,15 @@ class StandardMode(OperatingMode):
         -------
         str
             SSM CommandId for later status polling via ``get_command_invocation``.
+
+        Notes
+        -----
+        In one-shot mode a self-shutdown backstop is appended. The provider
+        normally terminates the instance from ``_cleanup_resources()`` once the
+        command reaches a terminal state, but that requires the driver process to
+        still be alive to poll. The backstop bounds the cost of a driver that
+        dies mid-job; it is scheduled after the command's exit status is captured
+        so it cannot mask a non-zero exit.
         """
         ssm = self.session.client("ssm")
         env_setup = (
@@ -1059,10 +1109,19 @@ class StandardMode(OperatingMode):
             f"export PARSL_PROVIDER_ID={self.provider_id}\n"
             "export PARSL_WORKER_ID=$(hostname)\n"
         )
+        script = env_setup + command
+        if self.one_shot:
+            # Detach the shutdown so SSM sees the command finish and reports the
+            # real exit code, then exit with that same code.
+            script += (
+                "\n_parsl_rc=$?\n"
+                "nohup sh -c 'sleep 30; shutdown -h now' >/dev/null 2>&1 &\n"
+                "exit $_parsl_rc\n"
+            )
         response = ssm.send_command(
             InstanceIds=[instance_id],
             DocumentName="AWS-RunShellScript",
-            Parameters={"commands": [env_setup + command]},
+            Parameters={"commands": [script]},
             Comment=f"Parsl job {job_id[:16]}",
         )
         command_id = response["Command"]["CommandId"]
@@ -1134,6 +1193,14 @@ class StandardMode(OperatingMode):
             "MinCount": 1,
             "UserData": init_script,
             "TagSpecifications": [{"ResourceType": "instance", "Tags": tags}],
+            # The init script runs `shutdown -h now` when auto_shutdown or
+            # one_shot is set, and EC2's default for an instance-initiated
+            # shutdown is *stop*, not terminate — leaving a stopped instance
+            # with a billed EBS volume. Worse, EC2_STATUS_MAPPING maps
+            # "stopped" to COMPLETED, so the provider drops the tracking record
+            # and the volume is orphaned as well as billed. DetachedMode already
+            # sets this on all of its launch paths.
+            "InstanceInitiatedShutdownBehavior": "terminate",
         }
 
         # Add network configuration if available
@@ -1201,6 +1268,20 @@ class StandardMode(OperatingMode):
 
         # Extract tags
         tags = run_args.pop("TagSpecifications", [{}])[0].get("Tags", [])
+
+        # RunInstances-only keys that RequestSpotInstances rejects in a
+        # LaunchSpecification. MinCount/MaxCount become InstanceCount, and
+        # InstanceInitiatedShutdownBehavior has no spot equivalent — a spot
+        # instance that shuts itself down is stopped, then reclaimed by EC2
+        # when the one-time request is already closed, so the provider's own
+        # terminate_instances in cleanup_resources() is what reclaims the EBS
+        # volume here.
+        for run_only_key in (
+            "InstanceInitiatedShutdownBehavior",
+            "MinCount",
+            "MaxCount",
+        ):
+            run_args.pop(run_only_key, None)
 
         # Prepare spot request
         spot_args = {
@@ -1397,7 +1478,7 @@ class StandardMode(OperatingMode):
         # Group IDs by resource type / tracking method
         ec2_instances = []
         spot_fleet_blocks = []
-        warm_pool_instances = []  # tracked via SSM command invocation
+        ssm_instances = []  # tracked via SSM command invocation
 
         for resource_id in resource_ids:
             resource = self.resources.get(resource_id)
@@ -1405,8 +1486,11 @@ class StandardMode(OperatingMode):
                 status_map[resource_id] = STATUS_UNKNOWN
                 continue
 
-            if resource.get("warm_pool") and resource.get("ssm_command_id"):
-                warm_pool_instances.append(resource_id)
+            # Any resource carrying an SSM command ID — warm pool or one-shot —
+            # is tracked by the command's own status, which reports the exit code.
+            # EC2 instance state cannot: it looks the same either way.
+            if resource.get("ssm_command_id"):
+                ssm_instances.append(resource_id)
             elif resource.get("type") == RESOURCE_TYPE_EC2:
                 ec2_instances.append(resource_id)
             elif resource.get("type") == RESOURCE_TYPE_SPOT_FLEET:
@@ -1414,10 +1498,10 @@ class StandardMode(OperatingMode):
             else:
                 status_map[resource_id] = STATUS_UNKNOWN
 
-        # --- Warm pool: poll SSM command invocation status ---
-        if warm_pool_instances:
+        # --- SSM dispatch: poll command invocation status for the exit code ---
+        if ssm_instances:
             ssm = self.session.client("ssm")
-            for instance_id in warm_pool_instances:
+            for instance_id in ssm_instances:
                 resource = self.resources[instance_id]
                 command_id = resource["ssm_command_id"]
                 try:
@@ -1442,6 +1526,18 @@ class StandardMode(OperatingMode):
                         status = STATUS_RUNNING
                     status_map[instance_id] = status
                     self.resources[instance_id]["status"] = status
+
+                    # Record the exit code so a FAILED job is diagnosable
+                    # without a second SSM round-trip.
+                    exit_code = response.get("ResponseCode")
+                    if exit_code is not None and exit_code >= 0:
+                        self.resources[instance_id]["exit_code"] = exit_code
+                    if status == STATUS_FAILED:
+                        logger.error(
+                            f"Command on {instance_id} reported {ssm_status} "
+                            f"(exit code {exit_code}): "
+                            f"{response.get('StandardErrorContent', '')[:500]}"
+                        )
                 except ClientError as e:
                     if "InvocationDoesNotExist" in str(e):
                         # Command not yet received by the instance

--- a/parsl_ephemeral_aws/modes/standard.py
+++ b/parsl_ephemeral_aws/modes/standard.py
@@ -34,6 +34,7 @@ from parsl_ephemeral_aws.exceptions import (
     SpotFleetError,
 )
 from parsl_ephemeral_aws.modes.base import OperatingMode
+from parsl_ephemeral_aws.state.base import STATE_KEY_MODE
 from parsl_ephemeral_aws.compute.spot_fleet import SpotFleetManager
 from parsl_ephemeral_aws.compute.spot_interruption import (
     SpotInterruptionMonitor,
@@ -466,7 +467,7 @@ class StandardMode(OperatingMode):
             state["spot_fleet_state"] = spot_fleet_state
 
             try:
-                self.state_store.save_state(state)
+                self.state_store.save_state(STATE_KEY_MODE, state)
                 logger.debug(
                     f"Saved state including SpotFleetManager with {len(self.spot_fleet_manager.blocks)} blocks"
                 )
@@ -475,7 +476,7 @@ class StandardMode(OperatingMode):
         else:
             # Save directly (includes baked AMI fields not in the base class state)
             try:
-                self.state_store.save_state(state)
+                self.state_store.save_state(STATE_KEY_MODE, state)
             except Exception as e:
                 logger.error(f"Failed to save state: {e}")
 
@@ -488,14 +489,10 @@ class StandardMode(OperatingMode):
             True if state was loaded successfully, False otherwise
         """
         try:
-            state = self.state_store.load_state()
+            state = self.state_store.load_state(STATE_KEY_MODE)
             if state and state.get("provider_id") == self.provider_id:
                 self.resources = state.get("resources", {})
-                self.vpc_id = state.get("vpc_id", self.vpc_id)
-                self.subnet_id = state.get("subnet_id", self.subnet_id)
-                self.security_group_id = state.get(
-                    "security_group_id", self.security_group_id
-                )
+                self._restore_network_ids(state)
                 self.initialized = state.get("initialized", False)
                 # Restore warm pool list; fall back to scanning resources for
                 # STATUS_WARM entries in case the key is absent (older state files)

--- a/parsl_ephemeral_aws/provider.py
+++ b/parsl_ephemeral_aws/provider.py
@@ -42,7 +42,7 @@ from parsl_ephemeral_aws.modes.base import OperatingMode
 from parsl_ephemeral_aws.modes.detached import DetachedMode
 from parsl_ephemeral_aws.modes.serverless import ServerlessMode
 from parsl_ephemeral_aws.modes.standard import StandardMode
-from parsl_ephemeral_aws.state.base import StateStore
+from parsl_ephemeral_aws.state.base import STATE_KEY_PROVIDER, StateStore
 from parsl_ephemeral_aws.state.file import FileStateStore
 from parsl_ephemeral_aws.state.parameter_store import ParameterStoreStateStore
 from parsl_ephemeral_aws.state.s3 import S3StateStore
@@ -392,11 +392,22 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
             region=self.region, profile_name=self.profile_name
         )
         self.state_store = self._initialize_state_store()
+
+        # Adopt any provider_id already recorded at this state location, before
+        # the operating mode is built with it.
+        if provider_id is None:
+            self._adopt_persisted_provider_id()
+
         self.operating_mode = self._initialize_operating_mode()
         self.resources: Dict[str, Dict[str, Any]] = {}
         self.job_map: Dict[str, Dict[str, Any]] = {}
         # Re-entrant lock so cancel() → _cleanup_resources() doesn't deadlock
         self._lock = threading.RLock()
+
+        # Restore whatever was persisted at this state location. Safe only now
+        # that the provider and its mode write separate keys (#78) — before
+        # that, loading here would have activated the mutual clobbering.
+        self._load_state()
 
         logger.info(f"Initialized EphemeralAWSProvider in {self.mode_type.value} mode")
 
@@ -468,6 +479,28 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
                 f"{', '.join([c.value for c in ComputeType])}"
             )
 
+    def _parameter_store_prefix(self) -> str:
+        """Return the SSM parameter prefix the state keys hang off.
+
+        Each state key becomes ``{prefix}/{key}``, so two providers sharing a
+        path share a slot — the same semantics as two ``FileStateStore``
+        instances on one file path, which is what makes state hand-off between
+        provider instances possible.
+        """
+        return self.parameter_store_path.rstrip("/")
+
+    def _s3_key_prefix(self) -> str:
+        """Return the S3 key prefix the state keys hang off.
+
+        ``s3_key`` predates state keys and defaults to a file name, which would
+        yield the odd ``ephemeral_aws_state.json/provider``. A ``.json`` suffix
+        is dropped so the prefix reads as the directory it now is.
+        """
+        prefix = self.s3_key.rstrip("/")
+        if prefix.endswith(".json"):
+            prefix = prefix[: -len(".json")]
+        return prefix
+
     def _initialize_state_store(self) -> StateStore:
         """Initialize the state store based on configuration.
 
@@ -481,10 +514,11 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
                 file_path=self.state_file_path, provider_id=self.provider_id
             )
         elif self.state_store_type == StateStoreType.PARAMETER_STORE:
+            # The AWS stores take the provider itself: they read its region and
+            # credentials, and Parameter Store also reads its audit_logger.
             return ParameterStoreStateStore(
-                session=self.session,
-                path=self.parameter_store_path,
-                provider_id=self.provider_id,
+                provider=self,
+                prefix=self._parameter_store_prefix(),
             )
         elif self.state_store_type == StateStoreType.S3:
             if not self.s3_bucket:
@@ -492,10 +526,9 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
                     "s3_bucket is required when using 's3' state store"
                 )
             return S3StateStore(
-                session=self.session,
-                bucket=self.s3_bucket,
-                key=self.s3_key,
-                provider_id=self.provider_id,
+                provider=self,
+                bucket_name=self.s3_bucket,
+                key_prefix=self._s3_key_prefix(),
             )
         else:
             raise ProviderConfigurationError(
@@ -770,7 +803,13 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
         return [cancel_results[jid] for jid in job_ids]
 
     def _save_state(self) -> None:
-        """Save the current state to the state store."""
+        """Save the current state under the provider's own state key.
+
+        The operating mode writes ``STATE_KEY_MODE`` from its own
+        ``save_state()``. Both used to write the whole document to one slot with
+        different key sets, so each overwrite destroyed the other's fields —
+        losing ``job_map`` here and the baked AMI ID there (#78).
+        """
         with self._lock:
             state = {
                 "provider_id": self.provider_id,
@@ -784,15 +823,44 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
             }
 
         try:
-            self.state_store.save_state(state)
+            self.state_store.save_state(STATE_KEY_PROVIDER, state)
             logger.debug("Saved provider state")
         except Exception as e:
             logger.error(f"Failed to save provider state: {e}")
 
-    def _load_state(self) -> None:
-        """Load the state from the state store."""
+    def _adopt_persisted_provider_id(self) -> None:
+        """Take over the provider_id recorded at this state location, if any.
+
+        Nothing about *where* state is stored depends on ``provider_id`` — the
+        file path, SSM prefix, and S3 key prefix are the only scoping. So two
+        providers sharing a path share a slot, which is exactly how state is
+        handed from one provider instance to its successor.
+
+        But ``provider_id`` defaults to a fresh UUID, and both this class and
+        ``OperatingMode.load_state()`` refuse to load a document whose
+        ``provider_id`` differs from their own. A successor therefore rejected
+        the very state it was pointed at, unless the caller happened to pass the
+        original ID back in. Adopting the persisted ID makes restart work with
+        nothing but a shared state location.
+
+        Only called when the caller did not pass ``provider_id`` explicitly; an
+        explicit ID is a deliberate choice and is left alone.
+        """
         try:
-            state = self.state_store.load_state()
+            state = self.state_store.load_state(STATE_KEY_PROVIDER)
+        except Exception as e:
+            logger.debug(f"No provider state to adopt an ID from: {e}")
+            return
+
+        persisted_id = (state or {}).get("provider_id")
+        if persisted_id and persisted_id != self.provider_id:
+            logger.info(f"Adopting persisted provider_id {persisted_id}")
+            self.provider_id = persisted_id
+
+    def _load_state(self) -> None:
+        """Load the state stored under the provider's own state key."""
+        try:
+            state = self.state_store.load_state(STATE_KEY_PROVIDER)
             if state and state.get("provider_id") == self.provider_id:
                 with self._lock:
                     self.resources = state.get("resources", {})
@@ -807,6 +875,24 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
                 logger.info(f"Loaded state with {len(self.resources)} resources")
         except Exception as e:
             logger.error(f"Failed to load provider state: {e}")
+
+    def _delete_state(self) -> None:
+        """Delete the persisted state for both the provider and its mode.
+
+        Both keys go: a mode document that outlives the provider's still
+        describes network IDs and a baked AMI that shutdown has just released.
+        """
+        try:
+            self.state_store.delete_state(STATE_KEY_PROVIDER)
+        except Exception as e:
+            logger.error(f"Failed to delete provider state: {e}")
+
+        delete_mode_state = getattr(self.operating_mode, "delete_state", None)
+        if callable(delete_mode_state):
+            try:
+                delete_mode_state()
+            except Exception as e:
+                logger.error(f"Failed to delete mode state: {e}")
 
     def _cleanup_resources(self) -> None:
         """Clean up resources that are completed or failed.
@@ -1015,8 +1101,11 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
                 self.resources = {}
                 self.job_map = {}
 
-            # Save the empty state
-            self._save_state()
+            # Delete the persisted state rather than saving an empty document.
+            # The resources it describes are gone, so a surviving document only
+            # misleads the next provider that reads the same slot — and for the
+            # AWS backends it also leaves parameters and objects behind.
+            self._delete_state()
 
             logger.info("Provider shutdown complete")
         except Exception as e:

--- a/parsl_ephemeral_aws/provider.py
+++ b/parsl_ephemeral_aws/provider.py
@@ -202,19 +202,31 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
         ready for immediate reuse without re-running worker_init.
         Requires ``auto_create_instance_profile=True`` or
         ``iam_instance_profile_arn`` (SSM SendCommand needs an IAM role).
-        Default is 0 (disabled).
+        Default is 0 (disabled).  ``mode="standard"`` only.
     warm_pool_ttl : int, optional
         Seconds a warm idle instance stays alive before being terminated.
-        Default is 600 (10 minutes).
+        Default is 600 (10 minutes).  ``mode="standard"`` only.
     bake_ami : bool, optional
         When True, run ``worker_init`` on a builder instance during
         ``initialize()``, snapshot it into a custom AMI, and use that AMI for
         all subsequent instance launches.  Eliminates the per-boot install
         overhead for new instances.  Default is False.
+        ``mode="standard"`` only.
     baked_ami_id : str, optional
         Pre-existing baked AMI ID to use instead of baking a new one.  When
         supplied, ``initialize()`` skips the baking step and uses this AMI
-        directly for all instance launches.
+        directly for all instance launches.  ``mode="standard"`` only.
+    one_shot : bool, optional
+        When True, each instance runs a single command over SSM and then
+        terminates, so the command's exit code determines the job status.
+        Default is False.  ``mode="standard"`` only.
+
+    Raises
+    ------
+    ProviderConfigurationError
+        If ``warm_pool_size``, ``warm_pool_ttl``, ``bake_ami``,
+        ``baked_ami_id``, or ``one_shot`` is set on any mode other than
+        ``"standard"`` — no other mode implements them.
     """
 
     @typechecked
@@ -366,6 +378,35 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
             raise ValueError(
                 "vpc_id, subnet_id, and security_group_id are required. "
                 "Pre-provision network resources outside the provider."
+            )
+
+        # Guard: the warm pool, AMI baking, and one-shot dispatch are implemented
+        # only by StandardMode, and _initialize_operating_mode() forwards them
+        # only on that branch. The provider itself, however, acts on them
+        # regardless of mode: it tags resources warm_pool=True, takes the
+        # warm-pool branch in _cleanup_resources(), and reports STATUS_WARM. No
+        # other mode's get_job_status() knows that status, so those instances are
+        # never cleaned up and leak with no error or warning. Refuse the
+        # combination rather than silently half-honouring it.
+        standard_only = [
+            name
+            for name, value, default in (
+                ("warm_pool_size", warm_pool_size, DEFAULT_WARM_POOL_SIZE),
+                ("warm_pool_ttl", warm_pool_ttl, DEFAULT_WARM_POOL_TTL),
+                ("bake_ami", bake_ami, DEFAULT_BAKE_AMI),
+                ("baked_ami_id", baked_ami_id, None),
+                ("one_shot", one_shot, DEFAULT_ONE_SHOT),
+            )
+            if value != default
+        ]
+        if standard_only and self.mode_type != OperatingModeType.STANDARD:
+            raise ProviderConfigurationError(
+                f"{', '.join(standard_only)} "
+                f"{'are' if len(standard_only) > 1 else 'is'} supported only by "
+                f"mode='standard', not mode='{self.mode_type.value}'. "
+                "The option would be silently ignored by the mode while the "
+                "provider still acted on it, leaking instances that no mode "
+                "would clean up."
             )
 
         # Guard: one_shot is incompatible with warm pool (instances are terminated immediately)

--- a/parsl_ephemeral_aws/provider.py
+++ b/parsl_ephemeral_aws/provider.py
@@ -351,8 +351,14 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
         self.one_shot = one_shot
         self.kwargs = kwargs
 
-        # Guard: network IDs are required (provider no longer creates VPC/subnet/SG)
-        if not vpc_id or not subnet_id or not security_group_id:
+        # Guard: network IDs are required (provider no longer creates VPC/subnet/SG).
+        # Lambda-only serverless is the one exception: functions run in the
+        # Lambda-managed VPC, so there is nothing for the caller to pre-provision.
+        lambda_only = (
+            self.mode_type == OperatingModeType.SERVERLESS
+            and self.compute_type == ComputeType.LAMBDA
+        )
+        if not lambda_only and (not vpc_id or not subnet_id or not security_group_id):
             raise ValueError(
                 "vpc_id, subnet_id, and security_group_id are required. "
                 "Pre-provision network resources outside the provider."
@@ -523,6 +529,7 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
             "use_public_ips": self.use_public_ips,
             "custom_ami": self.custom_ami,
             "debug": self.debug,
+            "region": self.region,
         }
 
         if self.mode_type == OperatingModeType.STANDARD:

--- a/parsl_ephemeral_aws/provider.py
+++ b/parsl_ephemeral_aws/provider.py
@@ -535,6 +535,7 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
         if self.mode_type == OperatingModeType.STANDARD:
             return StandardMode(
                 iam_instance_profile_arn=self.iam_instance_profile_arn,
+                auto_create_instance_profile=self.auto_create_instance_profile,
                 warm_pool_size=self.warm_pool_size,
                 warm_pool_ttl=self.warm_pool_ttl,
                 bake_ami=self.bake_ami,

--- a/parsl_ephemeral_aws/provider.py
+++ b/parsl_ephemeral_aws/provider.py
@@ -371,14 +371,19 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
                 "one-shot instances are terminated immediately and cannot be reused"
             )
 
-        # Guard: warm pool uses SSM SendCommand which requires an IAM instance profile
+        # Guard: the warm pool and one-shot mode both dispatch over SSM
+        # SendCommand, which needs the instance to carry an IAM instance profile
+        # holding AmazonSSMManagedInstanceCore. Without one the agent never
+        # registers and the command is never delivered.
+        needs_ssm = warm_pool_size > 0 or one_shot
         if (
-            warm_pool_size > 0
+            needs_ssm
             and not auto_create_instance_profile
             and not iam_instance_profile_arn
         ):
+            trigger = "warm_pool_size > 0" if warm_pool_size > 0 else "one_shot=True"
             raise ValueError(
-                "warm_pool_size > 0 requires either auto_create_instance_profile=True "
+                f"{trigger} requires either auto_create_instance_profile=True "
                 "or iam_instance_profile_arn to be set (SSM SendCommand needs IAM permissions)"
             )
 
@@ -696,9 +701,11 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
             for job_id in job_ids:
                 internal_statuses.setdefault(job_id, "UNKNOWN")
 
-        # Trigger cleanup to process warm-pool transitions and TTL evictions.
+        # Trigger cleanup to process warm-pool transitions and TTL evictions, and
+        # to terminate finished one-shot instances — their command is delivered
+        # over SSM rather than UserData, so nothing on the instance shuts it down.
         # _cleanup_resources() is idempotent and handles its own errors.
-        if self.warm_pool_size > 0:
+        if self.warm_pool_size > 0 or self.one_shot:
             self._cleanup_resources()
 
         return [

--- a/parsl_ephemeral_aws/provider.py
+++ b/parsl_ephemeral_aws/provider.py
@@ -42,7 +42,11 @@ from parsl_ephemeral_aws.modes.base import OperatingMode
 from parsl_ephemeral_aws.modes.detached import DetachedMode
 from parsl_ephemeral_aws.modes.serverless import ServerlessMode
 from parsl_ephemeral_aws.modes.standard import StandardMode
-from parsl_ephemeral_aws.state.base import STATE_KEY_PROVIDER, StateStore
+from parsl_ephemeral_aws.state.base import (
+    STATE_KEY_MODE,
+    STATE_KEY_PROVIDER,
+    StateStore,
+)
 from parsl_ephemeral_aws.state.file import FileStateStore
 from parsl_ephemeral_aws.state.parameter_store import ParameterStoreStateStore
 from parsl_ephemeral_aws.state.s3 import S3StateStore
@@ -845,17 +849,27 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
 
         Only called when the caller did not pass ``provider_id`` explicitly; an
         explicit ID is a deliberate choice and is left alone.
-        """
-        try:
-            state = self.state_store.load_state(STATE_KEY_PROVIDER)
-        except Exception as e:
-            logger.debug(f"No provider state to adopt an ID from: {e}")
-            return
 
-        persisted_id = (state or {}).get("provider_id")
-        if persisted_id and persisted_id != self.provider_id:
-            logger.info(f"Adopting persisted provider_id {persisted_id}")
-            self.provider_id = persisted_id
+        Both keys are consulted. The provider writes its own key only once a job
+        has been submitted, so a provider that constructed and exited without
+        submitting leaves the mode key alone at the location — and that is
+        precisely the state a successor needs, since it holds the network IDs and
+        the baked-AMI ownership flag.
+        """
+        for state_key in (STATE_KEY_PROVIDER, STATE_KEY_MODE):
+            try:
+                state = self.state_store.load_state(state_key)
+            except Exception as e:
+                logger.debug(f"No {state_key} state to adopt an ID from: {e}")
+                continue
+
+            persisted_id = (state or {}).get("provider_id")
+            if persisted_id and persisted_id != self.provider_id:
+                logger.info(
+                    f"Adopting provider_id {persisted_id} from {state_key} state"
+                )
+                self.provider_id = persisted_id
+                return
 
     def _load_state(self) -> None:
         """Load the state stored under the provider's own state key."""

--- a/parsl_ephemeral_aws/state/base.py
+++ b/parsl_ephemeral_aws/state/base.py
@@ -1,6 +1,12 @@
 """
 Base state store interface for the EphemeralAWSProvider.
 
+State documents are addressed by a **state key**. The provider and its operating
+mode persist different, partially overlapping sets of fields, so each owns its
+own key: without that separation the two full-document writes overwrite each
+other and mode-only fields (the baked AMI ID, the warm-pool list) or
+provider-only fields (``job_map``) are silently destroyed (#78).
+
 SPDX-License-Identifier: Apache-2.0
 SPDX-FileCopyrightText: 2025 Scott Friedman and Project Contributors
 """
@@ -9,16 +15,98 @@ import abc
 import logging
 from typing import Any, Dict, Optional
 
+import boto3
+
 
 logger = logging.getLogger(__name__)
+
+#: State key owned by ``EphemeralAWSProvider`` (``resources``, ``job_map``, ...)
+STATE_KEY_PROVIDER = "provider"
+
+#: State key owned by the ``OperatingMode`` (network IDs, baked AMI, warm pool, ...)
+STATE_KEY_MODE = "mode"
+
+
+def resolve_session(provider: Any) -> boto3.Session:
+    """Return a boto3 session for talking to a provider's account.
+
+    Prefers the session the provider already built — it resolved credentials
+    once, correctly, via ``utils.aws.create_session()``. Only when there is none
+    does this fall back to assembling a session from whatever credential
+    attributes the object happens to carry.
+
+    Every attribute is read with ``getattr`` because this is called with either
+    an ``EphemeralAWSProvider`` or an ``OperatingMode``, and neither defines the
+    full set. Reading them directly is what made the AWS state stores raise
+    ``AttributeError`` on construction (#77).
+
+    Parameters
+    ----------
+    provider : Any
+        An ``EphemeralAWSProvider`` or ``OperatingMode``
+
+    Returns
+    -------
+    boto3.Session
+        A session bound to the provider's region
+    """
+    existing = getattr(provider, "session", None)
+    if isinstance(existing, boto3.Session):
+        return existing
+
+    region = getattr(provider, "region", None)
+
+    session_kwargs: Dict[str, Any] = {}
+    access_key = getattr(provider, "aws_access_key_id", None)
+    secret_key = getattr(provider, "aws_secret_access_key", None)
+    if access_key and secret_key:
+        session_kwargs["aws_access_key_id"] = access_key
+        session_kwargs["aws_secret_access_key"] = secret_key
+
+    session_token = getattr(provider, "aws_session_token", None)
+    if session_token:
+        session_kwargs["aws_session_token"] = session_token
+
+    # An OperatingMode has no aws_profile; the provider names the field
+    # profile_name. Accept either.
+    profile = getattr(provider, "aws_profile", None) or getattr(
+        provider, "profile_name", None
+    )
+    if profile:
+        session_kwargs["profile_name"] = profile
+
+    return boto3.Session(region_name=region, **session_kwargs)
+
+
+def get_workflow_id(provider: Any) -> str:
+    """Return a provider's workflow identifier, for tagging stored state.
+
+    ``workflow_id`` is the convention the compute managers use; the provider
+    itself only guarantees ``provider_id``. Falls back to ``"unknown"`` so a
+    missing identifier degrades a tag rather than failing the save.
+    """
+    return str(
+        getattr(provider, "workflow_id", None)
+        or getattr(provider, "provider_id", None)
+        or "unknown"
+    )
+
+
+def get_provider_id(provider: Any) -> str:
+    """Return a provider's own identifier."""
+    return str(
+        getattr(provider, "provider_id", None)
+        or getattr(provider, "workflow_id", None)
+        or "unknown"
+    )
 
 
 class StateStore(abc.ABC):
     """Abstract base class for provider state stores.
 
-    A state store is responsible for persisting and retrieving the provider's state.
-    Different implementations store state in different locations, such as local files,
-    AWS Parameter Store, or S3.
+    A state store persists and retrieves state documents, each addressed by a
+    ``state_key``. Different implementations store them in different places —
+    local files, AWS Parameter Store, or S3.
 
     Attributes
     ----------
@@ -38,13 +126,17 @@ class StateStore(abc.ABC):
         logger.debug(f"Initialized {self.__class__.__name__}")
 
     @abc.abstractmethod
-    def save_state(self, state: Dict[str, Any]) -> None:
-        """Save the provider state.
+    def save_state(self, state_key: str, state_data: Dict[str, Any]) -> None:
+        """Save a state document.
+
+        Writing one key must leave the other keys in the store untouched.
 
         Parameters
         ----------
-        state : Dict[str, Any]
-            Provider state to save
+        state_key : str
+            Key to store the document under
+        state_data : Dict[str, Any]
+            State document to save
 
         Raises
         ------
@@ -54,13 +146,18 @@ class StateStore(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def load_state(self) -> Optional[Dict[str, Any]]:
-        """Load the provider state.
+    def load_state(self, state_key: str) -> Optional[Dict[str, Any]]:
+        """Load a state document.
+
+        Parameters
+        ----------
+        state_key : str
+            Key to load the document from
 
         Returns
         -------
         Optional[Dict[str, Any]]
-            Provider state if it exists, None otherwise
+            State document if it exists, None otherwise
 
         Raises
         ------
@@ -70,8 +167,15 @@ class StateStore(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def delete_state(self) -> None:
-        """Delete the provider state.
+    def delete_state(self, state_key: str) -> None:
+        """Delete a state document.
+
+        Deleting a key that does not exist is not an error.
+
+        Parameters
+        ----------
+        state_key : str
+            Key to delete the document for
 
         Raises
         ------

--- a/parsl_ephemeral_aws/state/file.py
+++ b/parsl_ephemeral_aws/state/file.py
@@ -22,16 +22,40 @@ from parsl_ephemeral_aws.exceptions import (
     StateSerializationError,
     StateStoreError,
 )
-from parsl_ephemeral_aws.state.base import StateStore
+from parsl_ephemeral_aws.state.base import (
+    STATE_KEY_MODE,
+    STATE_KEY_PROVIDER,
+    StateStore,
+)
 
 
 logger = logging.getLogger(__name__)
+
+#: Top-level key holding the per-state-key sub-documents. Its presence is what
+#: distinguishes a keyed document from a flat pre-v0.7.0 one.
+_DOCUMENTS_KEY = "_states"
+
+#: Written alongside the sub-documents so a reader can tell which layout it has
+#: without relying on key-name heuristics.
+_VERSION_KEY = "_version"
+_VERSION = 2
 
 
 class FileStateStore(StateStore):
     """File-based state store implementation.
 
-    Stores provider state in a local JSON file.
+    Stores state in a single local JSON file. Each ``state_key`` is a top-level
+    sub-document under ``_states``, so writing one key preserves the others:
+
+    .. code-block:: json
+
+        {"_version": 2, "_states": {"provider": {...}, "mode": {...}}}
+
+    Files written before v0.7.0 hold a single flat document with no ``_states``
+    wrapper. Those are read back under every key — the provider and the mode each
+    take the fields they recognise — and the first write upgrades the file to the
+    keyed layout, seeding both keys from the flat document so the writer's
+    counterpart can still find its fields afterwards.
 
     Attributes
     ----------
@@ -55,80 +79,33 @@ class FileStateStore(StateStore):
         self.file_path = file_path
         logger.debug(f"Initialized FileStateStore with file_path={file_path}")
 
-    def save_state(self, state: Dict[str, Any]) -> None:
-        """Save the provider state to a file.
-
-        Parameters
-        ----------
-        state : Dict[str, Any]
-            Provider state to save
-
-        Raises
-        ------
-        StateSerializationError
-            If serializing state fails
-        StateStoreError
-            If saving state fails
-        """
-        try:
-            # Create directory if it doesn't exist
-            os.makedirs(os.path.dirname(os.path.abspath(self.file_path)), exist_ok=True)
-
-            with open(self.file_path, "w") as f:
-                if _HAS_FCNTL:
-                    fcntl.flock(f, fcntl.LOCK_EX)
-                try:
-                    json.dump(state, f, indent=2)
-                finally:
-                    if _HAS_FCNTL:
-                        fcntl.flock(f, fcntl.LOCK_UN)
-
-            logger.debug(f"Saved state to {self.file_path}")
-        except json.JSONDecodeError as e:
-            logger.error(f"Failed to serialize state: {e}")
-            raise StateSerializationError(f"Failed to serialize state: {e}") from e
-        except OSError as e:
-            logger.error(f"Failed to write state file {self.file_path}: {e}")
-            raise StateStoreError(
-                f"Failed to write state file {self.file_path}: {e}"
-            ) from e
-        except Exception as e:
-            logger.error(f"Unexpected error saving state to {self.file_path}: {e}")
-            raise StateStoreError(
-                f"Unexpected error saving state to {self.file_path}: {e}"
-            ) from e
-
-    def load_state(self) -> Optional[Dict[str, Any]]:
-        """Load the provider state from a file.
+    def _read_document(self) -> Dict[str, Any]:
+        """Read and parse the whole state file.
 
         Returns
         -------
-        Optional[Dict[str, Any]]
-            Provider state if the file exists, None otherwise
+        Dict[str, Any]
+            The parsed file contents, or an empty dict if the file is absent.
 
         Raises
         ------
         StateDeserializationError
-            If deserializing state fails
+            If the file exists but is not valid JSON
         StateStoreError
-            If loading state fails
+            If the file cannot be read
         """
         if not os.path.exists(self.file_path):
-            logger.debug(f"State file {self.file_path} does not exist")
-            return None
+            return {}
 
         try:
             with open(self.file_path, "r") as f:
                 if _HAS_FCNTL:
                     fcntl.flock(f, fcntl.LOCK_SH)
                 try:
-                    state = json.load(f)
+                    document = json.load(f)
                 finally:
                     if _HAS_FCNTL:
                         fcntl.flock(f, fcntl.LOCK_UN)
-
-            logger.debug(f"Loaded state from {self.file_path}")
-            return state
         except json.JSONDecodeError as e:
             logger.error(f"Failed to deserialize state from {self.file_path}: {e}")
             raise StateDeserializationError(
@@ -145,8 +122,153 @@ class FileStateStore(StateStore):
                 f"Unexpected error loading state from {self.file_path}: {e}"
             ) from e
 
-    def delete_state(self) -> None:
-        """Delete the provider state file.
+        if not isinstance(document, dict):
+            raise StateDeserializationError(
+                f"State file {self.file_path} does not contain a JSON object"
+            )
+        return document
+
+    def _write_document(self, document: Dict[str, Any]) -> None:
+        """Serialize and write the whole state file.
+
+        Raises
+        ------
+        StateSerializationError
+            If the document cannot be serialized
+        StateStoreError
+            If the file cannot be written
+        """
+        try:
+            # Serialize before truncating the file, so a document that cannot be
+            # encoded leaves the previous state intact rather than emptying it.
+            payload = json.dumps(document, indent=2)
+        except (TypeError, ValueError) as e:
+            logger.error(f"Failed to serialize state: {e}")
+            raise StateSerializationError(f"Failed to serialize state: {e}") from e
+
+        try:
+            directory = os.path.dirname(os.path.abspath(self.file_path))
+            os.makedirs(directory, exist_ok=True)
+
+            with open(self.file_path, "w") as f:
+                if _HAS_FCNTL:
+                    fcntl.flock(f, fcntl.LOCK_EX)
+                try:
+                    f.write(payload)
+                finally:
+                    if _HAS_FCNTL:
+                        fcntl.flock(f, fcntl.LOCK_UN)
+        except OSError as e:
+            logger.error(f"Failed to write state file {self.file_path}: {e}")
+            raise StateStoreError(
+                f"Failed to write state file {self.file_path}: {e}"
+            ) from e
+        except Exception as e:
+            logger.error(f"Unexpected error saving state to {self.file_path}: {e}")
+            raise StateStoreError(
+                f"Unexpected error saving state to {self.file_path}: {e}"
+            ) from e
+
+    def save_state(self, state_key: str, state_data: Dict[str, Any]) -> None:
+        """Save a state document under *state_key*.
+
+        Read-modify-write: the other keys in the file are preserved.
+
+        Parameters
+        ----------
+        state_key : str
+            Key to store the document under
+        state_data : Dict[str, Any]
+            State document to save
+
+        Raises
+        ------
+        StateSerializationError
+            If serializing state fails
+        StateStoreError
+            If saving state fails
+        """
+        try:
+            existing = self._read_document()
+        except StateDeserializationError:
+            # An unreadable file must not block the write; the current state is
+            # more valuable than a corrupt document we cannot merge into.
+            logger.warning(
+                f"State file {self.file_path} is not readable JSON; overwriting it"
+            )
+            existing = {}
+
+        documents = existing.get(_DOCUMENTS_KEY)
+        if not isinstance(documents, dict):
+            # Upgrading a flat pre-v0.7.0 document. Seed both well-known keys
+            # from it: whichever of the provider and the mode writes first would
+            # otherwise erase the fields the other has not read yet.
+            documents = {}
+            if existing:
+                documents[STATE_KEY_PROVIDER] = existing
+                documents[STATE_KEY_MODE] = existing
+                logger.info(
+                    f"Upgrading {self.file_path} to keyed state; the previous "
+                    "document is retained under both the provider and mode keys"
+                )
+
+        documents[state_key] = state_data
+        self._write_document({_VERSION_KEY: _VERSION, _DOCUMENTS_KEY: documents})
+
+        logger.debug(f"Saved state key '{state_key}' to {self.file_path}")
+
+    def load_state(self, state_key: str) -> Optional[Dict[str, Any]]:
+        """Load the state document stored under *state_key*.
+
+        Parameters
+        ----------
+        state_key : str
+            Key to load the document from
+
+        Returns
+        -------
+        Optional[Dict[str, Any]]
+            State document if present, None otherwise. A flat pre-v0.7.0 file is
+            returned whole for any key.
+
+        Raises
+        ------
+        StateDeserializationError
+            If deserializing state fails
+        StateStoreError
+            If loading state fails
+        """
+        document = self._read_document()
+        if not document:
+            logger.debug(f"State file {self.file_path} does not exist or is empty")
+            return None
+
+        documents = document.get(_DOCUMENTS_KEY)
+        if isinstance(documents, dict):
+            state = documents.get(state_key)
+            if state is None:
+                logger.debug(f"State key '{state_key}' not present in {self.file_path}")
+                return None
+            logger.debug(f"Loaded state key '{state_key}' from {self.file_path}")
+            return state
+
+        # Flat pre-v0.7.0 document: the provider and the mode wrote to the same
+        # slot, so hand it to whichever asks and let each pick out its own fields.
+        logger.debug(
+            f"State file {self.file_path} predates state keys; "
+            f"returning the flat document for '{state_key}'"
+        )
+        return document
+
+    def delete_state(self, state_key: str) -> None:
+        """Delete the state document stored under *state_key*.
+
+        The file itself is removed once the last key is gone.
+
+        Parameters
+        ----------
+        state_key : str
+            Key to delete the document for
 
         Raises
         ------
@@ -160,8 +282,31 @@ class FileStateStore(StateStore):
             return
 
         try:
+            existing = self._read_document()
+        except StateDeserializationError:
+            # Unparseable: there is no sub-document to remove selectively, so
+            # dropping the file is the only meaningful interpretation.
+            existing = {}
+
+        documents = existing.get(_DOCUMENTS_KEY)
+        if isinstance(documents, dict):
+            documents.pop(state_key, None)
+            if documents:
+                self._write_document(
+                    {_VERSION_KEY: _VERSION, _DOCUMENTS_KEY: documents}
+                )
+                logger.debug(f"Deleted state key '{state_key}' from {self.file_path}")
+                return
+
+        self._remove_file()
+
+    def _remove_file(self) -> None:
+        """Delete the state file, tolerating its absence."""
+        try:
             os.remove(self.file_path)
             logger.debug(f"Deleted state file {self.file_path}")
+        except FileNotFoundError:
+            logger.debug(f"State file {self.file_path} already gone")
         except OSError as e:
             logger.error(f"Failed to delete state file {self.file_path}: {e}")
             raise StateStoreError(

--- a/parsl_ephemeral_aws/state/parameter_store.py
+++ b/parsl_ephemeral_aws/state/parameter_store.py
@@ -8,11 +8,10 @@ import json
 import logging
 from typing import Dict, Any, Optional
 
-import boto3
 from botocore.exceptions import ClientError
 
 from ..exceptions import StateError
-from .base import StateStore
+from .base import StateStore, get_provider_id, get_workflow_id, resolve_session
 from ..security import SecurityEventType, SecurityEventSeverity, SecurityEvent
 
 
@@ -39,27 +38,13 @@ class ParameterStoreState(StateStore):
         use_secure_string : bool, optional
             Whether to use SecureString parameter type, by default False
         """
+        super().__init__(get_provider_id(provider))
         self.provider = provider
         self.prefix = prefix.rstrip("/")
         self.use_secure_string = use_secure_string
+        self.workflow_id = get_workflow_id(provider)
 
-        # Initialize AWS session
-        session_kwargs = {}
-        if self.provider.aws_access_key_id and self.provider.aws_secret_access_key:
-            session_kwargs["aws_access_key_id"] = self.provider.aws_access_key_id
-            session_kwargs[
-                "aws_secret_access_key"
-            ] = self.provider.aws_secret_access_key
-
-        if self.provider.aws_session_token:
-            session_kwargs["aws_session_token"] = self.provider.aws_session_token
-
-        if self.provider.aws_profile:
-            session_kwargs["profile_name"] = self.provider.aws_profile
-
-        self.aws_session = boto3.Session(
-            region_name=self.provider.region, **session_kwargs
-        )
+        self.aws_session = resolve_session(provider)
 
         # Initialize clients
         self.ssm_client = self.aws_session.client("ssm")
@@ -134,7 +119,7 @@ class ParameterStoreState(StateStore):
                         Tags=[
                             {
                                 "Key": "ParslWorkflowId",
-                                "Value": self.provider.workflow_id,
+                                "Value": self.workflow_id,
                             }
                         ],
                     )
@@ -271,7 +256,7 @@ class ParameterStoreState(StateStore):
                 ParameterFilters=[
                     {
                         "Key": "tag:ParslWorkflowId",
-                        "Values": [self.provider.workflow_id],
+                        "Values": [self.workflow_id],
                     }
                 ]
             )

--- a/parsl_ephemeral_aws/state/s3.py
+++ b/parsl_ephemeral_aws/state/s3.py
@@ -8,11 +8,10 @@ import json
 import logging
 from typing import Dict, Any, Optional
 
-import boto3
 from botocore.exceptions import ClientError
 
 from ..exceptions import StateError
-from .base import StateStore
+from .base import StateStore, get_provider_id, get_workflow_id, resolve_session
 
 
 logger = logging.getLogger(__name__)
@@ -41,28 +40,15 @@ class S3State(StateStore):
         create_bucket_if_not_exists : bool, optional
             Whether to create the bucket if it doesn't exist, by default False
         """
+        super().__init__(get_provider_id(provider))
         self.provider = provider
         self.bucket_name = bucket_name
         self.key_prefix = key_prefix.rstrip("/")
         self.create_bucket_if_not_exists = create_bucket_if_not_exists
+        self.workflow_id = get_workflow_id(provider)
+        self.region = getattr(provider, "region", None)
 
-        # Initialize AWS session
-        session_kwargs = {}
-        if self.provider.aws_access_key_id and self.provider.aws_secret_access_key:
-            session_kwargs["aws_access_key_id"] = self.provider.aws_access_key_id
-            session_kwargs[
-                "aws_secret_access_key"
-            ] = self.provider.aws_secret_access_key
-
-        if self.provider.aws_session_token:
-            session_kwargs["aws_session_token"] = self.provider.aws_session_token
-
-        if self.provider.aws_profile:
-            session_kwargs["profile_name"] = self.provider.aws_profile
-
-        self.aws_session = boto3.Session(
-            region_name=self.provider.region, **session_kwargs
-        )
+        self.aws_session = resolve_session(provider)
 
         # Initialize clients
         self.s3_client = self.aws_session.client("s3")
@@ -83,16 +69,16 @@ class S3State(StateStore):
             if error_code == "404":
                 # Bucket doesn't exist, create it
                 try:
-                    # Create bucket in the current region
-                    if self.provider.region == "us-east-1":
-                        # us-east-1 requires special handling (no LocationConstraint)
+                    # Create bucket in the current region. us-east-1 rejects a
+                    # LocationConstraint; so does an unset region, where the
+                    # session's own default applies.
+                    region = self.region or self.aws_session.region_name
+                    if not region or region == "us-east-1":
                         self.s3_client.create_bucket(Bucket=self.bucket_name)
                     else:
                         self.s3_client.create_bucket(
                             Bucket=self.bucket_name,
-                            CreateBucketConfiguration={
-                                "LocationConstraint": self.provider.region
-                            },
+                            CreateBucketConfiguration={"LocationConstraint": region},
                         )
 
                     # Block all public access (replaces deprecated ACL="private")
@@ -114,7 +100,7 @@ class S3State(StateStore):
                                 {"Key": "ParslManagedBucket", "Value": "true"},
                                 {
                                     "Key": "ParslWorkflowId",
-                                    "Value": self.provider.workflow_id,
+                                    "Value": self.workflow_id,
                                 },
                             ]
                         },
@@ -169,7 +155,7 @@ class S3State(StateStore):
                 Key=object_key,
                 Body=state_json,
                 ContentType="application/json",
-                Metadata={"ParslWorkflowId": self.provider.workflow_id},
+                Metadata={"ParslWorkflowId": self.workflow_id},
             )
 
             logger.debug(f"Saved state to S3: {object_key}")
@@ -303,7 +289,7 @@ class S3State(StateStore):
         """Clean up all states for the current workflow."""
         try:
             # List objects with the workflow prefix
-            workflow_prefix = f"{self.key_prefix}/{self.provider.workflow_id}"
+            workflow_prefix = f"{self.key_prefix}/{self.workflow_id}"
 
             objects_to_delete = []
 

--- a/parsl_ephemeral_aws/utils/aws.py
+++ b/parsl_ephemeral_aws/utils/aws.py
@@ -815,6 +815,7 @@ def get_or_create_ssm_instance_profile(
         arn: str = response["InstanceProfile"]["Arn"]
         _attach_role_to_instance_profile(iam, profile_name, role_name)
         logger.info(f"Created IAM instance profile: {profile_name}")
+        _wait_for_instance_profile(session, arn)
         return arn
     except ClientError as e:
         if e.response["Error"]["Code"] == "EntityAlreadyExists":
@@ -822,10 +823,68 @@ def get_or_create_ssm_instance_profile(
             response = iam.get_instance_profile(InstanceProfileName=profile_name)
             raced_arn: str = response["InstanceProfile"]["Arn"]
             _attach_role_to_instance_profile(iam, profile_name, role_name)
+            _wait_for_instance_profile(session, raced_arn)
             return raced_arn
         raise ResourceCreationError(
             f"Failed to create instance profile {profile_name}: {e}"
         ) from e
+
+
+#: How long to wait for a new instance profile to become visible to EC2.
+_PROFILE_PROPAGATION_TIMEOUT_S = 60
+_PROFILE_PROPAGATION_DELAY_S = 2
+
+
+def _wait_for_instance_profile(
+    session: boto3.Session,
+    profile_arn: str,
+    timeout: int = _PROFILE_PROPAGATION_TIMEOUT_S,
+) -> None:
+    """Block until EC2 will accept *profile_arn*, or give up after *timeout*.
+
+    IAM is eventually consistent with respect to EC2: a profile that
+    ``create_instance_profile`` has already returned an ARN for is rejected by
+    ``RunInstances`` with ``InvalidParameterValue: Invalid IAM Instance Profile
+    ARN`` for the first several seconds (measured at ~10s). A dry-run
+    ``RunInstances`` is the only check that exercises the path that matters —
+    ``get_instance_profile`` succeeds immediately and so proves nothing.
+
+    A timeout is logged rather than raised: the launch that follows will report
+    the real error, and failing here would turn a slow propagation into a hard
+    error on a profile that is about to work.
+    """
+    ec2 = session.client("ec2")
+    image_id = get_default_ami(session.region_name or DEFAULT_REGION)
+    deadline = time.time() + timeout
+
+    while time.time() < deadline:
+        try:
+            ec2.run_instances(
+                ImageId=image_id,
+                MinCount=1,
+                MaxCount=1,
+                InstanceType="t3.micro",
+                IamInstanceProfile={"Arn": profile_arn},
+                DryRun=True,
+            )
+            return
+        except ClientError as e:
+            code = e.response["Error"]["Code"]
+            if code == "DryRunOperation":
+                # EC2 validated everything including the profile.
+                logger.debug(f"Instance profile {profile_arn} is visible to EC2")
+                return
+            if code != "InvalidParameterValue":
+                # Anything else (an unusable AMI here, say) is not what this
+                # check is for; let the real launch report it.
+                logger.debug(f"Instance profile propagation check skipped: {e}")
+                return
+            time.sleep(_PROFILE_PROPAGATION_DELAY_S)
+
+    logger.warning(
+        f"Instance profile {profile_arn} still not visible to EC2 after "
+        f"{timeout}s; launching anyway"
+    )
 
 
 def _attach_role_to_instance_profile(

--- a/parsl_ephemeral_aws/utils/aws.py
+++ b/parsl_ephemeral_aws/utils/aws.py
@@ -408,8 +408,7 @@ def delete_resource(
                         logger.debug(f"Deleting NAT gateway {ngw['NatGatewayId']}")
                     except ClientError as e:
                         logger.warning(
-                            f"Could not delete NAT gateway "
-                            f"{ngw['NatGatewayId']}: {e}"
+                            f"Could not delete NAT gateway {ngw['NatGatewayId']}: {e}"
                         )
                 # Poll until all NAT gateways have finished deleting (max ~2 min).
                 # Only enter the loop if we actually submitted deletion requests.
@@ -445,8 +444,7 @@ def delete_resource(
                             logger.debug(f"Deleted ENI {eni['NetworkInterfaceId']}")
                         except ClientError as e:
                             logger.warning(
-                                f"Could not delete ENI "
-                                f"{eni['NetworkInterfaceId']}: {e}"
+                                f"Could not delete ENI {eni['NetworkInterfaceId']}: {e}"
                             )
 
                 # Get all subnets in the VPC
@@ -507,8 +505,7 @@ def delete_resource(
                         logger.debug(f"Deleted route table {rt['RouteTableId']}")
                     except ClientError as e:
                         logger.warning(
-                            f"Could not delete route table "
-                            f"{rt['RouteTableId']}: {e}"
+                            f"Could not delete route table {rt['RouteTableId']}: {e}"
                         )
 
             # Delete the VPC
@@ -726,4 +723,130 @@ def get_or_create_iam_role(
                 ) from inner_e
         raise ResourceCreationError(
             f"Failed to create IAM role {role_name}: {e}"
+        ) from e
+
+
+def get_or_create_ssm_instance_profile(
+    session: boto3.Session,
+    name_suffix: str,
+    iam_instance_profile_arn: Optional[str] = None,
+    auto_create: bool = False,
+) -> Optional[str]:
+    """Resolve an IAM instance profile ARN granting SSM access, or None.
+
+    SSM ``SendCommand`` — used by warm-pool and one-shot dispatch — needs the
+    instance to carry a profile with the ``AmazonSSMManagedInstanceCore`` policy.
+    Without it the SSM agent never registers and every command dispatch times out.
+
+    Resolution order:
+
+    1. ``iam_instance_profile_arn`` if supplied → used directly.
+    2. ``auto_create`` → get-or-create a profile holding
+       ``AmazonSSMManagedInstanceCore``.
+    3. Otherwise → ``None``; the caller launches instances without a profile.
+
+    Both the create and the attach steps are idempotent, so concurrent callers
+    sharing a ``name_suffix`` converge on the same profile.
+
+    Parameters
+    ----------
+    session : boto3.Session
+        AWS session used to build the IAM client.
+    name_suffix : str
+        Discriminator appended to the role and profile names — normally the
+        provider ID, so resources are traceable back to their provider.
+    iam_instance_profile_arn : Optional[str], optional
+        Pre-existing profile ARN to use verbatim, by default None.
+    auto_create : bool, optional
+        Whether to create a profile when none was supplied, by default False.
+
+    Returns
+    -------
+    Optional[str]
+        ARN of the resolved instance profile, or None when neither an explicit
+        ARN was given nor auto-creation requested.
+
+    Raises
+    ------
+    ResourceCreationError
+        If the profile cannot be created or retrieved.
+    """
+    if iam_instance_profile_arn:
+        return iam_instance_profile_arn
+
+    if not auto_create:
+        return None
+
+    iam = session.client("iam")
+    role_name = f"parsl-ephemeral-ssm-role-{name_suffix}"
+    profile_name = f"parsl-ephemeral-ssm-profile-{name_suffix}"
+
+    get_or_create_iam_role(
+        iam_client=iam,
+        role_name=role_name,
+        assume_role_policy={
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {"Service": "ec2.amazonaws.com"},
+                    "Action": "sts:AssumeRole",
+                }
+            ],
+        },
+        policy_arns=["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"],
+        description=f"SSM instance role for Parsl ({name_suffix})",
+    )
+
+    # Ensure the instance profile exists and has the role attached
+    try:
+        response = iam.get_instance_profile(InstanceProfileName=profile_name)
+        existing_arn: str = response["InstanceProfile"]["Arn"]
+        _attach_role_to_instance_profile(iam, profile_name, role_name)
+        return existing_arn
+    except ClientError as e:
+        if e.response["Error"]["Code"] not in ("NoSuchEntity", "NoSuchEntityException"):
+            raise ResourceCreationError(
+                f"Failed to check instance profile {profile_name}: {e}"
+            ) from e
+
+    try:
+        response = iam.create_instance_profile(InstanceProfileName=profile_name)
+        arn: str = response["InstanceProfile"]["Arn"]
+        _attach_role_to_instance_profile(iam, profile_name, role_name)
+        logger.info(f"Created IAM instance profile: {profile_name}")
+        return arn
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "EntityAlreadyExists":
+            # Race condition — another caller created it; fetch the ARN
+            response = iam.get_instance_profile(InstanceProfileName=profile_name)
+            raced_arn: str = response["InstanceProfile"]["Arn"]
+            _attach_role_to_instance_profile(iam, profile_name, role_name)
+            return raced_arn
+        raise ResourceCreationError(
+            f"Failed to create instance profile {profile_name}: {e}"
+        ) from e
+
+
+def _attach_role_to_instance_profile(
+    iam_client: Any, profile_name: str, role_name: str
+) -> None:
+    """Attach a role to an instance profile, tolerating an existing attachment.
+
+    A profile holds at most one role, so re-attaching the same role is a no-op
+    that AWS reports as ``LimitExceeded``. Any other role already present is
+    left alone: the caller supplied the profile name, so its contents are
+    theirs to manage.
+    """
+    try:
+        iam_client.add_role_to_instance_profile(
+            InstanceProfileName=profile_name, RoleName=role_name
+        )
+    except ClientError as e:
+        code = e.response["Error"]["Code"]
+        if code in ("LimitExceeded", "LimitExceededException"):
+            logger.debug(f"Instance profile {profile_name} already holds a role")
+            return
+        raise ResourceCreationError(
+            f"Failed to attach role {role_name} to profile {profile_name}: {e}"
         ) from e

--- a/tests/aws/conftest.py
+++ b/tests/aws/conftest.py
@@ -13,6 +13,7 @@ import logging
 import os
 import uuid
 
+import boto3
 import pytest
 
 from parsl_ephemeral_aws import GlobusComputeProvider
@@ -45,7 +46,19 @@ def aws_region() -> str:
 
 @pytest.fixture(scope="session")
 def network_ids():
-    """Return pre-provisioned VPC/subnet/SG IDs, or skip if unset."""
+    """Return pre-provisioned VPC/subnet/SG IDs, or skip if unset.
+
+    The IDs are checked against ``AWS_TEST_REGION`` before any test runs. IDs
+    belonging to another region are not an error until a launch is attempted,
+    where they surface minutes in as ``InvalidSubnetID.NotFound`` from deep
+    inside ``RunInstances`` — after real instances have been billed.
+    ``AWS_TEST_REGION`` defaults to ``us-west-2``, so supplying the IDs alone is
+    easy to get wrong.
+
+    The session is built here rather than taken from the ``aws_session``
+    fixture, which is function-scoped and cannot be consumed by a session-scoped
+    fixture.
+    """
     missing = [
         name
         for name, val in [
@@ -57,6 +70,21 @@ def network_ids():
     ]
     if missing:
         pytest.skip(f"Set {', '.join(missing)} to run E2E tests")
+
+    try:
+        ec2 = boto3.Session(
+            profile_name=AWS_TEST_PROFILE, region_name=AWS_TEST_REGION
+        ).client("ec2")
+        ec2.describe_subnets(SubnetIds=[AWS_TEST_SUBNET_ID])
+        ec2.describe_security_groups(GroupIds=[AWS_TEST_SG_ID])
+    except Exception as exc:
+        pytest.fail(
+            f"AWS_TEST_SUBNET_ID={AWS_TEST_SUBNET_ID} / "
+            f"AWS_TEST_SG_ID={AWS_TEST_SG_ID} are not usable in region "
+            f"{AWS_TEST_REGION}: {exc}\n"
+            "Set AWS_TEST_REGION to the region holding these resources."
+        )
+
     return dict(
         vpc_id=AWS_TEST_VPC_ID,
         subnet_id=AWS_TEST_SUBNET_ID,

--- a/tests/aws/test_detached_mode_e2e.py
+++ b/tests/aws/test_detached_mode_e2e.py
@@ -19,6 +19,8 @@ import time
 import pytest
 from botocore.exceptions import ClientError
 
+from parsl.jobs.states import JobState
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -30,13 +32,18 @@ MAX_WAIT_S = 600  # 10 minutes
 
 
 def _poll_until(
-    provider, job_id: str, target_status: str, timeout: int = MAX_WAIT_S
+    provider, job_id: str, target_state: JobState, timeout: int = MAX_WAIT_S
 ) -> bool:
-    """Poll provider.status() until the job reaches *target_status* or timeout."""
+    """Poll provider.status() until the job reaches *target_state* or timeout.
+
+    ``status()`` returns ``List[JobStatus]``, not the ``List[Dict[str, str]]``
+    this suite was written against, and ``JobStatus`` is not subscriptable —
+    see #102.
+    """
     deadline = time.time() + timeout
     while time.time() < deadline:
         result = provider.status([job_id])
-        if result and result[0]["status"] == target_status:
+        if result and result[0].state == target_state:
             return True
         time.sleep(POLL_INTERVAL_S)
     return False
@@ -185,11 +192,11 @@ class TestDetachedModeComputeLifecycle:
         try:
             result = detached_provider.status([job_id])
             assert result, "status() returned an empty list"
-            status = result[0]["status"]
-            assert status in (
-                "PENDING",
-                "RUNNING",
-            ), f"Expected PENDING or RUNNING immediately after submit, got {status}"
+            state = result[0].state
+            assert state in (
+                JobState.PENDING,
+                JobState.RUNNING,
+            ), f"Expected PENDING or RUNNING immediately after submit, got {state}"
         finally:
             try:
                 detached_provider.cancel([job_id])
@@ -200,7 +207,7 @@ class TestDetachedModeComputeLifecycle:
         """A short ``echo`` command reaches COMPLETED within the timeout."""
         job_id = detached_provider.submit("echo hello-from-detached", tasks_per_node=1)
 
-        reached = _poll_until(detached_provider, job_id, "COMPLETED")
+        reached = _poll_until(detached_provider, job_id, JobState.COMPLETED)
         assert reached, f"Job {job_id} did not reach COMPLETED within {MAX_WAIT_S}s"
 
     def test_cancel_removes_job(self, detached_provider):
@@ -212,7 +219,7 @@ class TestDetachedModeComputeLifecycle:
         started = False
         while time.time() < deadline:
             result = detached_provider.status([job_id])
-            if result and result[0]["status"] in ("PENDING", "RUNNING"):
+            if result and result[0].state in (JobState.PENDING, JobState.RUNNING):
                 started = True
                 break
             time.sleep(POLL_INTERVAL_S)
@@ -223,10 +230,10 @@ class TestDetachedModeComputeLifecycle:
         # After cancel, the job should not be RUNNING
         result = detached_provider.status([job_id])
         if result:
-            status = result[0]["status"]
-            assert status not in (
-                "RUNNING",
-            ), f"Job {job_id} is still RUNNING after cancel(); status={status}"
+            state = result[0].state
+            assert (
+                state != JobState.RUNNING
+            ), f"Job {job_id} is still RUNNING after cancel(); state={state}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/aws/test_globus_compute_e2e.py
+++ b/tests/aws/test_globus_compute_e2e.py
@@ -41,6 +41,8 @@ from typing import Optional
 
 import pytest
 
+from parsl.jobs.states import JobState
+
 from parsl_ephemeral_aws import GlobusComputeProvider
 
 logger = logging.getLogger(__name__)
@@ -606,7 +608,7 @@ class TestGlobusComputeEC2Cleanup:
         deadline = time.time() + 120
         while time.time() < deadline:
             result = provider.status([job_id])
-            if result and result[0]["status"] in ("RUNNING", "COMPLETED"):
+            if result and result[0].state in (JobState.RUNNING, JobState.COMPLETED):
                 break
             time.sleep(POLL_INTERVAL_S)
 

--- a/tests/aws/test_one_shot_e2e.py
+++ b/tests/aws/test_one_shot_e2e.py
@@ -1,0 +1,284 @@
+"""Real-AWS end-to-end tests for one-shot mode (issues #66, #76).
+
+One-shot mode dispatches a single command per instance over SSM ``SendCommand``
+and terminates the instance afterwards. Two properties matter and neither can be
+verified with mocks:
+
+* a non-zero exit code must surface as ``FAILED``. Under the original UserData
+  design the instance state was identical for success and failure, so every job
+  reported COMPLETED.
+* the instance must reach ``terminated``, not ``stopped``. EC2 defaults an
+  instance-initiated shutdown to *stop*, which leaves a billed EBS volume — and
+  because ``EC2_STATUS_MAPPING`` maps ``stopped`` to COMPLETED, the provider
+  drops the tracking record and the volume is orphaned as well as billed.
+
+Run with::
+
+    AWS_TEST_VPC_ID=vpc-xxx AWS_TEST_SUBNET_ID=subnet-xxx AWS_TEST_SG_ID=sg-xxx \\
+    AWS_PROFILE=aws pytest tests/aws/test_one_shot_e2e.py -m aws --no-cov -v
+
+SPDX-License-Identifier: Apache-2.0
+SPDX-FileCopyrightText: 2025 Scott Friedman and Project Contributors
+"""
+
+import logging
+import time
+
+import pytest
+from parsl.jobs.states import JobState
+
+from parsl_ephemeral_aws.provider import EphemeralAWSProvider
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [pytest.mark.aws, pytest.mark.slow]
+
+POLL_INTERVAL_S = 15
+MAX_WAIT_S = 900  # 15 minutes — SSM registration plus worker_init on real iron
+
+AWS_TEST_PROFILE = "aws"
+
+
+def _poll_until_terminal(provider, job_id: str, timeout: int = MAX_WAIT_S):
+    """Poll ``status()`` until the job leaves PENDING/RUNNING.
+
+    Returns
+    -------
+    Optional[JobState]
+        The terminal state reached, or None on timeout.
+    """
+    non_terminal = (JobState.PENDING, JobState.RUNNING)
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        statuses = provider.status([job_id])
+        if statuses and statuses[0].state not in non_terminal:
+            return statuses[0].state
+        time.sleep(POLL_INTERVAL_S)
+    return None
+
+
+def _wait_for_instance_state(ec2, instance_id: str, wanted, timeout: int = 600):
+    """Poll ``describe_instances`` until the instance reaches one of *wanted*."""
+    deadline = time.time() + timeout
+    last = None
+    while time.time() < deadline:
+        try:
+            response = ec2.describe_instances(InstanceIds=[instance_id])
+        except Exception as exc:  # instance may have aged out entirely
+            logger.warning("describe_instances raised (treated as gone): %s", exc)
+            return "terminated"
+        for reservation in response.get("Reservations", []):
+            for instance in reservation.get("Instances", []):
+                last = instance["State"]["Name"]
+                if last in wanted:
+                    return last
+        time.sleep(POLL_INTERVAL_S)
+    return last
+
+
+@pytest.fixture
+def one_shot_provider(tmp_path, test_run_id, aws_region, network_ids):
+    """A provider in one-shot mode with SSM dispatch enabled.
+
+    ``auto_create_instance_profile=True`` is required: one-shot dispatch goes
+    through SSM ``SendCommand``, which needs the instance to carry a profile
+    holding ``AmazonSSMManagedInstanceCore``.
+    """
+    provider = EphemeralAWSProvider(
+        region=aws_region,
+        instance_type="t3.micro",
+        mode="standard",
+        one_shot=True,
+        auto_create_instance_profile=True,
+        state_store_type="file",
+        state_file_path=str(tmp_path / f"one-shot-{test_run_id}.json"),
+        profile_name=AWS_TEST_PROFILE,
+        additional_tags={"E2ETestRunId": test_run_id, "AutoCleanup": "true"},
+        waiter_delay=15,
+        waiter_max_attempts=40,
+        debug=True,
+        **network_ids,
+    )
+
+    yield provider
+
+    try:
+        provider.shutdown()
+    except Exception as exc:
+        logger.warning("Provider shutdown raised (best-effort): %s", exc)
+
+
+class TestOneShotExitCodes:
+    """A one-shot job's status must follow its command's exit code (#76b)."""
+
+    def test_successful_command_reports_completed(self, one_shot_provider):
+        """``exit 0`` → COMPLETED, with the exit code recorded."""
+        job_id = one_shot_provider.submit("echo hello-one-shot", tasks_per_node=1)
+
+        state = _poll_until_terminal(one_shot_provider, job_id)
+
+        assert state == JobState.COMPLETED, f"expected COMPLETED, got {state}"
+
+    def test_failing_command_reports_failed(self, one_shot_provider):
+        """``exit 1`` → FAILED.
+
+        This is the defect #66 specified and never implemented: status was
+        derived from EC2 instance state, which is identical either way, so a
+        failing command reported COMPLETED and Parsl never retried it.
+        """
+        job_id = one_shot_provider.submit(
+            "echo about-to-fail >&2; exit 1", tasks_per_node=1
+        )
+
+        state = _poll_until_terminal(one_shot_provider, job_id)
+
+        assert state == JobState.FAILED, f"expected FAILED, got {state}"
+
+    def test_exit_code_is_recorded_on_the_resource(self, one_shot_provider):
+        """The SSM response code is stored so a failure is diagnosable."""
+        job_id = one_shot_provider.submit("exit 42", tasks_per_node=1)
+        resource_id = one_shot_provider.job_map[job_id]["resource_id"]
+
+        state = _poll_until_terminal(one_shot_provider, job_id)
+        assert state == JobState.FAILED, f"expected FAILED, got {state}"
+
+        # provider._cleanup_resources() removes the record once terminal, so read
+        # the mode's copy, which is written during get_job_status().
+        resource = one_shot_provider.operating_mode.resources.get(resource_id, {})
+        assert resource.get("exit_code") == 42, (
+            f"expected exit_code 42, got {resource.get('exit_code')} "
+            f"(resource: {resource})"
+        )
+
+
+class TestOneShotInstanceTermination:
+    """One-shot instances must terminate, not stop (#76a)."""
+
+    def test_instance_terminates_rather_than_stopping(
+        self, one_shot_provider, aws_session, aws_region
+    ):
+        """A stopped instance keeps a billed EBS volume the provider forgot about."""
+        ec2 = aws_session.client("ec2", region_name=aws_region)
+
+        job_id = one_shot_provider.submit("echo hello-one-shot", tasks_per_node=1)
+        resource_id = one_shot_provider.job_map[job_id]["resource_id"]
+
+        state = _poll_until_terminal(one_shot_provider, job_id)
+        assert state == JobState.COMPLETED, f"expected COMPLETED, got {state}"
+
+        final = _wait_for_instance_state(
+            ec2, resource_id, ("terminated", "shutting-down", "stopped")
+        )
+        assert final in ("terminated", "shutting-down"), (
+            f"instance {resource_id} reached '{final}'; a stopped instance keeps "
+            "a billed EBS volume"
+        )
+
+    def test_launch_sets_shutdown_behavior_to_terminate(
+        self, one_shot_provider, aws_session, aws_region
+    ):
+        """Verify the attribute on the live instance, not just the API call."""
+        ec2 = aws_session.client("ec2", region_name=aws_region)
+
+        job_id = one_shot_provider.submit("echo hello-one-shot", tasks_per_node=1)
+        resource_id = one_shot_provider.job_map[job_id]["resource_id"]
+
+        try:
+            attribute = ec2.describe_instance_attribute(
+                InstanceId=resource_id,
+                Attribute="instanceInitiatedShutdownBehavior",
+            )
+            behavior = attribute["InstanceInitiatedShutdownBehavior"]["Value"]
+            assert behavior == "terminate", (
+                f"instance {resource_id} would '{behavior}' on shutdown, leaving "
+                "a billed EBS volume"
+            )
+        finally:
+            try:
+                one_shot_provider.cancel([job_id])
+            except Exception as exc:
+                logger.warning("teardown cancel raised (ignored): %s", exc)
+
+    def test_no_ebs_volume_is_left_behind(
+        self, one_shot_provider, aws_session, aws_region
+    ):
+        """The root volume must go with the instance."""
+        ec2 = aws_session.client("ec2", region_name=aws_region)
+
+        job_id = one_shot_provider.submit("echo hello-one-shot", tasks_per_node=1)
+        resource_id = one_shot_provider.job_map[job_id]["resource_id"]
+
+        response = ec2.describe_instances(InstanceIds=[resource_id])
+        volume_ids = [
+            mapping["Ebs"]["VolumeId"]
+            for reservation in response.get("Reservations", [])
+            for instance in reservation.get("Instances", [])
+            for mapping in instance.get("BlockDeviceMappings", [])
+            if "Ebs" in mapping
+        ]
+        assert volume_ids, f"instance {resource_id} reported no EBS volumes"
+
+        state = _poll_until_terminal(one_shot_provider, job_id)
+        assert state == JobState.COMPLETED, f"expected COMPLETED, got {state}"
+
+        _wait_for_instance_state(ec2, resource_id, ("terminated",))
+
+        remaining = ec2.describe_volumes(
+            VolumeIds=volume_ids,
+            Filters=[{"Name": "status", "Values": ["available", "in-use"]}],
+        ).get("Volumes", [])
+        assert not remaining, (
+            f"volumes still billable after termination: "
+            f"{[v['VolumeId'] for v in remaining]}"
+        )
+
+
+class TestOneShotConfiguration:
+    """Guards that keep a misconfigured one-shot provider from starting."""
+
+    def test_one_shot_requires_an_instance_profile(
+        self, tmp_path, test_run_id, aws_region, network_ids
+    ):
+        """SSM dispatch is impossible without a profile, so fail at construction."""
+        with pytest.raises(ValueError, match="one_shot=True requires"):
+            EphemeralAWSProvider(
+                region=aws_region,
+                mode="standard",
+                one_shot=True,
+                state_store_type="file",
+                state_file_path=str(tmp_path / f"guard-{test_run_id}.json"),
+                profile_name=AWS_TEST_PROFILE,
+                **network_ids,
+            )
+
+    def test_command_is_not_embedded_in_user_data(
+        self, one_shot_provider, aws_session, aws_region
+    ):
+        """The command travels over SSM; UserData only prepares the worker.
+
+        If the command were in UserData it would run before SSM was reachable
+        and its exit code would be unobservable.
+        """
+        import base64
+
+        ec2 = aws_session.client("ec2", region_name=aws_region)
+        sentinel = "sentinel-not-in-user-data"
+
+        job_id = one_shot_provider.submit(f"echo {sentinel}", tasks_per_node=1)
+        resource_id = one_shot_provider.job_map[job_id]["resource_id"]
+
+        try:
+            attribute = ec2.describe_instance_attribute(
+                InstanceId=resource_id, Attribute="userData"
+            )
+            user_data = base64.b64decode(
+                attribute.get("UserData", {}).get("Value", "")
+            ).decode()
+
+            assert sentinel not in user_data, "command leaked into UserData"
+            assert "/var/run/parsl_worker_ready" in user_data
+        finally:
+            try:
+                one_shot_provider.cancel([job_id])
+            except Exception as exc:
+                logger.warning("teardown cancel raised (ignored): %s", exc)

--- a/tests/aws/test_serverless_mode_e2e.py
+++ b/tests/aws/test_serverless_mode_e2e.py
@@ -25,6 +25,8 @@ import time
 import pytest
 from botocore.exceptions import ClientError
 
+from parsl.jobs.states import JobState
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -36,13 +38,18 @@ MAX_WAIT_S = 600  # 10 minutes
 
 
 def _poll_until(
-    provider, job_id: str, target_status: str, timeout: int = MAX_WAIT_S
+    provider, job_id: str, target_state: JobState, timeout: int = MAX_WAIT_S
 ) -> bool:
-    """Poll provider.status() until the job reaches *target_status* or timeout."""
+    """Poll provider.status() until the job reaches *target_state* or timeout.
+
+    ``status()`` returns ``List[JobStatus]``, not the ``List[Dict[str, str]]``
+    this suite was written against, and ``JobStatus`` is not subscriptable —
+    see #102.
+    """
     deadline = time.time() + timeout
     while time.time() < deadline:
         result = provider.status([job_id])
-        if result and result[0]["status"] == target_status:
+        if result and result[0].state == target_state:
             return True
         time.sleep(POLL_INTERVAL_S)
     return False
@@ -168,7 +175,7 @@ class TestLambdaLifecycle:
         """A short Lambda command transitions to COMPLETED within the timeout."""
         job_id = serverless_provider.submit("echo hello-from-lambda", tasks_per_node=1)
 
-        reached = _poll_until(serverless_provider, job_id, "COMPLETED")
+        reached = _poll_until(serverless_provider, job_id, JobState.COMPLETED)
         assert reached, f"Job {job_id} did not reach COMPLETED within {MAX_WAIT_S}s"
 
     def test_lambda_cancel_removes_function(

--- a/tests/aws/test_spot_e2e.py
+++ b/tests/aws/test_spot_e2e.py
@@ -22,6 +22,8 @@ import time
 
 import pytest
 
+from parsl.jobs.states import JobState
+
 from parsl_ephemeral_aws.provider import EphemeralAWSProvider
 
 logger = logging.getLogger(__name__)
@@ -35,34 +37,34 @@ MAX_WAIT_S = 600  # 10 minutes
 
 
 def _poll_until(
-    provider, job_id: str, target_status: str, timeout: int = MAX_WAIT_S
+    provider, job_id: str, target_state: JobState, timeout: int = MAX_WAIT_S
 ) -> bool:
-    """Poll provider.status() until the job reaches *target_status* or timeout.
+    """Poll provider.status() until the job reaches *target_state* or timeout.
 
-    Returns True if the target status was reached, False on timeout.
+    Returns True if the target state was reached, False on timeout.
+
+    ``status()`` returns ``List[JobStatus]``, not the ``List[Dict[str, str]]``
+    this suite was written against, and ``JobStatus`` is not subscriptable —
+    see #102.
     """
     deadline = time.time() + timeout
     while time.time() < deadline:
         result = provider.status([job_id])
-        if result and result[0]["status"] == target_status:
+        if result and result[0].state == target_state:
             return True
         time.sleep(POLL_INTERVAL_S)
     return False
 
 
-def _poll_until_not(
-    provider, job_id: str, current_status: str, timeout: int = MAX_WAIT_S
-) -> str:
-    """Poll until the job leaves *current_status*; return the new status or '' on timeout."""
+def _poll_until_not(provider, job_id: str, current_state: JobState, timeout=MAX_WAIT_S):
+    """Poll until the job leaves *current_state*; return the new state or None."""
     deadline = time.time() + timeout
     while time.time() < deadline:
         result = provider.status([job_id])
-        if result:
-            status = result[0]["status"]
-            if status != current_status:
-                return status
+        if result and result[0].state != current_state:
+            return result[0].state
         time.sleep(POLL_INTERVAL_S)
-    return ""
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -214,10 +216,10 @@ class TestSpotComputeLifecycle:
         try:
             result = spot_provider.status([job_id])
             assert result, "status() returned an empty list"
-            status = result[0]["status"]
+            state = result[0].state
             assert (
-                status == "RUNNING"
-            ), f"Expected status RUNNING immediately after submit, got {status}"
+                state == JobState.RUNNING
+            ), f"Expected RUNNING immediately after submit, got {state}"
         finally:
             try:
                 spot_provider.cancel([job_id])
@@ -233,7 +235,7 @@ class TestSpotComputeLifecycle:
         job_id = spot_provider.submit("echo hello-from-spot", tasks_per_node=1)
         resource_id = spot_provider.job_map[job_id]["resource_id"]
 
-        reached = _poll_until(spot_provider, job_id, "COMPLETED")
+        reached = _poll_until(spot_provider, job_id, JobState.COMPLETED)
         assert reached, f"Job {job_id} did not reach COMPLETED within {MAX_WAIT_S}s"
 
         ec2 = aws_session.client("ec2", region_name=aws_region)
@@ -258,7 +260,9 @@ class TestSpotComputeLifecycle:
         resource_id = spot_provider.job_map[job_id]["resource_id"]
 
         result = spot_provider.status([job_id])
-        assert result[0]["status"] == "RUNNING", "Expected RUNNING before cancellation"
+        assert (
+            result[0].state == JobState.RUNNING
+        ), "Expected RUNNING before cancellation"
 
         spot_provider.cancel([job_id])
 
@@ -400,7 +404,7 @@ class TestSpotInterruptionMonitor:
         # Confirm it is RUNNING first
         result = spot_provider.status([job_id])
         assert (
-            result and result[0]["status"] == "RUNNING"
+            result and result[0].state == JobState.RUNNING
         ), "Expected RUNNING status before force-termination"
 
         # Force-terminate the EC2 instance directly
@@ -413,13 +417,15 @@ class TestSpotInterruptionMonitor:
         )
 
         # Poll until the provider detects the change (3 minute timeout)
-        new_status = _poll_until_not(spot_provider, job_id, "RUNNING", timeout=180)
-        assert new_status, (
+        new_state = _poll_until_not(
+            spot_provider, job_id, JobState.RUNNING, timeout=180
+        )
+        assert new_state is not None, (
             f"Job {job_id} did not leave RUNNING state within 180s after "
             f"instance {resource_id} was force-terminated"
         )
         logger.info(
             "test_forced_termination: job %s transitioned from RUNNING to %s",
             job_id,
-            new_status,
+            new_state,
         )

--- a/tests/aws/test_standard_mode_e2e.py
+++ b/tests/aws/test_standard_mode_e2e.py
@@ -22,6 +22,8 @@ import logging
 
 import pytest
 
+from parsl.jobs.states import JobState
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -33,9 +35,9 @@ MAX_WAIT_S = 600  # 10 minutes
 
 
 def _poll_until(
-    provider, job_id: str, target_status: str, timeout: int = MAX_WAIT_S
+    provider, job_id: str, target_state: JobState, timeout: int = MAX_WAIT_S
 ) -> bool:
-    """Poll provider.status() until the job reaches *target_status* or timeout.
+    """Poll provider.status() until the job reaches *target_state* or timeout.
 
     Parameters
     ----------
@@ -43,20 +45,27 @@ def _poll_until(
         An initialised EphemeralAWSProvider instance.
     job_id:
         The job ID returned by provider.submit().
-    target_status:
-        The status string to wait for (e.g. "COMPLETED", "RUNNING").
+    target_state:
+        The ``JobState`` to wait for (e.g. ``JobState.COMPLETED``).
     timeout:
         Maximum number of seconds to wait before returning False.
 
     Returns
     -------
     bool
-        True if the target status was reached before the timeout.
+        True if the target state was reached before the timeout.
+
+    Notes
+    -----
+    ``status()`` returns ``List[JobStatus]``, not the ``List[Dict[str, str]]``
+    this suite was written against — and ``JobStatus`` is not subscriptable, so
+    the old ``result[0]["status"]`` raised ``TypeError`` on the first poll
+    rather than timing out. See #102.
     """
     deadline = time.time() + timeout
     while time.time() < deadline:
         result = provider.status([job_id])
-        if result and result[0]["status"] == target_status:
+        if result and result[0].state == target_state:
             return True
         time.sleep(POLL_INTERVAL_S)
     return False
@@ -128,10 +137,10 @@ class TestStandardModeComputeLifecycle:
         try:
             result = aws_provider.status([job_id])
             assert result, "status() returned an empty list"
-            status = result[0]["status"]
+            state = result[0].state
             assert (
-                status == "RUNNING"
-            ), f"Expected status RUNNING immediately after submit, got {status}"
+                state == JobState.RUNNING
+            ), f"Expected RUNNING immediately after submit, got {state}"
         finally:
             try:
                 aws_provider.cancel([job_id])
@@ -149,7 +158,7 @@ class TestStandardModeComputeLifecycle:
         job_id = aws_provider.submit("echo hello-from-ec2", tasks_per_node=1)
         resource_id = aws_provider.job_map[job_id]["resource_id"]
 
-        reached = _poll_until(aws_provider, job_id, "COMPLETED")
+        reached = _poll_until(aws_provider, job_id, JobState.COMPLETED)
         assert reached, f"Job {job_id} did not reach COMPLETED within {MAX_WAIT_S}s"
 
         # Verify the EC2 instance is in a terminal state
@@ -174,7 +183,9 @@ class TestStandardModeComputeLifecycle:
 
         # Confirm it is running first
         result = aws_provider.status([job_id])
-        assert result[0]["status"] == "RUNNING", "Expected RUNNING before cancellation"
+        assert (
+            result[0].state == JobState.RUNNING
+        ), "Expected RUNNING before cancellation"
 
         aws_provider.cancel([job_id])
 

--- a/tests/aws/test_state_backends_e2e.py
+++ b/tests/aws/test_state_backends_e2e.py
@@ -5,15 +5,13 @@ AWS Parameter Store (SSM) and S3, exercising the full state round-trip:
 
     initialise → state saved → re-create provider → state loaded → shutdown → state deleted
 
-NOTE on known bugs
-------------------
-As of v0.3.0 the ``ParameterStoreStateStore`` and ``S3StateStore`` classes were
-implemented with a different constructor signature than what ``EphemeralAWSProvider``
-passes when creating them (``session``, ``path``/``bucket``, ``provider_id`` vs
-the original ``provider`` object, ``prefix``/``bucket_name``).  These tests are
-written to exercise the **intended** behaviour; they will fail at provider
-construction time until those mismatches are resolved.  The failures serve as
-regression-test markers for issue #57.
+These tests were written against the **intended** behaviour while the AWS state
+backends could not be constructed at all: the provider passed ``session``,
+``path``/``bucket`` and ``provider_id``, while the stores took a ``provider``
+object plus ``prefix``/``bucket_name``, and both stores then read six credential
+attributes the provider does not define.  Fixed in v0.7.0 (#57, #77); state is
+now addressed by key so the provider and its mode no longer overwrite each
+other's document (#78).
 
 Run with::
 
@@ -42,14 +40,16 @@ MAX_WAIT_S = 600  # 10 minutes
 AWS_TEST_PROFILE = "aws"
 
 
-def _poll_until(
-    provider, job_id: str, target_status: str, timeout: int = MAX_WAIT_S
-) -> bool:
-    """Poll provider.status() until the job reaches *target_status* or timeout."""
+def _poll_until(provider, job_id: str, target_state, timeout: int = MAX_WAIT_S) -> bool:
+    """Poll provider.status() until the job reaches *target_state* or timeout.
+
+    ``status()`` returns Parsl ``JobStatus`` objects, so read ``.state`` rather
+    than subscripting.
+    """
     deadline = time.time() + timeout
     while time.time() < deadline:
         result = provider.status([job_id])
-        if result and result[0]["status"] == target_status:
+        if result and result[0].state == target_state:
             return True
         time.sleep(POLL_INTERVAL_S)
     return False
@@ -131,7 +131,7 @@ class TestParameterStoreState:
                 logger.warning("teardown cancel raised (ignored): %s", exc)
 
     def test_state_round_trips_through_parameter_store(
-        self, aws_session, test_run_id, aws_region
+        self, aws_session, test_run_id, aws_region, network_ids
     ):
         """State saved by one provider instance can be loaded by a new instance.
 
@@ -158,6 +158,7 @@ class TestParameterStoreState:
             waiter_delay=15,
             waiter_max_attempts=40,
             debug=True,
+            **network_ids,
         )
         provider1.operating_mode.initialize()
         job_id = provider1.submit("echo round-trip-test", tasks_per_node=1)
@@ -182,6 +183,7 @@ class TestParameterStoreState:
             waiter_delay=15,
             waiter_max_attempts=40,
             debug=True,
+            **network_ids,
         )
         try:
             provider2.operating_mode.initialize()  # should load saved state
@@ -292,7 +294,7 @@ class TestS3State:
                 logger.warning("teardown cancel raised (ignored): %s", exc)
 
     def test_state_round_trips_through_s3(
-        self, aws_session, test_run_id, aws_region, s3_state_bucket
+        self, aws_session, test_run_id, aws_region, s3_state_bucket, network_ids
     ):
         """State saved by one provider can be loaded by a new provider from S3.
 
@@ -317,6 +319,7 @@ class TestS3State:
             waiter_delay=15,
             waiter_max_attempts=40,
             debug=True,
+            **network_ids,
         )
         provider1.operating_mode.initialize()
         job_id = provider1.submit("echo round-trip-s3", tasks_per_node=1)
@@ -340,6 +343,7 @@ class TestS3State:
             waiter_delay=15,
             waiter_max_attempts=40,
             debug=True,
+            **network_ids,
         )
         try:
             provider2.operating_mode.initialize()

--- a/tests/integration/test_detached_mode_spot_fleet_integration.py
+++ b/tests/integration/test_detached_mode_spot_fleet_integration.py
@@ -13,8 +13,8 @@ import pytest
 import json
 
 try:
-    # Check if moto is available
-    import moto
+    # Check if moto is available — importing the decorators is the probe; a
+    # bare `import moto` alongside them was redundant.
     from moto import mock_ec2, mock_iam, mock_ssm, mock_cloudformation
 
     MOTO_AVAILABLE = True
@@ -36,20 +36,27 @@ pytestmark = pytest.mark.skipif(not MOTO_AVAILABLE, reason="moto not installed")
 
 
 class MockStateStore:
-    """Mock state store implementation for testing."""
+    """Mock state store implementation for testing.
+
+    Keyed like the real stores, so writing one key does not disturb another.
+    """
 
     def __init__(self):
         """Initialize with empty state."""
-        self.state = None
+        self.states = {}
 
-    def save_state(self, state):
-        """Save state."""
-        self.state = state
+    def save_state(self, state_key, state_data):
+        """Save state under a key."""
+        self.states[state_key] = state_data
         return True
 
-    def load_state(self):
-        """Load state."""
-        return self.state
+    def load_state(self, state_key):
+        """Load state stored under a key."""
+        return self.states.get(state_key)
+
+    def delete_state(self, state_key):
+        """Delete state stored under a key."""
+        self.states.pop(state_key, None)
 
 
 @mock_ec2

--- a/tests/integration/test_job_lifecycle.py
+++ b/tests/integration/test_job_lifecycle.py
@@ -19,6 +19,7 @@ import pytest
 
 from parsl_ephemeral_aws.exceptions import ProviderError
 from parsl_ephemeral_aws.provider import EphemeralAWSProvider
+from parsl_ephemeral_aws.state.base import STATE_KEY_PROVIDER
 from parsl_ephemeral_aws.state.file import FileStateStore
 from parsl_ephemeral_aws.utils.localstack import is_localstack_available
 
@@ -175,7 +176,7 @@ class TestJobLifecycle:
 
         # State is persisted by _save_state after submit; load it in a new instance
         state_store_2 = FileStateStore(file_path=state_file, provider_id=provider_id)
-        state = state_store_2.load_state()
+        state = state_store_2.load_state(STATE_KEY_PROVIDER)
 
         assert state is not None
         assert job_id in state.get("job_map", {})

--- a/tests/integration/test_state_persistence_integration.py
+++ b/tests/integration/test_state_persistence_integration.py
@@ -12,7 +12,9 @@ import uuid
 import pytest
 import tempfile
 import boto3
+from botocore.exceptions import ClientError
 
+from parsl_ephemeral_aws.state.base import STATE_KEY_PROVIDER
 from parsl_ephemeral_aws.state.file import FileStateStore
 from parsl_ephemeral_aws.state.parameter_store import ParameterStoreState
 from parsl_ephemeral_aws.state.s3 import S3State
@@ -48,6 +50,11 @@ class TestFileStateStoreIntegration:
     @pytest.fixture
     def complex_state(self):
         """Create a complex state dictionary with nested structures."""
+        # Bound to names so the two resource keys are visibly distinct. Written
+        # inline they were textually identical expressions -- distinct at runtime
+        # because uuid4() differs, but indistinguishable to a reader or a linter.
+        first_res = f"res-{uuid.uuid4().hex[:8]}"
+        second_res = f"res-{uuid.uuid4().hex[:8]}"
         return {
             "provider_info": {
                 "id": f"provider-{uuid.uuid4().hex[:8]}",
@@ -55,13 +62,13 @@ class TestFileStateStoreIntegration:
                 "created_at": "2023-01-01T00:00:00Z",
             },
             "resources": {
-                f"res-{uuid.uuid4().hex[:8]}": {
+                first_res: {
                     "instance_id": f"i-{uuid.uuid4().hex[:12]}",
                     "status": "running",
                     "ip_address": "10.0.0.1",
                     "tags": ["compute", "worker"],
                 },
-                f"res-{uuid.uuid4().hex[:8]}": {
+                second_res: {
                     "instance_id": f"i-{uuid.uuid4().hex[:12]}",
                     "status": "pending",
                     "ip_address": "10.0.0.2",
@@ -89,13 +96,13 @@ class TestFileStateStoreIntegration:
     def test_full_lifecycle(self, file_state_store, complex_state):
         """Test the full lifecycle of state persistence."""
         # 1. Save state
-        file_state_store.save_state(complex_state)
+        file_state_store.save_state(STATE_KEY_PROVIDER, complex_state)
 
         # Verify file exists
         assert os.path.exists(file_state_store.file_path)
 
         # 2. Load state
-        loaded_state = file_state_store.load_state()
+        loaded_state = file_state_store.load_state(STATE_KEY_PROVIDER)
 
         # Verify loaded state matches original
         assert loaded_state is not None
@@ -111,21 +118,21 @@ class TestFileStateStoreIntegration:
         # 3. Update state
         loaded_state["statistics"]["job_count"] += 1
         loaded_state["statistics"]["success_count"] += 1
-        file_state_store.save_state(loaded_state)
+        file_state_store.save_state(STATE_KEY_PROVIDER, loaded_state)
 
         # 4. Reload state and verify updates
-        reloaded_state = file_state_store.load_state()
+        reloaded_state = file_state_store.load_state(STATE_KEY_PROVIDER)
         assert reloaded_state["statistics"]["job_count"] == 11
         assert reloaded_state["statistics"]["success_count"] == 9
 
         # 5. Delete state
-        file_state_store.delete_state()
+        file_state_store.delete_state(STATE_KEY_PROVIDER)
 
-        # Verify file no longer exists
+        # Verify file no longer exists — this was the only key in it
         assert not os.path.exists(file_state_store.file_path)
 
         # 6. Load after delete should return None
-        final_state = file_state_store.load_state()
+        final_state = file_state_store.load_state(STATE_KEY_PROVIDER)
         assert final_state is None
 
     def test_concurrent_access(self, temp_dir, complex_state):
@@ -138,16 +145,16 @@ class TestFileStateStoreIntegration:
         store2 = FileStateStore(file_path=file_path, provider_id=provider_id)
 
         # Store 1 saves initial state
-        store1.save_state(complex_state)
+        store1.save_state(STATE_KEY_PROVIDER, complex_state)
 
         # Store 2 loads state, modifies it, and saves back
-        state2 = store2.load_state()
+        state2 = store2.load_state(STATE_KEY_PROVIDER)
         state2["statistics"]["job_count"] = 20
         state2["provider_info"]["updated_by"] = "store2"
-        store2.save_state(state2)
+        store2.save_state(STATE_KEY_PROVIDER, state2)
 
         # Store 1 reloads state - should see Store 2's changes
-        updated_state = store1.load_state()
+        updated_state = store1.load_state(STATE_KEY_PROVIDER)
         assert updated_state["statistics"]["job_count"] == 20
         assert updated_state["provider_info"]["updated_by"] == "store2"
 
@@ -516,7 +523,7 @@ class TestS3StateIntegration:
         try:
             s3_client.head_bucket(Bucket=bucket_name)
             bucket_exists = True
-        except:
+        except ClientError:
             bucket_exists = False
 
         assert not bucket_exists
@@ -533,7 +540,7 @@ class TestS3StateIntegration:
         try:
             s3_client.head_bucket(Bucket=bucket_name)
             bucket_exists = True
-        except:
+        except ClientError:
             bucket_exists = False
 
         assert bucket_exists

--- a/tests/unit/test_detached_mode.py
+++ b/tests/unit/test_detached_mode.py
@@ -11,6 +11,7 @@ import time
 import json
 
 from parsl_ephemeral_aws.modes.detached import DetachedMode
+from parsl_ephemeral_aws.state.base import STATE_KEY_MODE
 from parsl_ephemeral_aws.exceptions import (
     OperatingModeError,
     ResourceCreationError,
@@ -597,8 +598,11 @@ class TestDetachedMode:
         # Verify state_store.save_state was called
         mock_state_store.save_state.assert_called_once()
 
+        # The mode writes its own state key, so the provider's document survives
+        state_key, state = mock_state_store.save_state.call_args[0]
+        assert state_key == STATE_KEY_MODE
+
         # Verify state content
-        state = mock_state_store.save_state.call_args[0][0]
         assert state["provider_id"] == "test-provider"
         assert state["mode"] == "DetachedMode"
         assert state["vpc_id"] == "vpc-12345"

--- a/tests/unit/test_ecs_manager.py
+++ b/tests/unit/test_ecs_manager.py
@@ -1,0 +1,122 @@
+"""
+Unit tests for ECSManager network resource resolution.
+
+SPDX-License-Identifier: Apache-2.0
+SPDX-FileCopyrightText: 2025 Scott Friedman and Project Contributors
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from parsl_ephemeral_aws.compute.ecs import ECSManager
+from parsl_ephemeral_aws.exceptions import ResourceCreationError
+
+
+pytestmark = pytest.mark.unit
+
+
+def _manager(**provider_attrs):
+    """Build an ECSManager with only the attributes the method under test reads.
+
+    ``__init__`` pulls in the audit logger and credential manager, neither of
+    which is relevant to network resolution, so it is bypassed deliberately.
+    """
+    attrs = {
+        "vpc_id": None,
+        "subnet_id": None,
+        "subnet_ids": None,
+        "security_group_id": None,
+        "workflow_id": "test-workflow",
+    }
+    attrs.update(provider_attrs)
+
+    manager = object.__new__(ECSManager)
+    manager.provider = SimpleNamespace(**attrs)
+    manager.ec2_client = MagicMock()
+    manager.ec2_client.describe_security_groups.return_value = {
+        "SecurityGroups": [{"GroupId": "sg-existing"}]
+    }
+    return manager
+
+
+class TestECSNetworkResolution:
+    """Tests for ``ECSManager._get_or_create_network_resources``."""
+
+    def test_explicit_subnet_id_is_used_without_discovery(self):
+        """An explicit subnet_id must be honoured verbatim.
+
+        Regression test for the leftover line that unconditionally
+        dereferenced ``subnet_response`` — bound only in the discovery
+        branch — raising ``UnboundLocalError`` on every ECS submission once
+        subnet_id became a required argument.
+        """
+        manager = _manager(
+            vpc_id="vpc-explicit",
+            subnet_id="subnet-explicit",
+            security_group_id="sg-explicit",
+        )
+
+        result = manager._get_or_create_network_resources()
+
+        assert result["vpc_id"] == "vpc-explicit"
+        assert result["subnet_ids"] == ["subnet-explicit"]
+        manager.ec2_client.describe_vpcs.assert_not_called()
+        manager.ec2_client.describe_subnets.assert_not_called()
+
+    def test_explicit_subnet_ids_list_takes_precedence(self):
+        """A ``subnet_ids`` list wins over the singular ``subnet_id``."""
+        manager = _manager(
+            vpc_id="vpc-explicit",
+            subnet_id="subnet-singular",
+            subnet_ids=["subnet-a", "subnet-b"],
+        )
+
+        result = manager._get_or_create_network_resources()
+
+        assert result["subnet_ids"] == ["subnet-a", "subnet-b"]
+        manager.ec2_client.describe_subnets.assert_not_called()
+
+    def test_subnets_discovered_when_not_supplied(self):
+        """With no explicit subnet, subnets are discovered from the VPC."""
+        manager = _manager(vpc_id="vpc-explicit")
+        manager.ec2_client.describe_subnets.return_value = {
+            "Subnets": [{"SubnetId": "subnet-found-1"}, {"SubnetId": "subnet-found-2"}]
+        }
+
+        result = manager._get_or_create_network_resources()
+
+        assert result["subnet_ids"] == ["subnet-found-1", "subnet-found-2"]
+        manager.ec2_client.describe_subnets.assert_called_once()
+
+    def test_no_subnets_in_vpc_raises(self):
+        """An empty discovery result is an error, not an empty subnet list."""
+        manager = _manager(vpc_id="vpc-empty")
+        manager.ec2_client.describe_subnets.return_value = {"Subnets": []}
+
+        with pytest.raises(ResourceCreationError, match="No subnets found"):
+            manager._get_or_create_network_resources()
+
+    def test_falls_back_to_default_vpc(self):
+        """Without an explicit vpc_id, the account's default VPC is used."""
+        manager = _manager()
+        manager.ec2_client.describe_vpcs.return_value = {
+            "Vpcs": [{"VpcId": "vpc-default"}]
+        }
+        manager.ec2_client.describe_subnets.return_value = {
+            "Subnets": [{"SubnetId": "subnet-default"}]
+        }
+
+        result = manager._get_or_create_network_resources()
+
+        assert result["vpc_id"] == "vpc-default"
+        assert result["subnet_ids"] == ["subnet-default"]
+
+    def test_no_default_vpc_raises(self):
+        """No explicit vpc_id and no default VPC is a configuration error."""
+        manager = _manager()
+        manager.ec2_client.describe_vpcs.return_value = {"Vpcs": []}
+
+        with pytest.raises(ResourceCreationError, match="No default VPC found"):
+            manager._get_or_create_network_resources()

--- a/tests/unit/test_instance_profile.py
+++ b/tests/unit/test_instance_profile.py
@@ -1,0 +1,259 @@
+"""Unit tests for SSM instance profile resolution.
+
+Warm-pool and one-shot dispatch both go through SSM ``SendCommand``, which needs
+the instance to carry a profile holding ``AmazonSSMManagedInstanceCore``. The
+provider accepted ``auto_create_instance_profile`` but never forwarded it, so no
+profile was ever attached and every dispatch silently fell back to UserData.
+
+SPDX-License-Identifier: Apache-2.0
+SPDX-FileCopyrightText: 2025 Scott Friedman and Project Contributors
+"""
+
+from unittest.mock import MagicMock, patch
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from parsl_ephemeral_aws.modes.standard import StandardMode
+from parsl_ephemeral_aws.utils.aws import get_or_create_ssm_instance_profile
+
+
+pytestmark = pytest.mark.unit
+
+NETWORK_IDS = {
+    "vpc_id": "vpc-12345",
+    "subnet_id": "subnet-12345",
+    "security_group_id": "sg-12345",
+}
+
+SSM_POLICY_ARN = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+
+
+@pytest.fixture
+def iam_session(monkeypatch):
+    """A moto-backed session that can attach AWS managed policies.
+
+    moto only serves the AWS managed policy catalogue when
+    ``MOTO_IAM_LOAD_MANAGED_POLICIES`` is set, and it reads the variable when the
+    IAM backend is built — so it has to be in place before ``mock_aws`` starts.
+    The synthetic credentials keep moto from picking up an ambient real profile.
+    """
+    monkeypatch.setenv("MOTO_IAM_LOAD_MANAGED_POLICIES", "true")
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+    monkeypatch.delenv("AWS_PROFILE", raising=False)
+
+    with mock_aws():
+        yield boto3.Session(region_name="us-east-1")
+
+
+class TestGetOrCreateSSMInstanceProfile:
+    """Tests for ``utils.aws.get_or_create_ssm_instance_profile``."""
+
+    def test_explicit_arn_is_returned_verbatim(self):
+        """A supplied ARN wins; nothing is created."""
+        session = MagicMock()
+
+        result = get_or_create_ssm_instance_profile(
+            session=session,
+            name_suffix="wf",
+            iam_instance_profile_arn="arn:aws:iam::1:instance-profile/mine",
+            auto_create=True,
+        )
+
+        assert result == "arn:aws:iam::1:instance-profile/mine"
+        session.client.assert_not_called()
+
+    def test_returns_none_without_auto_create(self):
+        """With neither an ARN nor auto-creation, instances get no profile."""
+        session = MagicMock()
+
+        result = get_or_create_ssm_instance_profile(
+            session=session, name_suffix="wf", auto_create=False
+        )
+
+        assert result is None
+        session.client.assert_not_called()
+
+    def test_creates_role_and_profile_with_the_ssm_policy(self, iam_session):
+        """The created role must carry AmazonSSMManagedInstanceCore."""
+        session = iam_session
+
+        arn = get_or_create_ssm_instance_profile(
+            session=session, name_suffix="wf-1", auto_create=True
+        )
+
+        assert arn is not None
+        iam = session.client("iam")
+        profile = iam.get_instance_profile(
+            InstanceProfileName="parsl-ephemeral-ssm-profile-wf-1"
+        )["InstanceProfile"]
+
+        assert profile["Arn"] == arn
+        role_names = [role["RoleName"] for role in profile["Roles"]]
+        assert role_names == ["parsl-ephemeral-ssm-role-wf-1"]
+
+        attached = iam.list_attached_role_policies(
+            RoleName="parsl-ephemeral-ssm-role-wf-1"
+        )["AttachedPolicies"]
+        assert SSM_POLICY_ARN in [p["PolicyArn"] for p in attached]
+
+    def test_is_idempotent(self, iam_session):
+        """A second call reuses the profile rather than failing on the conflict."""
+        session = iam_session
+
+        first = get_or_create_ssm_instance_profile(
+            session=session, name_suffix="wf-2", auto_create=True
+        )
+        second = get_or_create_ssm_instance_profile(
+            session=session, name_suffix="wf-2", auto_create=True
+        )
+
+        assert first == second
+
+        # And the role is still attached exactly once.
+        iam = session.client("iam")
+        profile = iam.get_instance_profile(
+            InstanceProfileName="parsl-ephemeral-ssm-profile-wf-2"
+        )["InstanceProfile"]
+        assert len(profile["Roles"]) == 1
+
+    def test_attaches_the_role_to_a_pre_existing_empty_profile(self, iam_session):
+        """A profile left behind without its role must still be usable.
+
+        The original implementation returned early on ``get_instance_profile``
+        success, so a profile whose role attachment had failed stayed empty
+        forever and SSM never came online.
+        """
+        session = iam_session
+        iam = session.client("iam")
+        iam.create_instance_profile(
+            InstanceProfileName="parsl-ephemeral-ssm-profile-wf-3"
+        )
+
+        get_or_create_ssm_instance_profile(
+            session=session, name_suffix="wf-3", auto_create=True
+        )
+
+        profile = iam.get_instance_profile(
+            InstanceProfileName="parsl-ephemeral-ssm-profile-wf-3"
+        )["InstanceProfile"]
+        assert [r["RoleName"] for r in profile["Roles"]] == [
+            "parsl-ephemeral-ssm-role-wf-3"
+        ]
+
+
+class TestStandardModeProfileResolution:
+    """``StandardMode`` must resolve an ARN before instances are launched."""
+
+    @pytest.fixture
+    def mock_session(self):
+        session = MagicMock(spec=boto3.Session)
+        session.region_name = "us-east-1"
+        return session
+
+    @pytest.fixture
+    def mock_state_store(self):
+        store = MagicMock()
+        store.load_state.return_value = None
+        return store
+
+    def _mode(self, mock_session, mock_state_store, **overrides):
+        params = {
+            "provider_id": "test-provider",
+            "session": mock_session,
+            "state_store": mock_state_store,
+            "image_id": "ami-12345",
+            "region": "us-east-1",
+            **NETWORK_IDS,
+        }
+        params.update(overrides)
+        return StandardMode(**params)
+
+    def test_auto_create_flag_is_accepted(self, mock_session, mock_state_store):
+        """Regression: the mode had no such parameter, so it fell into kwargs."""
+        mode = self._mode(
+            mock_session,
+            mock_state_store,
+            warm_pool_size=2,
+            auto_create_instance_profile=True,
+        )
+        assert mode.auto_create_instance_profile is True
+
+    def test_initialize_resolves_the_arn(self, mock_session, mock_state_store):
+        """After initialize(), `_create_instance` must have an ARN to attach."""
+        mode = self._mode(
+            mock_session,
+            mock_state_store,
+            warm_pool_size=2,
+            auto_create_instance_profile=True,
+        )
+        assert mode.iam_instance_profile_arn is None
+
+        with patch(
+            "parsl_ephemeral_aws.modes.standard.get_or_create_ssm_instance_profile",
+            return_value="arn:aws:iam::1:instance-profile/created",
+        ) as resolve:
+            mode.initialize()
+
+        assert (
+            mode.iam_instance_profile_arn == "arn:aws:iam::1:instance-profile/created"
+        )
+        assert resolve.call_args.kwargs["name_suffix"] == "test-provider"
+        assert resolve.call_args.kwargs["auto_create"] is True
+
+    def test_explicit_arn_is_not_overwritten(self, mock_session, mock_state_store):
+        """An explicitly supplied profile must be left alone."""
+        mode = self._mode(
+            mock_session,
+            mock_state_store,
+            warm_pool_size=2,
+            iam_instance_profile_arn="arn:aws:iam::1:instance-profile/mine",
+            auto_create_instance_profile=True,
+        )
+
+        with patch(
+            "parsl_ephemeral_aws.modes.standard.get_or_create_ssm_instance_profile"
+        ) as resolve:
+            mode.initialize()
+
+        resolve.assert_not_called()
+        assert mode.iam_instance_profile_arn == "arn:aws:iam::1:instance-profile/mine"
+
+    def test_no_profile_is_created_when_not_requested(
+        self, mock_session, mock_state_store
+    ):
+        """Without the flag, no IAM resources are touched at all."""
+        mode = self._mode(mock_session, mock_state_store)
+
+        with patch(
+            "parsl_ephemeral_aws.modes.standard.get_or_create_ssm_instance_profile"
+        ) as resolve:
+            mode.initialize()
+
+        resolve.assert_not_called()
+        assert mode.iam_instance_profile_arn is None
+
+    def test_profile_creation_failure_is_not_fatal(
+        self, mock_session, mock_state_store
+    ):
+        """Dispatch degrades to UserData rather than the provider failing."""
+        mode = self._mode(
+            mock_session,
+            mock_state_store,
+            warm_pool_size=2,
+            auto_create_instance_profile=True,
+        )
+
+        with patch(
+            "parsl_ephemeral_aws.modes.standard.get_or_create_ssm_instance_profile",
+            side_effect=RuntimeError("IAM denied"),
+        ):
+            mode.initialize()
+
+        assert mode.initialized is True
+        assert mode.iam_instance_profile_arn is None

--- a/tests/unit/test_instance_profile.py
+++ b/tests/unit/test_instance_profile.py
@@ -13,10 +13,14 @@ from unittest.mock import MagicMock, patch
 
 import boto3
 import pytest
+from botocore.exceptions import ClientError
 from moto import mock_aws
 
 from parsl_ephemeral_aws.modes.standard import StandardMode
-from parsl_ephemeral_aws.utils.aws import get_or_create_ssm_instance_profile
+from parsl_ephemeral_aws.utils.aws import (
+    _wait_for_instance_profile,
+    get_or_create_ssm_instance_profile,
+)
 
 
 pytestmark = pytest.mark.unit
@@ -145,6 +149,115 @@ class TestGetOrCreateSSMInstanceProfile:
         assert [r["RoleName"] for r in profile["Roles"]] == [
             "parsl-ephemeral-ssm-role-wf-3"
         ]
+
+
+def _client_error(code):
+    """Return a ClientError carrying *code*, as boto3 would raise it."""
+    return ClientError({"Error": {"Code": code, "Message": code}}, "RunInstances")
+
+
+class TestWaitForInstanceProfile:
+    """IAM is eventually consistent with respect to EC2.
+
+    ``create_instance_profile`` returns an ARN that ``RunInstances`` rejects with
+    ``InvalidParameterValue: Invalid IAM Instance Profile ARN`` for roughly the
+    first ten seconds (measured against real AWS: created at t+4.1s, accepted at
+    t+14.5s). Making ``auto_create_instance_profile`` actually take effect
+    exposed this -- every warm-pool launch hit it. ``get_instance_profile``
+    succeeds immediately and so proves nothing; only a dry-run ``RunInstances``
+    exercises the path that matters.
+    """
+
+    @pytest.fixture
+    def session(self):
+        session = MagicMock(spec=boto3.Session)
+        session.region_name = "us-east-1"
+        return session
+
+    def test_returns_as_soon_as_ec2_accepts_the_arn(self, session):
+        """DryRunOperation means EC2 validated everything, profile included."""
+        ec2 = session.client.return_value
+        ec2.run_instances.side_effect = _client_error("DryRunOperation")
+
+        with patch("parsl_ephemeral_aws.utils.aws.time.sleep") as sleep:
+            _wait_for_instance_profile(session, "arn:aws:iam::1:instance-profile/p")
+
+        assert ec2.run_instances.call_count == 1
+        sleep.assert_not_called()
+
+    def test_retries_while_the_profile_is_still_propagating(self, session):
+        """InvalidParameterValue is the propagation window; keep waiting."""
+        ec2 = session.client.return_value
+        ec2.run_instances.side_effect = [
+            _client_error("InvalidParameterValue"),
+            _client_error("InvalidParameterValue"),
+            _client_error("DryRunOperation"),
+        ]
+
+        with patch("parsl_ephemeral_aws.utils.aws.time.sleep") as sleep:
+            _wait_for_instance_profile(session, "arn:aws:iam::1:instance-profile/p")
+
+        assert ec2.run_instances.call_count == 3
+        assert sleep.call_count == 2
+
+    def test_dry_run_passes_the_profile_arn_to_ec2(self, session):
+        """The dry run must actually name the profile, or it checks nothing."""
+        ec2 = session.client.return_value
+        ec2.run_instances.side_effect = _client_error("DryRunOperation")
+
+        _wait_for_instance_profile(session, "arn:aws:iam::1:instance-profile/p")
+
+        kwargs = ec2.run_instances.call_args.kwargs
+        assert kwargs["IamInstanceProfile"] == {
+            "Arn": "arn:aws:iam::1:instance-profile/p"
+        }
+        assert kwargs["DryRun"] is True
+
+    def test_unrelated_errors_do_not_spin(self, session):
+        """An unusable AMI here is not what this check is for.
+
+        Retrying would burn the whole timeout on an error that will never clear;
+        the real launch is the right place to report it.
+        """
+        ec2 = session.client.return_value
+        ec2.run_instances.side_effect = _client_error("InvalidAMIID.NotFound")
+
+        with patch("parsl_ephemeral_aws.utils.aws.time.sleep") as sleep:
+            _wait_for_instance_profile(session, "arn:aws:iam::1:instance-profile/p")
+
+        assert ec2.run_instances.call_count == 1
+        sleep.assert_not_called()
+
+    def test_timeout_warns_rather_than_raising(self, session):
+        """A slow propagation must not become a hard failure.
+
+        The launch that follows reports the real error if there is one; raising
+        here would fail a profile that is about to start working. Sleep drives a
+        fake clock so the loop really does iterate and then give up -- a zero
+        timeout would skip the body and prove nothing about the retry path.
+        """
+        ec2 = session.client.return_value
+        ec2.run_instances.side_effect = _client_error("InvalidParameterValue")
+
+        clock = [1000.0]
+
+        def advance(seconds):
+            clock[0] += seconds
+
+        with (
+            patch(
+                "parsl_ephemeral_aws.utils.aws.time.time", side_effect=lambda: clock[0]
+            ),
+            patch("parsl_ephemeral_aws.utils.aws.time.sleep", side_effect=advance),
+        ):
+            _wait_for_instance_profile(
+                session, "arn:aws:iam::1:instance-profile/p", timeout=10
+            )
+
+        # It retried for the full window, then returned so the launch reports
+        # the real error itself.
+        assert ec2.run_instances.call_count == 5
+        assert clock[0] == 1010.0
 
 
 class TestStandardModeProfileResolution:

--- a/tests/unit/test_lambda_manager.py
+++ b/tests/unit/test_lambda_manager.py
@@ -1,0 +1,142 @@
+"""Unit tests for LambdaManager code generation and credential configuration.
+
+Every existing test patches ``_generate_lambda_code`` with a stub return value,
+so the real body had never run — and it raised ``ValueError`` on every call.
+These tests execute it.
+
+SPDX-License-Identifier: Apache-2.0
+SPDX-FileCopyrightText: 2025 Scott Friedman and Project Contributors
+"""
+
+import io
+import zipfile
+from types import SimpleNamespace
+
+import pytest
+
+from parsl_ephemeral_aws.compute.lambda_func import LambdaManager
+from parsl_ephemeral_aws.security.credential_manager import CredentialConfiguration
+
+
+pytestmark = pytest.mark.unit
+
+
+def _manager(**provider_attrs):
+    """Build a LambdaManager with only the attributes under test.
+
+    ``__init__`` pulls in the audit logger and credential manager, neither of
+    which is relevant here, so it is bypassed deliberately.
+    """
+    attrs = {"workflow_id": "test-workflow", "region": "us-east-1"}
+    attrs.update(provider_attrs)
+
+    manager = object.__new__(LambdaManager)
+    manager.provider = SimpleNamespace(**attrs)
+    return manager
+
+
+def _handler_source(command):
+    """Generate the Lambda payload and return the handler module source."""
+    payload = _manager()._generate_lambda_code(command)
+    return zipfile.ZipFile(io.BytesIO(payload)).read("handler.py").decode()
+
+
+class TestGeneratedLambdaCode:
+    """The handler is generated from a template; it has to be valid Python."""
+
+    def test_generated_handler_compiles(self):
+        """Regression: the template was an f-string, so its dict braces were
+        read as replacement fields and every call raised ValueError."""
+        compile(_handler_source("echo hello"), "handler.py", "exec")
+
+    def test_generated_handler_runs_the_command(self):
+        """The handler must actually execute the baked-in command."""
+        namespace = {}
+        exec(_handler_source("echo hello"), namespace)  # noqa: S102
+
+        response = namespace["main"]({}, None)
+
+        assert response["statusCode"] == 200
+        assert response["returncode"] == 0
+        assert response["stdout"].strip() == "hello"
+
+    def test_nonzero_exit_reports_500(self):
+        """A failing command must be distinguishable from a successful one."""
+        namespace = {}
+        exec(_handler_source("exit 3"), namespace)  # noqa: S102
+
+        response = namespace["main"]({}, None)
+
+        assert response["statusCode"] == 500
+        assert response["returncode"] == 3
+
+    def test_event_command_overrides_the_baked_in_default(self):
+        """The event payload takes precedence over the compiled-in command."""
+        namespace = {}
+        exec(_handler_source("echo baked"), namespace)  # noqa: S102
+
+        response = namespace["main"]({"command": "echo from-event"}, None)
+
+        assert response["stdout"].strip() == "from-event"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "echo hello",
+            "python -c \"print('hi')\"",
+            "echo 'single'",
+            'echo "double"',
+            "echo a\\nb",
+        ],
+    )
+    def test_quoting_in_the_command_survives(self, command):
+        """The command is embedded as a JSON literal, so quotes must round-trip."""
+        namespace = {}
+        exec(_handler_source(command), namespace)  # noqa: S102
+
+        assert namespace["DEFAULT_COMMAND"] == command
+
+    def test_payload_is_a_zip_containing_handler_py(self):
+        """Lambda expects a ZIP whose handler module matches the configured name."""
+        payload = _manager()._generate_lambda_code("echo hello")
+
+        assert zipfile.ZipFile(io.BytesIO(payload)).namelist() == ["handler.py"]
+
+
+class TestCredentialConfiguration:
+    """The credential config used field names the dataclass does not have."""
+
+    def test_credential_config_is_constructible(self):
+        """Regression: aws_access_key_id/aws_secret_access_key/aws_session_token
+        are not fields on CredentialConfiguration, so this raised TypeError."""
+        manager = _manager()
+        manager.security_config = SimpleNamespace(
+            environment=SimpleNamespace(value="dev")
+        )
+
+        config = manager._create_credential_config_from_provider()
+
+        assert isinstance(config, CredentialConfiguration)
+
+    def test_no_profile_is_invented_when_the_provider_has_none(self):
+        """It previously defaulted to a profile literally named "aws"."""
+        manager = _manager()
+        manager.security_config = SimpleNamespace(
+            environment=SimpleNamespace(value="dev")
+        )
+
+        config = manager._create_credential_config_from_provider()
+
+        assert config.use_profile is None
+
+    def test_production_environment_disables_ambient_credentials(self):
+        """Matches the behaviour of the other three compute managers."""
+        manager = _manager(aws_profile="aws", aws_access_key_id="AKIA0000000000000000")
+        manager.security_config = SimpleNamespace(
+            environment=SimpleNamespace(value="production")
+        )
+
+        config = manager._create_credential_config_from_provider()
+
+        assert config.use_environment_variables is False
+        assert config.use_profile is None

--- a/tests/unit/test_network_verification.py
+++ b/tests/unit/test_network_verification.py
@@ -1,0 +1,430 @@
+"""Unit tests for network-resource verification across all three modes.
+
+Since #69 the VPC, subnet, and security group are supplied by the caller and are
+never created by this package. Two places still behaved as though they could be
+conjured back:
+
+* ``_verify_resources()`` set the attribute to ``None`` when the describe call
+  came back NotFound, so that ``initialize()`` would rebuild it. Nothing rebuilds
+  it now, and the ``None`` travelled to ``run_instances`` to surface as an opaque
+  ``InvalidParameterValue`` with no mention of the resource that was actually
+  missing.
+* ``OperatingMode.load_state()`` restored these IDs unconditionally, so a state
+  document written before they were required could put ``None`` back over an ID
+  the constructor had just validated.
+
+SPDX-License-Identifier: Apache-2.0
+SPDX-FileCopyrightText: 2025 Scott Friedman and Project Contributors
+"""
+
+from unittest.mock import MagicMock, patch
+
+import boto3
+import pytest
+from botocore.exceptions import ClientError
+
+from parsl_ephemeral_aws.exceptions import ResourceNotFoundError
+from parsl_ephemeral_aws.modes.detached import DetachedMode
+from parsl_ephemeral_aws.modes.serverless import ServerlessMode
+from parsl_ephemeral_aws.modes.standard import StandardMode
+
+
+pytestmark = pytest.mark.unit
+
+NETWORK_IDS = {
+    "vpc_id": "vpc-12345",
+    "subnet_id": "subnet-12345",
+    "security_group_id": "sg-12345",
+}
+
+#: (attribute, describe method, NotFound code) for each network resource.
+RESOURCES = [
+    ("vpc_id", "describe_vpcs", "InvalidVpcID.NotFound"),
+    ("subnet_id", "describe_subnets", "InvalidSubnetID.NotFound"),
+    ("security_group_id", "describe_security_groups", "InvalidGroup.NotFound"),
+]
+
+#: EC2 reports a syntactically invalid ID with a distinct code rather than
+#: NotFound. Confirmed against real AWS: ``sg-00000000000000000`` gives
+#: ``InvalidGroupId.Malformed``, while a subnet or VPC ID of the same shape gives
+#: ``NotFound``. Both mean the supplied ID is unusable.
+MALFORMED = [
+    ("vpc_id", "describe_vpcs", "InvalidVpcID.Malformed"),
+    ("subnet_id", "describe_subnets", "InvalidSubnetId.Malformed"),
+    ("security_group_id", "describe_security_groups", "InvalidGroupId.Malformed"),
+]
+
+#: All three modes verify the same three resources with the same code, which is
+#: why the implementation now lives once on ``OperatingMode``. Each mode is still
+#: exercised separately -- the bug was three copies drifting, and a single
+#: inherited method is only an improvement if every mode really does inherit it.
+MODES = [StandardMode, DetachedMode, ServerlessMode]
+
+
+def _client_error(code, operation="DescribeVpcs"):
+    """Return a ClientError carrying *code*, as boto3 would raise it."""
+    return ClientError({"Error": {"Code": code, "Message": code}}, operation)
+
+
+@pytest.fixture
+def ec2():
+    """A mock EC2 client whose describe calls all succeed by default."""
+    client = MagicMock()
+    client.describe_vpcs.return_value = {"Vpcs": [{"VpcId": "vpc-12345"}]}
+    client.describe_subnets.return_value = {"Subnets": [{"SubnetId": "subnet-12345"}]}
+    client.describe_security_groups.return_value = {
+        "SecurityGroups": [{"GroupId": "sg-12345"}]
+    }
+    return client
+
+
+@pytest.fixture
+def session(ec2):
+    session = MagicMock(spec=boto3.Session)
+    session.region_name = "us-east-1"
+    session.client.return_value = ec2
+    return session
+
+
+@pytest.fixture
+def state_store():
+    store = MagicMock()
+    store.load_state.return_value = None
+    return store
+
+
+def _mode(mode_class, session, state_store, **overrides):
+    params = {
+        "provider_id": "test-provider",
+        "session": session,
+        "state_store": state_store,
+        "image_id": "ami-12345",
+        **NETWORK_IDS,
+    }
+    params.update(overrides)
+    return mode_class(**params)
+
+
+class TestVerifyResourcesRaisesOnMissingNetwork:
+    """A missing network resource must be named, not silently nulled."""
+
+    @pytest.mark.parametrize("mode_class", MODES, ids=lambda c: c.__name__)
+    @pytest.mark.parametrize("attribute,describe,code", RESOURCES, ids=lambda v: str(v))
+    def test_missing_resource_raises_and_names_it(
+        self, mode_class, attribute, describe, code, session, state_store, ec2
+    ):
+        """The ID and the attribute both appear in the message.
+
+        Previously this logged a warning and set the attribute to ``None``, so
+        the failure resurfaced later as ``InvalidParameterValue`` from inside
+        ``run_instances`` -- an error that names neither the resource nor the
+        reason.
+        """
+        mode = _mode(mode_class, session, state_store)
+        getattr(ec2, describe).side_effect = _client_error(code)
+
+        with pytest.raises(ResourceNotFoundError) as excinfo:
+            mode._verify_resources()
+
+        message = str(excinfo.value)
+        assert attribute in message
+        assert NETWORK_IDS[attribute] in message
+
+        # And the ID is left intact for the caller to inspect or correct.
+        assert getattr(mode, attribute) == NETWORK_IDS[attribute]
+
+    @pytest.mark.parametrize("mode_class", MODES, ids=lambda c: c.__name__)
+    @pytest.mark.parametrize("attribute,describe,code", MALFORMED, ids=lambda v: str(v))
+    def test_a_malformed_id_is_reported_the_same_way(
+        self, mode_class, attribute, describe, code, session, state_store, ec2
+    ):
+        """A typo'd ID is the same user error as a deleted one.
+
+        Only NotFound was matched at first, so a malformed ID escaped as a raw
+        ClientError from whichever describe happened to run -- found by feeding
+        a bogus ID to a real AWS account.
+        """
+        mode = _mode(mode_class, session, state_store)
+        getattr(ec2, describe).side_effect = _client_error(code)
+
+        with pytest.raises(ResourceNotFoundError) as excinfo:
+            mode._verify_resources()
+
+        assert attribute in str(excinfo.value)
+
+    @pytest.mark.parametrize("mode_class", MODES, ids=lambda c: c.__name__)
+    def test_the_error_code_is_read_not_string_matched(
+        self, mode_class, session, state_store, ec2
+    ):
+        """Matching must key off the code field, not the rendered message.
+
+        A resource whose *name* or ARN contains the text "InvalidVpcID.NotFound"
+        would otherwise be mistaken for a missing one, and the reverse: any
+        future change to botocore's message formatting would silently stop the
+        match. The code field is the contract.
+        """
+        mode = _mode(mode_class, session, state_store)
+        ec2.describe_vpcs.side_effect = ClientError(
+            {
+                "Error": {
+                    "Code": "RequestLimitExceeded",
+                    "Message": "throttled; unrelated to InvalidVpcID.NotFound",
+                }
+            },
+            "DescribeVpcs",
+        )
+
+        with pytest.raises(ClientError) as excinfo:
+            mode._verify_resources()
+
+        assert excinfo.value.response["Error"]["Code"] == "RequestLimitExceeded"
+
+    @pytest.mark.parametrize("mode_class", MODES, ids=lambda c: c.__name__)
+    def test_all_present_verifies_quietly(self, mode_class, session, state_store, ec2):
+        """The happy path checks all three and changes nothing."""
+        mode = _mode(mode_class, session, state_store)
+
+        mode._verify_resources()
+
+        ec2.describe_vpcs.assert_called_once_with(VpcIds=["vpc-12345"])
+        ec2.describe_subnets.assert_called_once_with(SubnetIds=["subnet-12345"])
+        ec2.describe_security_groups.assert_called_once_with(GroupIds=["sg-12345"])
+        for attribute, expected in NETWORK_IDS.items():
+            assert getattr(mode, attribute) == expected
+
+    @pytest.mark.parametrize("mode_class", MODES, ids=lambda c: c.__name__)
+    def test_unrelated_client_errors_propagate_unchanged(
+        self, mode_class, session, state_store, ec2
+    ):
+        """An auth or throttling failure is not a missing resource.
+
+        Reporting ``UnauthorizedOperation`` as ResourceNotFoundError would send
+        the caller looking for a VPC that is in fact right where they left it.
+        """
+        mode = _mode(mode_class, session, state_store)
+        ec2.describe_vpcs.side_effect = _client_error("UnauthorizedOperation")
+
+        with pytest.raises(ClientError) as excinfo:
+            mode._verify_resources()
+
+        assert excinfo.value.response["Error"]["Code"] == "UnauthorizedOperation"
+
+    @pytest.mark.parametrize("mode_class", MODES, ids=lambda c: c.__name__)
+    def test_the_vpc_is_checked_before_its_children(
+        self, mode_class, session, state_store, ec2
+    ):
+        """A deleted VPC is reported as such, not as a missing subnet.
+
+        Deleting a VPC takes its subnets and security groups with it, so all
+        three describes fail at once. Checking the VPC first means the message
+        names the cause rather than one of its consequences.
+        """
+        mode = _mode(mode_class, session, state_store)
+        for _, describe, code in RESOURCES:
+            getattr(ec2, describe).side_effect = _client_error(code)
+
+        with pytest.raises(ResourceNotFoundError) as excinfo:
+            mode._verify_resources()
+
+        assert "vpc_id" in str(excinfo.value)
+        ec2.describe_subnets.assert_not_called()
+        ec2.describe_security_groups.assert_not_called()
+
+    def test_lambda_only_serverless_has_nothing_to_verify(self, session, state_store):
+        """Lambda supplies its own networking, so no IDs means no describes.
+
+        ``require_network_resources=False`` lets this mode construct without
+        them; verification has to tolerate the same absence or the mode could
+        never initialize.
+        """
+        mode = ServerlessMode(
+            provider_id="test-provider",
+            session=session,
+            state_store=state_store,
+            worker_type="lambda",
+        )
+        assert mode.vpc_id is None
+
+        mode._verify_resources()
+
+        session.client.return_value.describe_vpcs.assert_not_called()
+
+
+class TestInitializeVerifiesOnBothPaths:
+    """Verification has to run on a first launch, not only on resume.
+
+    ``_verify_resources()`` was called from inside the ``if load_state():``
+    branch, so it only ever ran when a state document was already present. A
+    first-run provider -- the common case, and the only case for a fresh state
+    path -- never checked its network IDs at all. Found by pointing a real
+    provider at a deleted security group: nothing raised, because with no state
+    to load, the check was skipped entirely.
+    """
+
+    @pytest.mark.parametrize("mode_class", MODES, ids=lambda c: c.__name__)
+    def test_a_first_launch_verifies(self, mode_class, session, state_store, ec2):
+        """No state to load, and the VPC is gone: initialize() must still fail."""
+        mode = _mode(mode_class, session, state_store)
+        state_store.load_state.return_value = None
+        ec2.describe_vpcs.side_effect = _client_error("InvalidVpcID.NotFound")
+
+        with pytest.raises(Exception) as excinfo:
+            mode.initialize()
+
+        # Standard and detached wrap initialize() failures in
+        # ResourceCreationError; the cause is what identifies the defect.
+        assert isinstance(excinfo.value, ResourceNotFoundError) or isinstance(
+            excinfo.value.__cause__, ResourceNotFoundError
+        )
+
+    @pytest.mark.parametrize("mode_class", MODES, ids=lambda c: c.__name__)
+    def test_a_resume_verifies(self, mode_class, session, state_store, ec2):
+        """The path that always did verify must keep doing so."""
+        mode = _mode(mode_class, session, state_store)
+        state_store.load_state.return_value = {
+            "provider_id": "test-provider",
+            "resources": {},
+            "initialized": True,
+            **NETWORK_IDS,
+        }
+        ec2.describe_vpcs.side_effect = _client_error("InvalidVpcID.NotFound")
+
+        with pytest.raises(Exception) as excinfo:
+            mode.initialize()
+
+        assert isinstance(excinfo.value, ResourceNotFoundError) or isinstance(
+            excinfo.value.__cause__, ResourceNotFoundError
+        )
+
+
+class TestDetachedBastionVerification:
+    """Detached mode adds the bastion, which it *can* legitimately rebuild."""
+
+    def test_a_missing_bastion_is_cleared_not_raised(self, session, state_store, ec2):
+        """Unlike the network, the bastion belongs to this mode.
+
+        ``initialize()`` reads the cleared ``bastion_id`` as its signal to build
+        a replacement, so clearing it is correct here and raising would strand a
+        provider that could recover on its own.
+        """
+        mode = _mode(DetachedMode, session, state_store, bastion_host_type="ec2")
+        mode.bastion_id = "i-deadbeef"
+        ec2.describe_instances.side_effect = _client_error(
+            "InvalidInstanceID.NotFound", "DescribeInstances"
+        )
+
+        mode._verify_resources()
+
+        assert mode.bastion_id is None
+
+    def test_the_network_is_verified_before_the_bastion(
+        self, session, state_store, ec2
+    ):
+        """A missing VPC stops the check; the bastion is moot without one."""
+        mode = _mode(DetachedMode, session, state_store, bastion_host_type="ec2")
+        mode.bastion_id = "i-deadbeef"
+        ec2.describe_vpcs.side_effect = _client_error("InvalidVpcID.NotFound")
+
+        with pytest.raises(ResourceNotFoundError):
+            mode._verify_resources()
+
+        ec2.describe_instances.assert_not_called()
+        assert mode.bastion_id == "i-deadbeef"
+
+    def test_initialize_rebuilds_a_bastion_that_has_gone_away(
+        self, session, state_store, ec2
+    ):
+        """Resuming onto a dead bastion must recreate it, not carry on.
+
+        ``initialize()`` returned as soon as state loaded, so the ``bastion_id``
+        that ``_verify_resources()`` had just cleared was never acted on. The
+        provider came up "initialized" with no bastion, and every submitted job
+        went into an SSM parameter path that nothing was reading.
+        """
+        mode = _mode(DetachedMode, session, state_store, bastion_host_type="ec2")
+        mode.bastion_id = "i-gone"
+        ec2.describe_instances.side_effect = _client_error(
+            "InvalidInstanceID.NotFound", "DescribeInstances"
+        )
+
+        with (
+            patch.object(mode, "load_state", return_value=True),
+            patch.object(mode, "save_state"),
+            patch.object(
+                mode, "_create_bastion_direct", return_value="i-fresh"
+            ) as create,
+        ):
+            mode.initialize()
+
+        create.assert_called_once()
+        assert mode.bastion_id == "i-fresh"
+        assert mode.initialized is True
+
+    def test_a_live_bastion_is_left_alone_on_resume(self, session, state_store, ec2):
+        """The common resume path must not churn a perfectly good bastion."""
+        mode = _mode(DetachedMode, session, state_store, bastion_host_type="ec2")
+        mode.bastion_id = "i-alive"
+        ec2.describe_instances.return_value = {
+            "Reservations": [
+                {"Instances": [{"InstanceId": "i-alive", "State": {"Name": "running"}}]}
+            ]
+        }
+
+        with (
+            patch.object(mode, "load_state", return_value=True),
+            patch.object(mode, "_create_bastion_direct") as create,
+        ):
+            mode.initialize()
+
+        create.assert_not_called()
+        assert mode.bastion_id == "i-alive"
+
+
+class TestLoadStateNeverNullsAValidatedId:
+    """A stale state document must not undo constructor validation."""
+
+    @pytest.mark.parametrize("mode_class", MODES, ids=lambda c: c.__name__)
+    @pytest.mark.parametrize("attribute", list(NETWORK_IDS), ids=str)
+    def test_a_null_in_state_does_not_overwrite_the_configured_id(
+        self, mode_class, attribute, session, state_store
+    ):
+        """State written before #69 carries ``None`` for these fields.
+
+        The constructor value was validated; the null was not. Restoring it
+        would defer the failure to ``run_instances``, where it reads as a bad
+        parameter rather than as stale state.
+        """
+        mode = _mode(mode_class, session, state_store)
+        stale = {
+            "provider_id": "test-provider",
+            "resources": {},
+            "initialized": True,
+            **{name: None for name in NETWORK_IDS},
+        }
+        state_store.load_state.return_value = stale
+
+        assert mode.load_state() is True
+
+        for name, expected in NETWORK_IDS.items():
+            assert getattr(mode, name) == expected
+
+    @pytest.mark.parametrize("mode_class", MODES, ids=lambda c: c.__name__)
+    def test_a_populated_state_document_still_wins(
+        self, mode_class, session, state_store
+    ):
+        """Guarding against nulls must not stop legitimate restoration."""
+        mode = _mode(mode_class, session, state_store)
+        state_store.load_state.return_value = {
+            "provider_id": "test-provider",
+            "resources": {},
+            "initialized": True,
+            "vpc_id": "vpc-saved",
+            "subnet_id": "subnet-saved",
+            "security_group_id": "sg-saved",
+        }
+
+        assert mode.load_state() is True
+
+        assert mode.vpc_id == "vpc-saved"
+        assert mode.subnet_id == "subnet-saved"
+        assert mode.security_group_id == "sg-saved"

--- a/tests/unit/test_provider_edge_cases.py
+++ b/tests/unit/test_provider_edge_cases.py
@@ -951,6 +951,36 @@ class TestStateKeySeparation:
         assert second.provider_id == first.provider_id
         assert second.job_map == {"job-1": {"resource_id": "resource-1"}}
 
+    def test_the_id_is_adopted_from_mode_state_when_no_provider_state_exists(
+        self, tmp_dir
+    ):
+        """Only the mode key exists until a job is submitted.
+
+        The provider writes its own key from ``_save_state()``, which runs on
+        submit/status/cancel — so a provider that constructed and exited without
+        submitting leaves *only* the mode document behind. Adoption originally
+        read the provider key alone and found nothing, so the successor kept its
+        fresh UUID and ``OperatingMode.load_state()`` rejected the mode document
+        on the ID gate. Found against real AWS: a resumed provider silently took
+        the create path and never noticed its security group had been deleted.
+        """
+        state_file = os.path.join(tmp_dir, "mode-only.json")
+
+        first = self._provider_sharing(state_file)
+        mode = self._mode(first.provider_id, first.state_store)
+        mode.save_state()
+
+        # Only the mode key is present — exactly the no-submit case.
+        assert first.state_store.load_state(STATE_KEY_PROVIDER) is None
+        assert first.state_store.load_state(STATE_KEY_MODE) is not None
+
+        second = self._provider_sharing(state_file)
+
+        assert second.provider_id == first.provider_id
+        # And with the ID adopted, the mode's own load now clears its gate.
+        successor_mode = self._mode(second.provider_id, second.state_store)
+        assert successor_mode.load_state() is True
+
     def test_an_explicit_provider_id_is_never_overridden(self, tmp_dir):
         """A caller-supplied ID is a deliberate choice; adoption must skip it.
 

--- a/tests/unit/test_provider_edge_cases.py
+++ b/tests/unit/test_provider_edge_cases.py
@@ -366,9 +366,11 @@ class TestAMIBaking:
             security_group_id="sg-123",
         )
         # Run just the baking branch by calling initialize() with network already set
-        with patch.object(mode, "save_state"), patch.object(
-            mode, "load_state", return_value=False
-        ), patch.object(mode, "_verify_resources"):
+        with (
+            patch.object(mode, "save_state"),
+            patch.object(mode, "load_state", return_value=False),
+            patch.object(mode, "_verify_resources"),
+        ):
             mode.initialize()
 
         assert mode.image_id == "ami-prefab"
@@ -592,21 +594,37 @@ class TestOneShotMode:
 
     def test_one_shot_compatible_with_zero_warm_pool(self, tmp_dir):
         """one_shot=True with warm_pool_size=0 (default) constructs without error."""
-        provider, _ = _make_provider(tmp_dir, one_shot=True, warm_pool_size=0)
+        provider, _ = _make_provider(
+            tmp_dir,
+            one_shot=True,
+            warm_pool_size=0,
+            iam_instance_profile_arn=_FAKE_IAM_ARN,
+        )
         assert provider.one_shot is True
 
-    def test_one_shot_enforces_shutdown_in_init_script(self, tmp_dir):
-        """_prepare_init_script includes 'shutdown -h now' when one_shot=True, auto_shutdown=False."""
+    def test_one_shot_iam_guard_raises(self, tmp_dir):
+        """One-shot dispatches over SSM, so it needs an instance profile too."""
+        with pytest.raises(ValueError, match="one_shot=True requires"):
+            _make_provider(tmp_dir, one_shot=True)
+
+    def test_one_shot_iam_guard_passes_with_auto_create(self, tmp_dir):
+        """auto_create_instance_profile=True satisfies the one-shot IAM guard."""
+        provider, _ = _make_provider(
+            tmp_dir, one_shot=True, auto_create_instance_profile=True
+        )
+        assert provider.one_shot is True
+
+    def _one_shot_mode(self, tmp_dir, **overrides):
+        """Build a StandardMode with one_shot=True and a mocked session."""
         from parsl_ephemeral_aws.modes.standard import StandardMode
 
         provider_id = f"test-{uuid.uuid4().hex[:8]}"
         state_file = os.path.join(tmp_dir, f"{provider_id}.json")
         state_store = FileStateStore(file_path=state_file, provider_id=provider_id)
-        session_mock = MagicMock()
 
-        mode = StandardMode(
+        params = dict(
             provider_id=provider_id,
-            session=session_mock,
+            session=MagicMock(),
             state_store=state_store,
             image_id="ami-12345678",
             auto_shutdown=False,
@@ -615,6 +633,138 @@ class TestOneShotMode:
             subnet_id="subnet-test001",
             security_group_id="sg-test00001",
         )
+        params.update(overrides)
+        return StandardMode(**params)
+
+    def test_one_shot_dispatches_over_ssm_not_userdata(self, tmp_dir):
+        """One-shot uses SSM so the command's exit code is observable.
+
+        UserData cannot report an exit code — the instance state is identical
+        whether the command succeeded or failed (#76).
+        """
+        mode = self._one_shot_mode(tmp_dir)
+
+        assert mode._uses_ssm_dispatch() is True
 
         script = mode._prepare_init_script("echo hi", "job-1")
+        assert "echo hi" not in script
+        assert "/var/run/parsl_worker_ready" in script
+        # No UserData shutdown: it would race the SSM dispatch and kill the
+        # instance before the command was ever delivered.
+        assert "shutdown -h now" not in script
+
+    def test_one_shot_ssm_command_carries_shutdown_backstop(self, tmp_dir):
+        """The dispatched command shuts the instance down if the driver dies."""
+        mode = self._one_shot_mode(tmp_dir)
+        ssm = mode.session.client.return_value
+        ssm.send_command.return_value = {"Command": {"CommandId": "cmd-1"}}
+
+        mode._dispatch_ssm_command("i-123", "echo hi", "job-1")
+
+        script = ssm.send_command.call_args.kwargs["Parameters"]["commands"][0]
+        assert "echo hi" in script
         assert "shutdown -h now" in script
+        # The exit code is captured before the shutdown is scheduled, and
+        # re-raised, so a failing command still reports FAILED.
+        assert "_parsl_rc=$?" in script
+        assert "exit $_parsl_rc" in script
+
+    def test_non_one_shot_ssm_command_has_no_shutdown(self, tmp_dir):
+        """Warm-pool instances must survive the command for reuse."""
+        mode = self._one_shot_mode(
+            tmp_dir, one_shot=False, warm_pool_size=2, auto_shutdown=True
+        )
+        ssm = mode.session.client.return_value
+        ssm.send_command.return_value = {"Command": {"CommandId": "cmd-1"}}
+
+        mode._dispatch_ssm_command("i-123", "echo hi", "job-1")
+
+        script = ssm.send_command.call_args.kwargs["Parameters"]["commands"][0]
+        assert "shutdown" not in script
+
+    def test_instances_terminate_rather_than_stop_on_shutdown(self, tmp_dir):
+        """EC2 defaults an instance-initiated shutdown to *stop*, billing EBS.
+
+        Regression for #76: a stopped instance keeps a billed volume, and
+        EC2_STATUS_MAPPING maps "stopped" to COMPLETED, so the provider drops
+        the tracking record and the volume is orphaned as well as billed.
+        """
+        mode = self._one_shot_mode(tmp_dir)
+        ec2 = mode.session.client.return_value
+        ec2.run_instances.return_value = {"Instances": [{"InstanceId": "i-123"}]}
+
+        mode._create_instance("#!/bin/bash\n", "job-1")
+
+        run_args = ec2.run_instances.call_args.kwargs
+        assert run_args["InstanceInitiatedShutdownBehavior"] == "terminate"
+
+    def test_spot_launch_spec_omits_run_instances_only_keys(self, tmp_dir):
+        """RequestSpotInstances rejects RunInstances-only keys (#97).
+
+        ``run_args`` is built for ``run_instances`` and reused as the spot
+        ``LaunchSpecification``; boto3 validates parameter names client-side, so
+        leaving any of these in makes every spot request raise before it reaches
+        AWS.
+        """
+        mode = self._one_shot_mode(tmp_dir, use_spot=True)
+        ec2 = mode.session.client.return_value
+        ec2.request_spot_instances.return_value = {
+            "SpotInstanceRequests": [{"SpotInstanceRequestId": "sir-1"}]
+        }
+        ec2.describe_spot_instance_requests.return_value = {
+            "SpotInstanceRequests": [{"InstanceId": "i-123"}]
+        }
+
+        mode._create_instance("#!/bin/bash\n", "job-1")
+
+        spec = ec2.request_spot_instances.call_args.kwargs["LaunchSpecification"]
+        for key in ("MinCount", "MaxCount", "InstanceInitiatedShutdownBehavior"):
+            assert key not in spec, f"{key} is not valid in a LaunchSpecification"
+
+    def test_one_shot_status_comes_from_the_ssm_exit_code(self, tmp_dir):
+        """A non-zero exit must report FAILED, not COMPLETED."""
+        from parsl_ephemeral_aws.constants import STATUS_COMPLETED, STATUS_FAILED
+
+        mode = self._one_shot_mode(tmp_dir)
+        mode.resources["i-123"] = {
+            "type": "ec2",
+            "one_shot": True,
+            "ssm_command_id": "cmd-1",
+            "status": "RUNNING",
+        }
+        ssm = mode.session.client.return_value
+        ssm.get_command_invocation.return_value = {
+            "Status": "Failed",
+            "ResponseCode": 1,
+            "StandardErrorContent": "boom",
+        }
+
+        assert mode.get_job_status(["i-123"]) == {"i-123": STATUS_FAILED}
+        assert mode.resources["i-123"]["exit_code"] == 1
+
+        ssm.get_command_invocation.return_value = {
+            "Status": "Success",
+            "ResponseCode": 0,
+        }
+        assert mode.get_job_status(["i-123"]) == {"i-123": STATUS_COMPLETED}
+        assert mode.resources["i-123"]["exit_code"] == 0
+
+    def test_failed_dispatch_terminates_the_instance(self, tmp_dir):
+        """With no command in UserData there is nothing to fall back to.
+
+        Leaving the instance up would idle it until max_idle_time while
+        reporting RUNNING, so the submit fails loudly and the instance goes.
+        """
+        mode = self._one_shot_mode(tmp_dir)
+        mode.initialized = True
+        ec2 = mode.session.client.return_value
+        ec2.run_instances.return_value = {"Instances": [{"InstanceId": "i-123"}]}
+
+        with patch.object(
+            mode, "_wait_for_ssm_online", side_effect=RuntimeError("no SSM")
+        ):
+            with pytest.raises(Exception, match="no SSM"):
+                mode.submit_job(job_id="job-1", command="echo hi", tasks_per_node=1)
+
+        ec2.terminate_instances.assert_called_once_with(InstanceIds=["i-123"])
+        assert "i-123" not in mode.resources

--- a/tests/unit/test_provider_edge_cases.py
+++ b/tests/unit/test_provider_edge_cases.py
@@ -14,7 +14,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from parsl_ephemeral_aws.exceptions import ProviderError
+from parsl_ephemeral_aws.exceptions import ProviderConfigurationError, ProviderError
 from parsl_ephemeral_aws.provider import EphemeralAWSProvider
 from parsl_ephemeral_aws.state.base import STATE_KEY_MODE, STATE_KEY_PROVIDER
 from parsl_ephemeral_aws.state.file import FileStateStore
@@ -1020,3 +1020,167 @@ class TestStateKeySeparation:
         provider.shutdown()
 
         assert provider.state_store.load_state(STATE_KEY_PROVIDER) is None
+
+
+# ---------------------------------------------------------------------------
+# TestStandardOnlyOptionGuard
+# ---------------------------------------------------------------------------
+
+
+#: The options StandardMode alone implements, with a non-default value for each.
+#: ``_initialize_operating_mode()`` forwards them only on the STANDARD branch --
+#: correct -- but the provider acts on them regardless of mode, which is what
+#: makes the mismatch leak rather than merely no-op. See #80.
+STANDARD_ONLY_OPTIONS = [
+    ("warm_pool_size", 2),
+    ("warm_pool_ttl", 900),
+    ("bake_ami", True),
+    ("baked_ami_id", "ami-prebaked01"),
+    ("one_shot", True),
+]
+
+NON_STANDARD_MODES = ["detached", "serverless"]
+
+
+def _construct(mode, **extra_kwargs):
+    """Construct a provider in *mode*, with AWS and the operating mode mocked.
+
+    Unlike ``_make_provider`` this does not pin ``mode="standard"``, and it
+    patches ``initialize`` so construction does not reach AWS. The guard under
+    test runs in ``__init__`` before either the state store or the mode is
+    built, so nothing here can mask it.
+    """
+    with (
+        patch("parsl_ephemeral_aws.provider.create_session") as mock_session_factory,
+        patch.object(
+            EphemeralAWSProvider, "_initialize_state_store", return_value=MagicMock()
+        ),
+        patch.object(
+            EphemeralAWSProvider, "_initialize_operating_mode", return_value=MagicMock()
+        ),
+        patch.object(EphemeralAWSProvider, "_load_state", return_value=None),
+    ):
+        mock_session_factory.return_value = MagicMock()
+        return EphemeralAWSProvider(
+            region="us-east-1",
+            image_id="ami-12345678",
+            mode=mode,
+            vpc_id="vpc-test00001",
+            subnet_id="subnet-test001",
+            security_group_id="sg-test00001",
+            **extra_kwargs,
+        )
+
+
+@pytest.mark.unit
+class TestStandardOnlyOptionGuard:
+    """StandardMode-only options must be refused on other modes (#80)."""
+
+    @pytest.mark.parametrize("mode", NON_STANDARD_MODES)
+    @pytest.mark.parametrize("option,value", STANDARD_ONLY_OPTIONS)
+    def test_the_option_is_refused_on_a_non_standard_mode(self, mode, option, value):
+        """Each option, on each mode that cannot honour it, must raise.
+
+        Silently ignoring it is what #80 is about: with
+        ``mode="detached", warm_pool_size=2`` the provider tagged resources
+        ``warm_pool=True``, took the warm-pool branch in ``_cleanup_resources()``,
+        and set ``STATUS_WARM`` -- a status no other mode's
+        ``get_job_status()`` recognises -- so the instances were never cleaned
+        up and leaked with no error at all.
+        """
+        extra = {option: value}
+        # warm_pool_size and one_shot also trip the SSM IAM guard; supply a
+        # profile so a pass here cannot be the wrong guard firing.
+        extra["iam_instance_profile_arn"] = _FAKE_IAM_ARN
+
+        with pytest.raises(ProviderConfigurationError, match=option):
+            _construct(mode, **extra)
+
+    @pytest.mark.parametrize("option,value", STANDARD_ONLY_OPTIONS)
+    def test_the_option_is_accepted_on_standard_mode(self, option, value):
+        """The same option must still be accepted where it is implemented.
+
+        A guard that rejected these everywhere would pass the test above while
+        breaking the feature.
+        """
+        extra = {option: value, "iam_instance_profile_arn": _FAKE_IAM_ARN}
+
+        provider = _construct("standard", **extra)
+
+        assert getattr(provider, option) == value
+
+    @pytest.mark.parametrize("mode", NON_STANDARD_MODES)
+    def test_a_non_standard_mode_with_no_such_option_constructs(self, mode):
+        """The guard must not fire on the defaults.
+
+        Every provider passes through it, so a wrong comparison here would
+        break detached and serverless mode outright.
+        """
+        provider = _construct(mode)
+
+        assert provider.mode_type.value == mode
+
+    @pytest.mark.parametrize("mode", NON_STANDARD_MODES)
+    def test_explicitly_passing_a_default_is_not_refused(self, mode):
+        """Passing the documented default is a no-op, not a misconfiguration.
+
+        The guard compares against the default rather than testing presence, so
+        ``warm_pool_size=0`` -- which asks for nothing -- must be allowed.
+        """
+        provider = _construct(
+            mode,
+            warm_pool_size=0,
+            warm_pool_ttl=600,
+            bake_ami=False,
+            baked_ami_id=None,
+            one_shot=False,
+        )
+
+        assert provider.warm_pool_size == 0
+
+    def test_every_offending_option_is_named_at_once(self):
+        """The message must list all of them, not just the first found.
+
+        Reporting one at a time means a caller who set three fixes them one
+        construction at a time.
+        """
+        with pytest.raises(ProviderConfigurationError) as excinfo:
+            _construct(
+                "detached",
+                warm_pool_size=2,
+                bake_ami=True,
+                one_shot=True,
+                iam_instance_profile_arn=_FAKE_IAM_ARN,
+            )
+
+        message = str(excinfo.value)
+        for option in ("warm_pool_size", "bake_ami", "one_shot"):
+            assert option in message
+
+    def test_the_message_names_the_mode_that_was_asked_for(self):
+        """Naming the mode is what makes the error actionable."""
+        with pytest.raises(ProviderConfigurationError, match="serverless"):
+            _construct("serverless", bake_ami=True)
+
+    def test_the_mode_guard_precedes_the_ssm_iam_guard(self):
+        """Mode rejection must come first, or the error misdirects.
+
+        ``one_shot=True`` on detached mode with no IAM profile trips two guards.
+        The IAM one would tell the caller to set
+        ``auto_create_instance_profile`` -- which cannot help, because detached
+        mode does not implement one-shot at all.
+        """
+        with pytest.raises(ProviderConfigurationError, match="one_shot"):
+            _construct("detached", one_shot=True)
+
+    def test_a_standard_only_option_does_not_leak_through_kwargs(self):
+        """The guard must catch the option itself, not just the named parameter.
+
+        All five are real ``__init__`` parameters today, so this is a
+        regression fence: were one ever demoted to ``**kwargs`` it would reach
+        the mode silently again.
+        """
+        with pytest.raises(ProviderConfigurationError, match="warm_pool_size"):
+            _construct(
+                "detached", warm_pool_size=1, iam_instance_profile_arn=_FAKE_IAM_ARN
+            )

--- a/tests/unit/test_provider_edge_cases.py
+++ b/tests/unit/test_provider_edge_cases.py
@@ -16,6 +16,7 @@ import pytest
 
 from parsl_ephemeral_aws.exceptions import ProviderError
 from parsl_ephemeral_aws.provider import EphemeralAWSProvider
+from parsl_ephemeral_aws.state.base import STATE_KEY_MODE, STATE_KEY_PROVIDER
 from parsl_ephemeral_aws.state.file import FileStateStore
 
 
@@ -456,13 +457,16 @@ class TestAMIBaking:
         mode._owns_baked_ami = True
 
         saved = {}
+        keys_written = []
 
-        def _capture_state(state):
+        def _capture_state(state_key, state):
+            keys_written.append(state_key)
             saved.update(state)
 
         with patch.object(state_store, "save_state", side_effect=_capture_state):
             mode.save_state()
 
+        assert keys_written == [STATE_KEY_MODE]
         assert saved.get("baked_ami_id") == "ami-saved001"
         assert saved.get("owns_baked_ami") is True
 
@@ -768,3 +772,221 @@ class TestOneShotMode:
 
         ec2.terminate_instances.assert_called_once_with(InstanceIds=["i-123"])
         assert "i-123" not in mode.resources
+
+
+# ---------------------------------------------------------------------------
+# TestStateKeySeparation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestStateKeySeparation:
+    """The provider and its mode must not overwrite each other's state (#78)."""
+
+    @pytest.fixture
+    def tmp_dir(self):
+        with tempfile.TemporaryDirectory() as d:
+            yield d
+
+    @staticmethod
+    def _mode(provider_id, state_store):
+        """Return a StandardMode sharing *state_store* with the provider."""
+        from parsl_ephemeral_aws.modes.standard import StandardMode
+
+        return StandardMode(
+            provider_id=provider_id,
+            session=MagicMock(),
+            state_store=state_store,
+            image_id="ami-base",
+            vpc_id="vpc-test00001",
+            subnet_id="subnet-test001",
+            security_group_id="sg-test00001",
+        )
+
+    def test_provider_and_mode_writes_coexist(self, tmp_dir):
+        """A mode write must not destroy job_map, nor a provider write the baked AMI.
+
+        Both writers previously issued full-document overwrites into one slot, so
+        whichever went last erased the other's fields: the baked AMI ID (leaking
+        the AMI and its snapshots, since cleanup could no longer see it) or
+        job_map (losing the job-to-resource mapping across restart).
+        """
+        provider, _ = _make_provider(tmp_dir)
+        state_store = provider.state_store
+        mode = self._mode(provider.provider_id, state_store)
+        mode._baked_ami_id = "ami-baked001"
+        mode._owns_baked_ami = True
+
+        mode.save_state()
+        provider.job_map["job-1"] = "resource-1"
+        provider._save_state()
+        # A second mode write is the point at which the provider's fields used
+        # to disappear.
+        mode.save_state()
+
+        mode_state = state_store.load_state(STATE_KEY_MODE)
+        provider_state = state_store.load_state(STATE_KEY_PROVIDER)
+
+        assert mode_state["baked_ami_id"] == "ami-baked001"
+        assert mode_state["owns_baked_ami"] is True
+        assert provider_state["job_map"] == {"job-1": "resource-1"}
+
+    def test_both_writers_survive_a_round_trip(self, tmp_dir):
+        """Reloading restores the mode's baked AMI and the provider's job_map."""
+        provider, _ = _make_provider(tmp_dir)
+        state_store = provider.state_store
+        mode = self._mode(provider.provider_id, state_store)
+        mode._baked_ami_id = "ami-baked001"
+        mode._owns_baked_ami = True
+        mode.initialized = True
+
+        mode.save_state()
+        provider.job_map["job-1"] = "resource-1"
+        provider._save_state()
+
+        # A fresh mode and provider reading the same file, as after a restart.
+        reloaded_mode = self._mode(provider.provider_id, state_store)
+        assert reloaded_mode.load_state() is True
+        assert reloaded_mode._baked_ami_id == "ami-baked001"
+        assert reloaded_mode._owns_baked_ami is True
+        assert reloaded_mode.image_id == "ami-baked001"
+
+        provider.job_map.clear()
+        provider._load_state()
+        assert provider.job_map == {"job-1": "resource-1"}
+
+    def test_mode_load_ignores_the_provider_document(self, tmp_dir):
+        """The mode must not pick up the provider's document as its own.
+
+        The provider writes provider_id too, so an unkeyed read would match the
+        mode's own provider_id check and load the wrong shape.
+        """
+        provider, _ = _make_provider(tmp_dir)
+        provider.job_map["job-1"] = "resource-1"
+        provider._save_state()
+
+        mode = self._mode(provider.provider_id, provider.state_store)
+        assert mode.load_state() is False
+        assert mode.initialized is False
+
+    def test_shutdown_deletes_both_documents(self, tmp_dir):
+        """shutdown() must delete both keys, not save an empty document.
+
+        ``delete_state`` was implemented in all three stores and the ABC but
+        called from nowhere; shutdown wrote an empty document instead, which on
+        the AWS backends left SSM parameters and S3 objects behind and on any
+        backend left a document describing resources that no longer exist.
+        """
+        provider, _ = _make_provider(tmp_dir)
+        state_store = provider.state_store
+        mode = self._mode(provider.provider_id, state_store)
+        mode._baked_ami_id = "ami-baked001"
+
+        mode.save_state()
+        provider.job_map["job-1"] = "resource-1"
+        provider._save_state()
+        assert state_store.load_state(STATE_KEY_MODE) is not None
+        assert state_store.load_state(STATE_KEY_PROVIDER) is not None
+
+        # The provider's operating_mode is a MagicMock, so route the mode
+        # deletion at the real store the way the live mode would.
+        provider.operating_mode.delete_state.side_effect = mode.delete_state
+
+        provider.shutdown()
+
+        assert state_store.load_state(STATE_KEY_MODE) is None
+        assert state_store.load_state(STATE_KEY_PROVIDER) is None
+
+    @staticmethod
+    def _provider_sharing(state_file, **extra):
+        """Build a provider at *state_file* without passing a provider_id.
+
+        ``_make_provider`` always supplies one, which is exactly the case that
+        skips adoption — so restart has to be modelled with a provider that lets
+        the ID default, as a real successor process would.
+        """
+        with (
+            patch(
+                "parsl_ephemeral_aws.provider.create_session"
+            ) as mock_session_factory,
+            patch.object(
+                EphemeralAWSProvider,
+                "_initialize_operating_mode",
+                return_value=MagicMock(),
+            ),
+        ):
+            mock_session_factory.return_value = MagicMock()
+            return EphemeralAWSProvider(
+                region="us-east-1",
+                image_id="ami-12345678",
+                instance_type="t3.micro",
+                mode="standard",
+                state_store_type="file",
+                state_file_path=state_file,
+                min_blocks=0,
+                init_blocks=0,
+                vpc_id="vpc-test00001",
+                subnet_id="subnet-test001",
+                security_group_id="sg-test00001",
+                **extra,
+            )
+
+    def test_a_successor_provider_loads_state_from_the_same_path(self, tmp_dir):
+        """Restart must restore job_map given nothing but a shared state path.
+
+        Two independent defects made this impossible: ``_load_state()`` was
+        never called from ``__init__`` at all, and it refuses a document whose
+        ``provider_id`` differs from its own -- while ``provider_id`` defaults to
+        a fresh UUID and does not affect *where* state is stored. So a successor
+        rejected the very state it was pointed at.
+        """
+        state_file = os.path.join(tmp_dir, "shared.json")
+
+        first = self._provider_sharing(state_file)
+        first.job_map["job-1"] = {"resource_id": "resource-1"}
+        first._save_state()
+
+        second = self._provider_sharing(state_file)
+
+        assert second.provider_id == first.provider_id
+        assert second.job_map == {"job-1": {"resource_id": "resource-1"}}
+
+    def test_an_explicit_provider_id_is_never_overridden(self, tmp_dir):
+        """A caller-supplied ID is a deliberate choice; adoption must skip it.
+
+        Otherwise a provider asked for a specific identity would silently answer
+        to whichever ID happened to be sitting at that state location.
+        """
+        state_file = os.path.join(tmp_dir, "shared.json")
+
+        first = self._provider_sharing(state_file)
+        first._save_state()
+
+        second = self._provider_sharing(state_file, provider_id="explicit-id")
+
+        assert second.provider_id == "explicit-id"
+        # And it declines the other provider's state rather than adopting it.
+        assert second.job_map == {}
+
+    def test_a_fresh_path_leaves_the_generated_id_alone(self, tmp_dir):
+        """With nothing persisted there is no ID to adopt and no state to load."""
+        provider = self._provider_sharing(os.path.join(tmp_dir, "empty.json"))
+
+        assert provider.provider_id
+        assert provider.job_map == {}
+
+    def test_shutdown_survives_a_mode_without_delete_state(self, tmp_dir):
+        """A mode that predates delete_state must not break shutdown.
+
+        ``_delete_state`` guards with ``callable(getattr(...))``; without it a
+        third-party mode -- or a test double built with ``spec=`` -- would turn
+        shutdown into an error path.
+        """
+        provider, _ = _make_provider(tmp_dir)
+        provider.job_map["job-1"] = "resource-1"
+        provider._save_state()
+        del provider.operating_mode.delete_state
+
+        provider.shutdown()
+
+        assert provider.state_store.load_state(STATE_KEY_PROVIDER) is None

--- a/tests/unit/test_serverless_mode.py
+++ b/tests/unit/test_serverless_mode.py
@@ -10,6 +10,7 @@ import boto3
 import time
 
 from parsl_ephemeral_aws.modes.serverless import ServerlessMode
+from parsl_ephemeral_aws.state.base import STATE_KEY_MODE
 from parsl_ephemeral_aws.exceptions import (
     JobSubmissionError,
 )
@@ -785,8 +786,11 @@ class TestServerlessMode:
         # Verify state_store.save_state was called
         mock_state_store.save_state.assert_called_once()
 
+        # The mode writes its own state key, so the provider's document survives
+        state_key, state = mock_state_store.save_state.call_args[0]
+        assert state_key == STATE_KEY_MODE
+
         # Verify state content
-        state = mock_state_store.save_state.call_args[0][0]
         assert state["provider_id"] == "test-provider"
         assert state["mode"] == "ServerlessMode"
         assert state["vpc_id"] == "vpc-12345"

--- a/tests/unit/test_serverless_mode.py
+++ b/tests/unit/test_serverless_mode.py
@@ -247,7 +247,8 @@ class TestServerlessMode:
         assert mode.vpc_id == "vpc-12345"
         assert mode.subnet_id == "subnet-12345"
         assert mode.security_group_id == "sg-12345"
-        assert mode.create_vpc is False
+        # ECSManager reads subnet_ids in preference to subnet_id
+        assert mode.subnet_ids == ["subnet-12345"]
 
     def test_initialize_lambda_only(self, serverless_mode):
         """Test initialize method for Lambda-only mode."""

--- a/tests/unit/test_serverless_mode_contract.py
+++ b/tests/unit/test_serverless_mode_contract.py
@@ -1,0 +1,263 @@
+"""Unit tests for the ServerlessMode ↔ compute-manager contract and network guard.
+
+These cover the repair of a mode that had never successfully constructed: the
+manager contract (#72), the parameters lost between provider and mode (#73), and
+the network guard that demanded IDs Lambda has no use for (#74).
+
+SPDX-License-Identifier: Apache-2.0
+SPDX-FileCopyrightText: 2025 Scott Friedman and Project Contributors
+"""
+
+from unittest.mock import MagicMock
+
+import boto3
+import pytest
+
+from parsl_ephemeral_aws.constants import (
+    WORKER_TYPE_AUTO,
+    WORKER_TYPE_ECS,
+    WORKER_TYPE_LAMBDA,
+)
+from parsl_ephemeral_aws.exceptions import ConfigurationError
+from parsl_ephemeral_aws.modes.serverless import ServerlessMode
+
+
+pytestmark = pytest.mark.unit
+
+NETWORK_IDS = {
+    "vpc_id": "vpc-12345",
+    "subnet_id": "subnet-12345",
+    "security_group_id": "sg-12345",
+}
+
+
+@pytest.fixture
+def mock_session():
+    """A mock boto3 session."""
+    session = MagicMock(spec=boto3.Session)
+    session.region_name = "us-east-1"
+    return session
+
+
+@pytest.fixture
+def mock_state_store():
+    """A mock state store that reports no persisted state."""
+    store = MagicMock()
+    store.load_state.return_value = None
+    return store
+
+
+def _mode(mock_session, mock_state_store, **overrides):
+    """Construct a ServerlessMode with the supplied overrides."""
+    params = {
+        "provider_id": "test-provider",
+        "session": mock_session,
+        "state_store": mock_state_store,
+        "region": "us-east-1",
+    }
+    params.update(overrides)
+    return ServerlessMode(**params)
+
+
+class TestManagerContract:
+    """LambdaManager and ECSManager are handed the mode as their `provider`."""
+
+    # The attributes both managers read off their `provider`. Missing
+    # `workflow_id` made every construction raise AttributeError.
+    REQUIRED_ATTRS = (
+        "workflow_id",
+        "aws_access_key_id",
+        "aws_secret_access_key",
+        "aws_session_token",
+        "aws_profile",
+        "security_config",
+        "use_spot_instances",
+        "subnet_ids",
+        "region",
+    )
+
+    @pytest.mark.parametrize("attr", REQUIRED_ATTRS)
+    def test_manager_contract_attribute_present(
+        self, mock_session, mock_state_store, attr
+    ):
+        """Every attribute the managers read must exist on the mode."""
+        mode = _mode(
+            mock_session, mock_state_store, worker_type=WORKER_TYPE_AUTO, **NETWORK_IDS
+        )
+        assert hasattr(mode, attr), f"managers read provider.{attr}"
+
+    def test_workflow_id_matches_provider_id(self, mock_session, mock_state_store):
+        """`workflow_id` names IAM roles and clusters; it tracks the provider ID."""
+        mode = _mode(
+            mock_session, mock_state_store, worker_type=WORKER_TYPE_AUTO, **NETWORK_IDS
+        )
+        assert mode.workflow_id == mode.provider_id == "test-provider"
+
+    def test_subnet_ids_derived_from_subnet_id(self, mock_session, mock_state_store):
+        """ECSManager prefers a `subnet_ids` list over the singular ID."""
+        mode = _mode(
+            mock_session, mock_state_store, worker_type=WORKER_TYPE_ECS, **NETWORK_IDS
+        )
+        assert mode.subnet_ids == ["subnet-12345"]
+
+    def test_subnet_ids_is_none_without_a_subnet(self, mock_session, mock_state_store):
+        """Lambda-only mode has no subnet, so the list stays unset rather than [None]."""
+        mode = _mode(mock_session, mock_state_store, worker_type=WORKER_TYPE_LAMBDA)
+        assert mode.subnet_ids is None
+
+    def test_use_spot_instances_tracks_use_spot(self, mock_session, mock_state_store):
+        """ECSManager reads `use_spot_instances` to request Fargate Spot."""
+        mode = _mode(
+            mock_session,
+            mock_state_store,
+            worker_type=WORKER_TYPE_ECS,
+            use_spot=True,
+            **NETWORK_IDS,
+        )
+        assert mode.use_spot_instances is True
+
+
+class TestConditionalNetworkGuard:
+    """Lambda needs no network IDs; ECS and auto do."""
+
+    def test_lambda_constructs_without_network_ids(
+        self, mock_session, mock_state_store
+    ):
+        """Lambda functions run in the Lambda-managed VPC — nothing to supply."""
+        mode = _mode(mock_session, mock_state_store, worker_type=WORKER_TYPE_LAMBDA)
+
+        assert mode.require_network_resources is False
+        assert mode.vpc_id is None
+
+    @pytest.mark.parametrize("worker_type", [WORKER_TYPE_ECS, WORKER_TYPE_AUTO])
+    def test_ecs_and_auto_require_network_ids(
+        self, mock_session, mock_state_store, worker_type
+    ):
+        """Fargate's awsvpcConfiguration is mandatory, so the IDs are too."""
+        with pytest.raises(
+            ValueError, match="vpc_id, subnet_id, and security_group_id"
+        ):
+            _mode(mock_session, mock_state_store, worker_type=worker_type)
+
+    def test_invalid_worker_type_reported_before_network_guard(
+        self, mock_session, mock_state_store
+    ):
+        """A bad worker type is the real error even when IDs are also absent."""
+        with pytest.raises(ConfigurationError, match="worker_type"):
+            _mode(mock_session, mock_state_store, worker_type="bogus")
+
+
+class TestProviderParameterPlumbing:
+    """`compute_type`, `memory_size`, and `timeout` used to vanish into **kwargs."""
+
+    @pytest.mark.parametrize(
+        "compute_type,expected",
+        [("lambda", WORKER_TYPE_LAMBDA), ("LAMBDA", WORKER_TYPE_LAMBDA)],
+    )
+    def test_compute_type_maps_to_worker_type(
+        self, mock_session, mock_state_store, compute_type, expected
+    ):
+        """The provider's `compute_type` is the outward name for `worker_type`."""
+        mode = _mode(mock_session, mock_state_store, compute_type=compute_type)
+        assert mode.worker_type == expected
+
+    def test_compute_type_enum_member_is_unwrapped(
+        self, mock_session, mock_state_store
+    ):
+        """It arrives as a ComputeType, whose str() is the qualified name."""
+        from parsl_ephemeral_aws.provider import ComputeType
+
+        mode = _mode(mock_session, mock_state_store, compute_type=ComputeType.LAMBDA)
+        assert mode.worker_type == WORKER_TYPE_LAMBDA
+
+    def test_compute_type_ec2_is_treated_as_unset(self, mock_session, mock_state_store):
+        """ "ec2" is the provider-wide default and means nothing here."""
+        mode = _mode(mock_session, mock_state_store, compute_type="ec2", **NETWORK_IDS)
+        assert mode.worker_type == WORKER_TYPE_AUTO
+
+    def test_memory_size_overrides_lambda_memory(self, mock_session, mock_state_store):
+        """`memory_size` is the provider-facing name for `lambda_memory`."""
+        mode = _mode(
+            mock_session,
+            mock_state_store,
+            worker_type=WORKER_TYPE_LAMBDA,
+            lambda_memory=1024,
+            memory_size=512,
+        )
+        assert mode.lambda_memory == 512
+
+    def test_timeout_overrides_lambda_timeout(self, mock_session, mock_state_store):
+        """`timeout` is the provider-facing name for `lambda_timeout`."""
+        mode = _mode(
+            mock_session,
+            mock_state_store,
+            worker_type=WORKER_TYPE_LAMBDA,
+            lambda_timeout=300,
+            timeout=120,
+        )
+        assert mode.lambda_timeout == 120
+
+    def test_native_names_survive_when_no_override_supplied(
+        self, mock_session, mock_state_store
+    ):
+        """Absent the provider-facing aliases, the native values stand."""
+        mode = _mode(
+            mock_session,
+            mock_state_store,
+            worker_type=WORKER_TYPE_LAMBDA,
+            lambda_memory=1024,
+            lambda_timeout=300,
+        )
+        assert (mode.lambda_memory, mode.lambda_timeout) == (1024, 300)
+
+
+class TestNetworkResourcesAreNeverCreated:
+    """#69 removed VPC creation; serverless kept a CloudFormation copy of it."""
+
+    @pytest.mark.parametrize(
+        "helper", ["_create_vpc", "_create_subnet", "_create_security_group"]
+    )
+    def test_creation_helpers_are_gone(self, helper):
+        """The mode must offer no way to create network resources."""
+        assert not hasattr(ServerlessMode, helper)
+
+    def test_create_vpc_parameter_is_gone(self, mock_session, mock_state_store):
+        """`create_vpc` is no longer a knob, so it must not linger as an attribute."""
+        mode = _mode(mock_session, mock_state_store, worker_type=WORKER_TYPE_LAMBDA)
+        assert not hasattr(mode, "create_vpc")
+
+    def test_cleanup_infrastructure_leaves_the_security_group_alone(
+        self, mock_session, mock_state_store
+    ):
+        """The SG belongs to the caller; deleting it was destroying user resources."""
+        mode = _mode(
+            mock_session, mock_state_store, worker_type=WORKER_TYPE_ECS, **NETWORK_IDS
+        )
+        ec2 = mock_session.client("ec2")
+        ec2.reset_mock()
+
+        mode.cleanup_infrastructure()
+
+        ec2.delete_security_group.assert_not_called()
+        assert mode.security_group_id == "sg-12345"
+
+
+class TestInitializedFlag:
+    """`initialize()` never set the flag, so every submit re-ran it."""
+
+    def test_initialize_sets_the_flag(self, mock_session, mock_state_store):
+        """A successful initialize must be observable, and therefore idempotent."""
+        mode = _mode(mock_session, mock_state_store, worker_type=WORKER_TYPE_LAMBDA)
+        assert mode.initialized is False
+
+        mode.lambda_manager = MagicMock()
+        mode._initialize_compute_managers = MagicMock()
+
+        mode.initialize()
+
+        assert mode.initialized is True
+        mode._initialize_compute_managers.assert_called_once()
+
+        # A second call is a no-op rather than a repeat of the work.
+        mode.initialize()
+        mode._initialize_compute_managers.assert_called_once()

--- a/tests/unit/test_standard_mode.py
+++ b/tests/unit/test_standard_mode.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch, call
 import boto3
 
 from parsl_ephemeral_aws.modes.standard import StandardMode
+from parsl_ephemeral_aws.state.base import STATE_KEY_MODE
 from parsl_ephemeral_aws.exceptions import (
     OperatingModeError,
     ResourceCreationError,
@@ -439,8 +440,11 @@ class TestStandardMode:
         # Verify state_store.save_state was called
         mock_state_store.save_state.assert_called_once()
 
+        # The mode writes its own state key, so the provider's document survives
+        state_key, state = mock_state_store.save_state.call_args[0]
+        assert state_key == STATE_KEY_MODE
+
         # Verify state content
-        state = mock_state_store.save_state.call_args[0][0]
         assert state["provider_id"] == "test-provider"
         assert state["mode"] == "StandardMode"
         assert state["vpc_id"] == "vpc-12345"

--- a/tests/unit/test_state_error_handling.py
+++ b/tests/unit/test_state_error_handling.py
@@ -14,10 +14,16 @@ import pytest
 from unittest.mock import MagicMock, patch
 from botocore.exceptions import ClientError
 
+from parsl_ephemeral_aws.state.base import STATE_KEY_MODE, STATE_KEY_PROVIDER
 from parsl_ephemeral_aws.state.file import FileStateStore
 from parsl_ephemeral_aws.state.parameter_store import ParameterStoreState
 from parsl_ephemeral_aws.state.s3 import S3State
-from parsl_ephemeral_aws.exceptions import StateError, StateDeserializationError
+from parsl_ephemeral_aws.exceptions import (
+    StateDeserializationError,
+    StateError,
+    StateSerializationError,
+    StateStoreError,
+)
 
 
 class TestFileStateStoreErrorHandling:
@@ -45,8 +51,10 @@ class TestFileStateStoreErrorHandling:
     def test_save_state_permission_error(self, file_state_store, test_state):
         """Test handling permission error when saving state."""
         with patch("builtins.open", side_effect=PermissionError("Permission denied")):
-            with pytest.raises(StateError) as exc_info:
-                file_state_store.save_state(test_state)
+            # StateStoreError, not the StateError subclass: an unwritable file is
+            # a store failure, and file.py has always raised the parent.
+            with pytest.raises(StateStoreError) as exc_info:
+                file_state_store.save_state(STATE_KEY_PROVIDER, test_state)
 
             assert "Permission denied" in str(exc_info.value)
 
@@ -60,7 +68,7 @@ class TestFileStateStoreErrorHandling:
 
         # Should create directories and save successfully
         test_state = {"key": "value"}
-        file_store.save_state(test_state)
+        file_store.save_state(STATE_KEY_PROVIDER, test_state)
 
         # Verify file was created
         assert os.path.exists(nested_path)
@@ -68,12 +76,12 @@ class TestFileStateStoreErrorHandling:
         # Verify content
         with open(nested_path, "r") as f:
             saved_state = json.load(f)
-            assert saved_state == test_state
+            assert saved_state["_states"][STATE_KEY_PROVIDER] == test_state
 
     def test_load_state_file_not_found(self, file_state_store):
         """Test handling file not found when loading state."""
         # File doesn't exist yet
-        state = file_state_store.load_state()
+        state = file_state_store.load_state(STATE_KEY_PROVIDER)
 
         # Should return None, not raise an exception
         assert state is None
@@ -86,14 +94,14 @@ class TestFileStateStoreErrorHandling:
 
         # Should raise StateDeserializationError
         with pytest.raises(StateDeserializationError) as exc_info:
-            file_state_store.load_state()
+            file_state_store.load_state(STATE_KEY_PROVIDER)
 
         assert "Failed to deserialize state" in str(exc_info.value)
 
     def test_delete_state_file_not_found(self, file_state_store):
         """Test handling file not found when deleting state."""
         # File doesn't exist yet
-        file_state_store.delete_state()
+        file_state_store.delete_state(STATE_KEY_PROVIDER)
 
         # Should not raise an exception
         assert not os.path.exists(file_state_store.file_path)
@@ -101,17 +109,17 @@ class TestFileStateStoreErrorHandling:
     def test_delete_state_permission_error(self, file_state_store, test_state):
         """Test handling permission error when deleting state."""
         # Save state first
-        file_state_store.save_state(test_state)
+        file_state_store.save_state(STATE_KEY_PROVIDER, test_state)
 
         # Mock permission error on unlink
         with patch("os.remove", side_effect=PermissionError("Permission denied")):
-            with pytest.raises(StateError) as exc_info:
-                file_state_store.delete_state()
+            with pytest.raises(StateStoreError) as exc_info:
+                file_state_store.delete_state(STATE_KEY_PROVIDER)
 
             assert "Permission denied" in str(exc_info.value)
 
     def test_concurrent_write_scenario(self, temp_dir):
-        """Test a scenario mimicking concurrent writes."""
+        """Test a scenario mimicking concurrent writes to the same state key."""
         file_path = os.path.join(temp_dir, "shared_state.json")
 
         # Create two separate state store instances for the same file
@@ -120,16 +128,139 @@ class TestFileStateStoreErrorHandling:
 
         # First store saves state
         state1 = {"owner": "provider1", "data": [1, 2, 3]}
-        store1.save_state(state1)
+        store1.save_state(STATE_KEY_PROVIDER, state1)
 
         # Second store overwrites with its state
         state2 = {"owner": "provider2", "data": [4, 5, 6]}
-        store2.save_state(state2)
+        store2.save_state(STATE_KEY_PROVIDER, state2)
 
-        # Verify final state is from store2
-        loaded_state = store1.load_state()
+        # Verify final state is from store2 — sharing a path and a key means
+        # sharing a slot, which is what makes state hand-off possible.
+        loaded_state = store1.load_state(STATE_KEY_PROVIDER)
         assert loaded_state["owner"] == "provider2"
         assert loaded_state["data"] == [4, 5, 6]
+
+
+class TestFileStateStoreKeying:
+    """Tests for the keyed state interface in FileStateStore (#77, #78)."""
+
+    @pytest.fixture
+    def state_path(self):
+        """Path to a state file inside a temporary directory."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            yield os.path.join(tmp_dir, "state.json")
+
+    @pytest.fixture
+    def store(self, state_path):
+        """Create a FileStateStore instance."""
+        return FileStateStore(state_path, "test-provider")
+
+    def test_keys_do_not_clobber_each_other(self, store):
+        """Writing one key leaves the other key's document untouched (#78).
+
+        This is the regression: the provider and the mode persist different
+        field sets, and a full-document overwrite from either destroyed the
+        other's fields — the baked AMI ID and warm pool, or job_map.
+        """
+        mode_state = {"baked_ami_id": "ami-baked", "owns_baked_ami": True}
+        provider_state = {"job_map": {"job-1": "res-1"}}
+
+        store.save_state(STATE_KEY_MODE, mode_state)
+        store.save_state(STATE_KEY_PROVIDER, provider_state)
+        # A second mode write is where the provider's fields used to vanish.
+        store.save_state(STATE_KEY_MODE, mode_state)
+
+        assert store.load_state(STATE_KEY_MODE) == mode_state
+        assert store.load_state(STATE_KEY_PROVIDER) == provider_state
+
+    def test_missing_key_returns_none(self, store):
+        """A key that was never written reads back as None, not as another key."""
+        store.save_state(STATE_KEY_MODE, {"vpc_id": "vpc-12345"})
+
+        assert store.load_state(STATE_KEY_PROVIDER) is None
+
+    def test_delete_one_key_keeps_the_other(self, store):
+        """Deleting one key preserves the others and keeps the file."""
+        store.save_state(STATE_KEY_MODE, {"vpc_id": "vpc-12345"})
+        store.save_state(STATE_KEY_PROVIDER, {"job_map": {}})
+
+        store.delete_state(STATE_KEY_MODE)
+
+        assert store.load_state(STATE_KEY_MODE) is None
+        assert store.load_state(STATE_KEY_PROVIDER) == {"job_map": {}}
+        assert os.path.exists(store.file_path)
+
+    def test_file_removed_once_last_key_is_deleted(self, store):
+        """The state file itself goes away with the last key."""
+        store.save_state(STATE_KEY_PROVIDER, {"job_map": {}})
+
+        store.delete_state(STATE_KEY_PROVIDER)
+
+        assert not os.path.exists(store.file_path)
+
+    def test_delete_absent_key_is_not_an_error(self, store):
+        """Deleting a key that is not present succeeds, per the ABC contract."""
+        store.save_state(STATE_KEY_PROVIDER, {"job_map": {}})
+
+        store.delete_state(STATE_KEY_MODE)
+
+        assert store.load_state(STATE_KEY_PROVIDER) == {"job_map": {}}
+
+    def test_flat_document_is_readable_under_any_key(self, store):
+        """A pre-v0.7.0 flat document is handed to whichever key asks.
+
+        Both writers shared one slot before state keys, so each takes the
+        fields it recognises out of the same document.
+        """
+        flat = {
+            "provider_id": "test-provider",
+            "vpc_id": "vpc-12345",
+            "baked_ami_id": "ami-old",
+            "job_map": {"job-1": "res-1"},
+        }
+        with open(store.file_path, "w") as f:
+            json.dump(flat, f)
+
+        assert store.load_state(STATE_KEY_MODE) == flat
+        assert store.load_state(STATE_KEY_PROVIDER) == flat
+
+    def test_flat_document_upgrade_keeps_the_other_key(self, store):
+        """Upgrading a flat document seeds both keys, so no fields are lost.
+
+        Whichever writer goes first would otherwise erase the fields its
+        counterpart has not read yet.
+        """
+        flat = {
+            "provider_id": "test-provider",
+            "baked_ami_id": "ami-old",
+            "job_map": {"job-1": "res-1"},
+        }
+        with open(store.file_path, "w") as f:
+            json.dump(flat, f)
+
+        # The mode writes first, upgrading the file to the keyed layout.
+        store.save_state(STATE_KEY_MODE, {"baked_ami_id": "ami-new"})
+
+        assert store.load_state(STATE_KEY_MODE) == {"baked_ami_id": "ami-new"}
+        # The provider has not written yet; its fields must have survived.
+        assert store.load_state(STATE_KEY_PROVIDER)["job_map"] == {"job-1": "res-1"}
+
+        with open(store.file_path, "r") as f:
+            document = json.load(f)
+        assert document["_version"] == 2
+        assert set(document["_states"]) == {STATE_KEY_MODE, STATE_KEY_PROVIDER}
+
+    def test_serialization_failure_leaves_previous_state_intact(self, store):
+        """An unencodable document must not empty the file.
+
+        Serializing before truncating is what makes this hold.
+        """
+        store.save_state(STATE_KEY_PROVIDER, {"job_map": {"job-1": "res-1"}})
+
+        with pytest.raises(StateSerializationError):
+            store.save_state(STATE_KEY_MODE, {"handle": object()})
+
+        assert store.load_state(STATE_KEY_PROVIDER) == {"job_map": {"job-1": "res-1"}}
 
 
 @patch("boto3.Session")


### PR DESCRIPTION
Phase 1 of the v0.7.0 repair plan. Nine commits, each independently reviewable.

Closes #70, #71, #72, #73, #74, #75, #76, #77, #78, #79, #80, #94, #95, #96, #97, #98, #99, #100, #101, #102.

## What was wrong

`4ff23f6` (#69) removed VPC/subnet/SG creation and made the IDs required, but was applied to two of three modes and never propagated to the fixtures. Reconnaissance found the damage ran deeper — several of these paths had never executed at all.

**Hazards (data loss / destruction of caller resources)**
- `ServerlessMode.cleanup_infrastructure()` deleted the caller's security group with no ownership check, from the `except` handler on every failed `initialize()` (#70).
- `SpotFleetManager._cleanup_network_resources()` deleted the caller's SG, subnet, **every IGW attached to the VPC**, and the VPC itself — on IDs it had adopted from the provider. The IGW detach can succeed against a live VPC and blackhole egress for unrelated workloads (#94).

**Never-worked paths**
- `ServerlessMode` could not be constructed at all: `AttributeError: no attribute 'workflow_id'` (#72). Since `__init__` calls `initialize()` unconditionally, `mode="serverless"` *always* raised.
- `ECSManager` raised `UnboundLocalError` on every submission (#71).
- `LambdaManager._generate_lambda_code()` raised `ValueError: Invalid format specifier` on every call — all six test call sites stubbed the method, so the real body had never run (#96).
- `state_store_type="s3"` / `"parameter_store"` could not be constructed — three stacked defects, each hidden behind the previous (#57, #77). The `session=` kwarg the provider passed exists nowhere in the codebase.
- `StandardMode._create_spot_instance()` failed boto3 param validation on every call (#97).

**Silent leaks and cost**
- Provider and mode wrote full-document overwrites to the same state slot, destroying each other's fields — losing `baked_ami_id`/`owns_baked_ami` **leaked the AMI and its EBS snapshots** and silently re-baked on restart (#78).
- One-shot instances *stopped* instead of terminating, leaving a billed EBS volume that the provider had already dropped from tracking (#76).
- `shutdown()` saved an empty state document instead of deleting it, so SSM parameters and S3 objects accumulated per run (#99).
- StandardMode-only options on other modes tagged resources `warm_pool=True` and set `STATUS_WARM` — a status no other mode recognises — so instances leaked with no error at all (#80).
- `auto_create_instance_profile` was never forwarded, so the documented warm-pool config silently fell back to UserData on every submit (#75).

**Unreachable state**
- `_load_state()` was never called from `__init__`, and its `provider_id` gate could never match. Nothing survived a restart on any backend (#100).
- `_verify_resources()` nulled the ID it had just found missing; since #69 nothing creates a replacement (#79).

## Verified against real AWS

Unit tests could not catch most of this. Everything here was probed live under `AWS_PROFILE=aws`:

- IAM/EC2 eventual consistency measured: `create_instance_profile` returned an ARN at t+4.1s, but `RunInstances` did not accept it until **t+14.5s**. `get_instance_profile` succeeds immediately and proves nothing, so the wait polls a dry-run `RunInstances` (#98).
- EC2 answers a malformed ID with `.Malformed`, not `NotFound` — and the suffix casing differs per resource (`InvalidGroupId.Malformed` vs `InvalidVpcID.Malformed`). All six codes matched, on the `Error.Code` field rather than the rendered message.
- `tests/aws/test_state_backends_e2e.py`: **8 passed**.
- `tests/aws/test_standard_mode_e2e.py`: **3 failed, 2 passed → 5 passed**.

## Also found while verifying

Three defects surfaced only because the fixes made them reachable:

- **#101** — provider-ID adoption read only the provider's state key, which does not exist until a job is submitted. A provider that exited without submitting left only the mode document, so a successor discarded the very document holding its network IDs.
- **#102** — the E2E suite subscripted `JobStatus` in 14 places, a pattern predating the v0.5.0 `List[JobStatus]` change. Worse than the three visible failures: a polling helper that raises on its first call cannot time out, so **no** spot, detached, serverless, or Globus lifecycle assertion downstream of a `_poll_until` had ever run.
- `DetachedMode.initialize()` returned unconditionally on a state load, so a resumed provider whose bastion had been terminated never rebuilt it — every job dispatched into an SSM path nothing was reading.

## Test posture

Unit suite `155 → 324 passed`, no new failures (the remaining `38 failed / 86 errors` is the pre-existing baseline that Phase 2 targets — chiefly 6 mode fixtures missing network IDs, the inert `@patch("boto3.Session")` classes, and moto 5.x removing `mock_ec2`).

Every new invariant was mutation-checked rather than merely asserted. For #79, seven mutants — revert-to-nulling, unconditional network restore, unconditional detached return, dropped `.Malformed` codes, verify-only-on-resume, adoption-reads-provider-key-only, detached-never-loads-state — are each caught. For #80: disabling the guard fails 14 tests, comparing presence instead of the default fails 4, reordering it after the IAM guard fails 2.

New test files: `test_network_verification.py` (53), `test_serverless_mode_contract.py` (30), `test_lambda_manager.py` (13), `test_instance_profile.py` (10), `test_ecs_manager.py` (6), `tests/aws/test_one_shot_e2e.py` (8).

## Note on scope

`#69`'s three duplicate `_verify_resources` implementations were byte-identical — the condition that let them drift. That method now lives once on `OperatingMode`, but the tests still parametrize over all three modes: a single inherited method is only an improvement if every mode really does inherit it.

Dead-code removal (~4,000 LOC) stays deferred to v0.8.0 per the plan.