### PR TITLE
refactor: match Parsl ExecutionProvider signatures (closes #82)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -507,6 +507,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `"parsl.auto"` is treated as "no caller-chosen name", the same as the `None`
   this provider previously defaulted to. `self.resources` is widened to
   `Dict[object, Any]` to match the base declaration (closes #82).
+- `status()` and `cancel()` collect their per-job results by *position* rather
+  than in a dict keyed by the job ID. `Sequence[object]` admits unhashable IDs,
+  and using one as a dict key raised `TypeError: unhashable type: 'list'` — from
+  inside the `except` handler too, so it escaped the method rather than being
+  reported as UNKNOWN. Positional collection also means a repeated ID yields one
+  entry per occurrence, which is what Parsl indexes (refs #82).
 - Minimum Parsl raised from `2026.1.5` to `2026.4.20`. Not the `2026.7` #82
   proposed: `globus-compute-endpoint` pins Parsl *exactly* (4.15.0 →
   `parsl==2026.4.20`), so any floor above that makes the `globus` extra

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   live VPC and blackhole egress for unrelated workloads (closes #94).
 
 ### Fixed
+- `scale_in()` passed `None` into `cancel()` for any tracked resource carrying no
+  `job_id`, which `@typechecked` turned into
+  `TypeCheckError: item 0 of argument "job_ids" ... is not an instance of str` —
+  aborting the whole scale-in rather than skipping the one resource. A resource
+  normally has a `job_id`, but an interrupted `submit()` or a partially-restored
+  state document can leave it absent. Such resources are now filtered out. (This,
+  not Parsl, was the real source of the non-string-ID hazard #82 describes:
+  `BlockProviderExecutor.blocks_to_job_id` is `Dict[str, str]` and `submit()`
+  returns `str`, so Parsl round-trips strings safely) (closes #82).
 - The `test-bats` CI job failed in setup, before running a test. `sudo` was
   applied to the `npm install` line only, so `mkdir -p /usr/local/lib/bats` ran
   unprivileged and died on `Permission denied` once the runner image stopped
@@ -367,6 +376,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a first run can proceed with no saved state (closes #122).
 
 ### Added
+- `cores_per_node` and `mem_per_node` constructor arguments. Parsl's
+  `ExecutionProvider` declares both and `HighThroughputExecutor` sizes its worker
+  count from them — with both `None` it takes the
+  `# our best guess-- we do not have any provider hints` branch and runs **one
+  worker per node** however large the instance. When not supplied they are
+  resolved from `ec2:DescribeInstanceTypes` via the new
+  `utils.aws.describe_instance_capacity()`, which returns `(None, None)` on any
+  failure: it runs during `__init__`, so an unreachable or unauthorized EC2 must
+  not stop the provider from constructing. Serverless mode leaves both `None`
+  deliberately — Lambda and Fargate have no node to describe, and `memory_size`
+  is a per-invocation allocation rather than the same concept (closes #82).
+- `TestExecutionProviderConformance` in `tests/unit/test_provider_interface.py`
+  asserts the three signatures against `inspect.signature(ExecutionProvider.*)`
+  rather than restating them, so a future base-class change surfaces as a test
+  failure instead of a runtime `TypeCheckError`. Also covers opaque job IDs
+  through `status()`/`cancel()`, positional ordering when opaque and real IDs are
+  mixed, and `tests/unit/test_instance_capacity.py` for the capacity lookup
+  (closes #82).
 - `tests/substrate_support.py` — emulator session/client helpers and VPC
   setup/teardown, replacing the package-internal
   `parsl_ephemeral_aws/utils/localstack.py`. It lives under `tests/` because no
@@ -468,6 +495,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   template is caught (refs #112, #113).
 
 ### Changed
+- `submit()`, `status()`, and `cancel()` now carry Parsl's own signatures:
+  `submit(command, tasks_per_node, job_name="parsl.auto")`,
+  `status(job_ids: Sequence[object])`, and `cancel(job_ids: Sequence[object])`.
+  They were `List[str]` with `job_name: Optional[str] = None`, which is narrower
+  than the base class — and `@typechecked` on the class makes annotations
+  load-bearing at runtime, so a non-`str` ID raised `TypeCheckError` instead of
+  being reported as unknown. `job_map` stays string-keyed: each incoming ID is
+  narrowed once at the method boundary, and anything that is not a `str` resolves
+  to `JobState.UNKNOWN` (or `False` from `cancel()`) rather than raising.
+  `"parsl.auto"` is treated as "no caller-chosen name", the same as the `None`
+  this provider previously defaulted to. `self.resources` is widened to
+  `Dict[object, Any]` to match the base declaration (closes #82).
+- Minimum Parsl raised from `2026.1.5` to `2026.4.20`. Not the `2026.7` #82
+  proposed: `globus-compute-endpoint` pins Parsl *exactly* (4.15.0 →
+  `parsl==2026.4.20`), so any floor above that makes the `globus` extra
+  unresolvable. The signatures above are identical across the whole range —
+  2026.7.x only widened `status`/`cancel` from `List[object]` to
+  `Sequence[object]`, and `Sequence` is the wider type, so one declaration
+  satisfies every version in the range (refs #82).
 - **The AWS emulator is now [substrate](https://github.com/scttfrdmn/substrate),
   not LocalStack.** LocalStack OSS is end-of-life: the repository was archived
   read-only in March 2026, `4.14.0` is the last community image, and

--- a/parsl_ephemeral_aws/provider.py
+++ b/parsl_ephemeral_aws/provider.py
@@ -13,7 +13,7 @@ import threading
 import time
 import uuid
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Sequence
 
 import botocore.session
 from parsl.jobs.states import JobState, JobStatus
@@ -51,7 +51,7 @@ from parsl_ephemeral_aws.state.base import (
 from parsl_ephemeral_aws.state.file import FileStateStore
 from parsl_ephemeral_aws.state.parameter_store import ParameterStoreStateStore
 from parsl_ephemeral_aws.state.s3 import S3StateStore
-from parsl_ephemeral_aws.utils.aws import create_session
+from parsl_ephemeral_aws.utils.aws import create_session, describe_instance_capacity
 
 
 logger = logging.getLogger(__name__)
@@ -283,6 +283,8 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
         bake_ami: bool = DEFAULT_BAKE_AMI,
         baked_ami_id: Optional[str] = None,
         one_shot: bool = DEFAULT_ONE_SHOT,
+        cores_per_node: Optional[int] = None,
+        mem_per_node: Optional[float] = None,
         **kwargs: Any,
     ) -> None:
         """Initialize the Ephemeral AWS Provider."""
@@ -318,7 +320,10 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
             init_blocks=init_blocks,
         )
 
-        # Set basic attributes - resolve image_id if not provided
+        # Set basic attributes - resolve image_id if not provided.
+        # Genuinely optional: serverless needs no AMI, and auto-detection can
+        # fail, in which case the mode raises at initialize() instead.
+        self.image_id: Optional[str]
         if (
             image_id is None
             and mode.lower() in ["standard", "detached"]
@@ -460,13 +465,35 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
         )
         self.state_store = self._initialize_state_store()
 
+        # cores_per_node / mem_per_node are declared by Parsl's
+        # ExecutionProvider so an executor can size its worker pool -- HTEX
+        # divides them by its per-worker requirements, and guesses 1 worker per
+        # node when both are None. EC2 knows the real figures for the chosen
+        # instance type, so resolve them unless the caller said otherwise. The
+        # lookup is best-effort: it must not stop the provider constructing.
+        if cores_per_node is not None or mem_per_node is not None:
+            self.cores_per_node = cores_per_node
+            self.mem_per_node = mem_per_node
+        elif self.mode_type == OperatingModeType.SERVERLESS:
+            # Lambda and Fargate have no "node" to describe; memory_size is the
+            # per-invocation allocation, which is not the same concept.
+            self.cores_per_node = None
+            self.mem_per_node = None
+        else:
+            self.cores_per_node, self.mem_per_node = describe_instance_capacity(
+                self.session, self.instance_type
+            )
+
         # Adopt any provider_id already recorded at this state location, before
         # the operating mode is built with it.
         if provider_id is None:
             self._adopt_persisted_provider_id()
 
         self.operating_mode = self._initialize_operating_mode()
-        self.resources: Dict[str, Dict[str, Any]] = {}
+        # ``Dict[object, Any]`` is the type the base class declares. Keys are
+        # always the mode's string resource IDs in practice; the wider
+        # annotation exists so the attribute is a valid override.
+        self.resources: Dict[object, Any] = {}
         self.job_map: Dict[str, Dict[str, Any]] = {}
         # Re-entrant lock so cancel() → _cleanup_resources() doesn't deadlock
         self._lock = threading.RLock()
@@ -791,7 +818,7 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
             )
 
     def submit(
-        self, command: str, tasks_per_node: int, job_name: Optional[str] = None
+        self, command: str, tasks_per_node: int, job_name: str = "parsl.auto"
     ) -> str:
         """Submit a job to execute the specified command.
 
@@ -801,15 +828,20 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
             Command to execute.
         tasks_per_node : int
             Number of tasks to run per node.
-        job_name : Optional[str]
-            Name for the job.
+        job_name : str
+            Human-friendly name for the job request. Defaults to Parsl's
+            ``"parsl.auto"`` sentinel, which is replaced with a unique
+            generated name.
 
         Returns
         -------
         str
             Job ID for tracking status.
         """
-        job_name = job_name or f"parsl-job-{str(uuid.uuid4())[:8]}"
+        # ``"parsl.auto"`` is the base class's default, and `None` was this
+        # provider's own former default; both mean "no caller-chosen name".
+        if not job_name or job_name == "parsl.auto":
+            job_name = f"parsl-job-{str(uuid.uuid4())[:8]}"
         job_id = f"{self.provider_id}-{str(uuid.uuid4())}"
 
         # Check if we have capacity (lock protects len(self.resources))
@@ -860,39 +892,48 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
             logger.error(f"Failed to submit job {job_name}: {e}")
             raise ProviderError(f"Failed to submit job: {e}")
 
-    def status(self, job_ids: List[str]) -> List[JobStatus]:
+    def status(self, job_ids: Sequence[object]) -> List[JobStatus]:
         """Get the status of a list of jobs.
 
         Parameters
         ----------
-        job_ids : List[str]
-            List of job IDs.
+        job_ids : Sequence[object]
+            Job identifiers as returned by :meth:`submit`. Typed as ``object``
+            to match Parsl's ``ExecutionProvider``, which treats job IDs as
+            opaque; this provider issues strings, so anything else resolves to
+            ``JobState.UNKNOWN`` rather than raising.
 
         Returns
         -------
         List[JobStatus]
             List of JobStatus objects corresponding to each job_id.
         """
-        # Internal string-keyed status map updated in-place; return value is
-        # rebuilt as List[JobStatus] at the end.
-        internal_statuses: Dict[str, str] = {}
+        # Internal status map keyed by the job IDs as given.
+        internal_statuses: Dict[object, str] = {}
+
+        # Narrow each opaque ID to the string key ``job_map`` uses, once, so the
+        # internal map stays string-keyed. An ID this provider never issued —
+        # or one that is not a string at all — narrows to None and falls through
+        # to UNKNOWN rather than raising.
+        job_keys = [(jid, jid if isinstance(jid, str) else None) for jid in job_ids]
 
         try:
             # Short-circuit jobs already in a terminal state — avoids stale
             # re-queries when an instance has been reused for a different job.
             with self._lock:
-                for job_id in job_ids:
-                    if job_id in self.job_map:
-                        cached = self.job_map[job_id].get("status", "UNKNOWN")
+                for job_id, key in job_keys:
+                    if key is not None and key in self.job_map:
+                        cached = self.job_map[key].get("status", "UNKNOWN")
                         if cached in _TERMINAL_STATES:
                             internal_statuses[job_id] = cached
 
                 # Only poll for non-terminal jobs
                 resource_ids = [
-                    self.job_map[job_id]["resource_id"]
-                    for job_id in job_ids
-                    if job_id in self.job_map
-                    and self.job_map[job_id].get("status") not in _TERMINAL_STATES
+                    self.job_map[key]["resource_id"]
+                    for _, key in job_keys
+                    if key is not None
+                    and key in self.job_map
+                    and self.job_map[key].get("status") not in _TERMINAL_STATES
                 ]
 
             # Fetch status outside lock (may involve network calls)
@@ -902,14 +943,14 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
 
             # Update internal state under lock
             with self._lock:
-                for job_id in job_ids:
+                for job_id, key in job_keys:
                     if job_id in internal_statuses:
                         continue  # already set by terminal short-circuit
-                    if job_id in self.job_map:
-                        resource_id = self.job_map[job_id]["resource_id"]
+                    if key is not None and key in self.job_map:
+                        resource_id = self.job_map[key]["resource_id"]
                         if resource_id in status_map:
                             status_str = status_map[resource_id]
-                            self.job_map[job_id]["status"] = status_str
+                            self.job_map[key]["status"] = status_str
                             if resource_id in self.resources:
                                 self.resources[resource_id]["status"] = status_str
                             internal_statuses[job_id] = status_str
@@ -943,13 +984,15 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
             for jid in job_ids
         ]
 
-    def cancel(self, job_ids: List[str]) -> List[bool]:
+    def cancel(self, job_ids: Sequence[object]) -> List[bool]:
         """Cancel specified jobs.
 
         Parameters
         ----------
-        job_ids : List[str]
-            List of job IDs to cancel.
+        job_ids : Sequence[object]
+            Job identifiers to cancel. Typed as ``object`` to match Parsl's
+            ``ExecutionProvider``; an ID this provider never issued reports
+            ``False`` rather than raising.
 
         Returns
         -------
@@ -957,15 +1000,18 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
             True for each job_id where cancellation was accepted, False otherwise.
         """
         # Track success per job_id; defaults to False (unknown / not found)
-        cancel_results: Dict[str, bool] = {jid: False for jid in job_ids}
+        cancel_results: Dict[object, bool] = {jid: False for jid in job_ids}
+
+        # Narrow to ``job_map``'s string keys once — see status() for why.
+        job_keys = [(jid, jid if isinstance(jid, str) else None) for jid in job_ids]
 
         try:
             # Read resource IDs under lock
             with self._lock:
                 resources_to_terminate = [
-                    self.job_map[job_id]["resource_id"]
-                    for job_id in job_ids
-                    if job_id in self.job_map
+                    self.job_map[key]["resource_id"]
+                    for _, key in job_keys
+                    if key is not None and key in self.job_map
                 ]
 
             # Cancel jobs outside lock (may involve network calls)
@@ -973,12 +1019,12 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
 
             # Update internal state under lock
             with self._lock:
-                for job_id in job_ids:
-                    if job_id in self.job_map:
-                        resource_id = self.job_map[job_id]["resource_id"]
+                for job_id, key in job_keys:
+                    if key is not None and key in self.job_map:
+                        resource_id = self.job_map[key]["resource_id"]
                         if resource_id in cancel_map:
                             status_str = cancel_map[resource_id]
-                            self.job_map[job_id]["status"] = status_str
+                            self.job_map[key]["status"] = status_str
                             if resource_id in self.resources:
                                 self.resources[resource_id]["status"] = status_str
                             cancel_results[job_id] = status_str != "UNKNOWN"
@@ -1110,6 +1156,11 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
         # Scan resources under lock to build action lists
         with self._lock:
             for resource_id, resource in self.resources.items():
+                # Parsl's base class declares ``resources`` as ``Dict[object, Any]``,
+                # but every key this provider inserts is a mode-issued string ID.
+                # Narrow here so cleanup_resources() and job_map stay string-typed.
+                if not isinstance(resource_id, str):
+                    continue
                 status = resource.get("status", "UNKNOWN")
 
                 if resource.get("warm_pool"):
@@ -1156,7 +1207,9 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
                 current_warm = [
                     rid
                     for rid, r in self.resources.items()
-                    if r.get("warm_pool") and r.get("status") == STATUS_WARM
+                    if isinstance(rid, str)
+                    and r.get("warm_pool")
+                    and r.get("status") == STATUS_WARM
                 ]
                 for resource_id in warm_transitions:
                     if resource_id not in self.resources:
@@ -1257,10 +1310,16 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
                 if resource.get("status") == "RUNNING"
             ]
             resources_to_terminate = running_resources[:blocks]
+            # Drop resources carrying no job_id rather than passing None down.
+            # A tracked resource normally has one, but a partially-restored
+            # state document or an interrupted submit can leave it absent, and
+            # `@typechecked` on this class turns that into a TypeCheckError from
+            # cancel() instead of a no-op.
             job_ids = [
-                self.resources[resource_id].get("job_id")
+                job_id
                 for resource_id in resources_to_terminate
-                if resource_id in self.resources
+                if (job_id := self.resources.get(resource_id, {}).get("job_id"))
+                is not None
             ]
 
         # Cancel the selected jobs (cancel() acquires the lock internally)

--- a/parsl_ephemeral_aws/provider.py
+++ b/parsl_ephemeral_aws/provider.py
@@ -908,29 +908,32 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
         List[JobStatus]
             List of JobStatus objects corresponding to each job_id.
         """
-        # Internal status map keyed by the job IDs as given.
-        internal_statuses: Dict[object, str] = {}
-
         # Narrow each opaque ID to the string key ``job_map`` uses, once, so the
-        # internal map stays string-keyed. An ID this provider never issued —
-        # or one that is not a string at all — narrows to None and falls through
-        # to UNKNOWN rather than raising.
-        job_keys = [(jid, jid if isinstance(jid, str) else None) for jid in job_ids]
+        # internal map stays string-keyed. An ID this provider never issued — or
+        # one that is not a string at all — narrows to None and falls through to
+        # UNKNOWN rather than raising.
+        job_keys = [jid if isinstance(jid, str) else None for jid in job_ids]
+
+        # Statuses are collected by *position*, not by ID. ``Sequence[object]``
+        # permits unhashable IDs, so keying this by the ID itself would raise
+        # ``TypeError: unhashable type`` on e.g. a list — and the return value is
+        # positional regardless, so duplicate IDs also stay correct.
+        internal_statuses: Dict[int, str] = {}
 
         try:
             # Short-circuit jobs already in a terminal state — avoids stale
             # re-queries when an instance has been reused for a different job.
             with self._lock:
-                for job_id, key in job_keys:
+                for i, key in enumerate(job_keys):
                     if key is not None and key in self.job_map:
                         cached = self.job_map[key].get("status", "UNKNOWN")
                         if cached in _TERMINAL_STATES:
-                            internal_statuses[job_id] = cached
+                            internal_statuses[i] = cached
 
                 # Only poll for non-terminal jobs
                 resource_ids = [
                     self.job_map[key]["resource_id"]
-                    for _, key in job_keys
+                    for key in job_keys
                     if key is not None
                     and key in self.job_map
                     and self.job_map[key].get("status") not in _TERMINAL_STATES
@@ -943,8 +946,8 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
 
             # Update internal state under lock
             with self._lock:
-                for job_id, key in job_keys:
-                    if job_id in internal_statuses:
+                for i, key in enumerate(job_keys):
+                    if i in internal_statuses:
                         continue  # already set by terminal short-circuit
                     if key is not None and key in self.job_map:
                         resource_id = self.job_map[key]["resource_id"]
@@ -953,20 +956,20 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
                             self.job_map[key]["status"] = status_str
                             if resource_id in self.resources:
                                 self.resources[resource_id]["status"] = status_str
-                            internal_statuses[job_id] = status_str
+                            internal_statuses[i] = status_str
                         else:
                             # Resource not found — likely already cleaned up
-                            internal_statuses[job_id] = "COMPLETED"
+                            internal_statuses[i] = "COMPLETED"
                     else:
-                        internal_statuses[job_id] = "UNKNOWN"
+                        internal_statuses[i] = "UNKNOWN"
 
             # Save the updated state
             self._save_state()
 
         except Exception as e:
             logger.error(f"Failed to get status for jobs {job_ids}: {e}")
-            for job_id in job_ids:
-                internal_statuses.setdefault(job_id, "UNKNOWN")
+            for i in range(len(job_keys)):
+                internal_statuses.setdefault(i, "UNKNOWN")
 
         # Trigger cleanup to process warm-pool transitions and TTL evictions, and
         # to terminate finished one-shot instances — their command is delivered
@@ -978,10 +981,10 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
         return [
             JobStatus(
                 _STRING_TO_JOB_STATE.get(
-                    internal_statuses.get(jid, "UNKNOWN"), JobState.UNKNOWN
+                    internal_statuses.get(i, "UNKNOWN"), JobState.UNKNOWN
                 )
             )
-            for jid in job_ids
+            for i in range(len(job_keys))
         ]
 
     def cancel(self, job_ids: Sequence[object]) -> List[bool]:
@@ -999,18 +1002,20 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
         List[bool]
             True for each job_id where cancellation was accepted, False otherwise.
         """
-        # Track success per job_id; defaults to False (unknown / not found)
-        cancel_results: Dict[object, bool] = {jid: False for jid in job_ids}
-
         # Narrow to ``job_map``'s string keys once — see status() for why.
-        job_keys = [(jid, jid if isinstance(jid, str) else None) for jid in job_ids]
+        job_keys = [jid if isinstance(jid, str) else None for jid in job_ids]
+
+        # Success tracked by position, not by ID: an unhashable ID is legal under
+        # ``Sequence[object]`` and would raise TypeError as a dict key. Defaults
+        # to False (unknown / not found).
+        cancel_results: Dict[int, bool] = {i: False for i in range(len(job_keys))}
 
         try:
             # Read resource IDs under lock
             with self._lock:
                 resources_to_terminate = [
                     self.job_map[key]["resource_id"]
-                    for _, key in job_keys
+                    for key in job_keys
                     if key is not None and key in self.job_map
                 ]
 
@@ -1019,7 +1024,7 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
 
             # Update internal state under lock
             with self._lock:
-                for job_id, key in job_keys:
+                for i, key in enumerate(job_keys):
                     if key is not None and key in self.job_map:
                         resource_id = self.job_map[key]["resource_id"]
                         if resource_id in cancel_map:
@@ -1027,7 +1032,7 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
                             self.job_map[key]["status"] = status_str
                             if resource_id in self.resources:
                                 self.resources[resource_id]["status"] = status_str
-                            cancel_results[job_id] = status_str != "UNKNOWN"
+                            cancel_results[i] = status_str != "UNKNOWN"
                         # else: resource not in cancel_map → remains False
 
             # Clean up completed/failed resources (acquires lock internally)
@@ -1039,7 +1044,7 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
         except Exception as e:
             logger.error(f"Failed to cancel jobs {job_ids}: {e}")
 
-        return [cancel_results[jid] for jid in job_ids]
+        return [cancel_results[i] for i in range(len(job_keys))]
 
     def _save_state(self) -> None:
         """Save the current state under the provider's own state key.

--- a/parsl_ephemeral_aws/utils/aws.py
+++ b/parsl_ephemeral_aws/utils/aws.py
@@ -9,7 +9,7 @@ import json
 import logging
 import os
 import time
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import boto3
 from botocore.exceptions import (
@@ -205,6 +205,53 @@ def get_default_ami(region: str) -> str:
         message = f"No default AMI found for region {region}"
         logger.error(message)
         raise AMINotFoundError(message)
+
+
+def describe_instance_capacity(
+    session: boto3.Session, instance_type: str
+) -> Tuple[Optional[int], Optional[float]]:
+    """Look up an instance type's vCPU count and memory in GB.
+
+    Parsl's ``ExecutionProvider`` declares ``cores_per_node`` and
+    ``mem_per_node`` so an executor can size its worker pool: HTEX divides them
+    by its per-worker requirements to pick ``workers_per_node``, and falls back
+    to a hardcoded guess of 1 when both are ``None``. EC2 already knows the real
+    numbers, so there is no reason to make the caller supply them.
+
+    Failure is not an error. This is an optimisation hint, and a provider that
+    cannot reach EC2 during ``__init__`` should still construct — so any
+    exception yields ``(None, None)``, which is exactly the base class's default.
+
+    Parameters
+    ----------
+    session : boto3.Session
+        Session used to call ``ec2:DescribeInstanceTypes``.
+    instance_type : str
+        Instance type to describe, e.g. ``"t3.micro"``.
+
+    Returns
+    -------
+    Tuple[Optional[int], Optional[float]]
+        ``(vcpus, memory_gb)``, or ``(None, None)`` if the lookup failed.
+    """
+    try:
+        response = session.client("ec2").describe_instance_types(
+            InstanceTypes=[instance_type]
+        )
+        info = response["InstanceTypes"][0]
+        vcpus = info["VCpuInfo"]["DefaultVCpus"]
+        # AWS reports memory in MiB; Parsl documents mem_per_node in GB.
+        memory_gb = info["MemoryInfo"]["SizeInMiB"] / 1024
+        logger.debug(
+            f"Instance type {instance_type} has {vcpus} vCPUs and {memory_gb:.2f} GB memory"
+        )
+        return vcpus, memory_gb
+    except Exception as e:
+        logger.debug(
+            f"Could not describe instance type {instance_type}: {e}. "
+            "cores_per_node/mem_per_node stay unset."
+        )
+        return None, None
 
 
 def wait_for_resource(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
     "Topic :: System :: Distributed Computing",
 ]
 dependencies = [
-    "parsl>=2026.1.5",
+    "parsl>=2026.4.20",
     "boto3>=1.20.0",
     "botocore>=1.23.0",
     "cryptography>=3.4.0",

--- a/tests/unit/test_instance_capacity.py
+++ b/tests/unit/test_instance_capacity.py
@@ -1,0 +1,81 @@
+"""Unit tests for instance-capacity lookup.
+
+Parsl's ``ExecutionProvider`` declares ``cores_per_node``/``mem_per_node``, and
+``HighThroughputExecutor`` sizes its worker count from them — when both are
+``None`` it falls back to a single worker per node regardless of how large the
+instance is. ``describe_instance_capacity`` fills them in from EC2, and must
+degrade to ``(None, None)`` rather than raise: it runs during ``__init__``, so an
+unreachable EC2 must not stop the provider from constructing.
+
+SPDX-License-Identifier: Apache-2.0
+SPDX-FileCopyrightText: 2025 Scott Friedman and Project Contributors
+"""
+
+from unittest.mock import MagicMock
+
+import boto3
+import pytest
+from botocore.exceptions import ClientError, NoCredentialsError
+from moto import mock_aws
+
+from parsl_ephemeral_aws.utils.aws import describe_instance_capacity
+
+
+pytestmark = pytest.mark.unit
+
+
+class TestDescribeInstanceCapacity:
+    """Capacity lookup against moto and against failing clients."""
+
+    @mock_aws
+    def test_returns_vcpus_and_memory_in_gb(self):
+        """t3.micro is 2 vCPU / 1 GiB; memory is converted from MiB."""
+        session = boto3.Session(region_name="us-east-1")
+
+        vcpus, memory_gb = describe_instance_capacity(session, "t3.micro")
+
+        assert vcpus == 2
+        assert memory_gb == 1.0
+
+    @mock_aws
+    def test_larger_instance_type(self):
+        """A multi-GiB type converts without integer truncation."""
+        session = boto3.Session(region_name="us-east-1")
+
+        vcpus, memory_gb = describe_instance_capacity(session, "m5.xlarge")
+
+        assert vcpus == 4
+        assert memory_gb == 16.0
+
+    @mock_aws
+    def test_unknown_instance_type_returns_none(self):
+        """An invalid type yields (None, None), matching the base default."""
+        session = boto3.Session(region_name="us-east-1")
+
+        assert describe_instance_capacity(session, "not-a-real-type") == (None, None)
+
+    def test_client_error_returns_none(self):
+        """An API failure is an absent hint, not an error."""
+        session = MagicMock()
+        session.client.return_value.describe_instance_types.side_effect = ClientError(
+            {"Error": {"Code": "UnauthorizedOperation", "Message": "denied"}},
+            "DescribeInstanceTypes",
+        )
+
+        assert describe_instance_capacity(session, "t3.micro") == (None, None)
+
+    def test_missing_credentials_returns_none(self):
+        """No credentials during __init__ must not stop construction."""
+        session = MagicMock()
+        session.client.side_effect = NoCredentialsError()
+
+        assert describe_instance_capacity(session, "t3.micro") == (None, None)
+
+    def test_empty_response_returns_none(self):
+        """An empty InstanceTypes list must not IndexError."""
+        session = MagicMock()
+        session.client.return_value.describe_instance_types.return_value = {
+            "InstanceTypes": []
+        }
+
+        assert describe_instance_capacity(session, "t3.micro") == (None, None)

--- a/tests/unit/test_provider_interface.py
+++ b/tests/unit/test_provider_interface.py
@@ -316,3 +316,152 @@ class TestProviderInterface:
                 f.result()
 
         assert not errors, f"Errors during concurrent submit+status: {errors}"
+
+
+@pytest.mark.unit
+class TestExecutionProviderConformance:
+    """The provider must satisfy Parsl's ExecutionProvider contract (closes #82).
+
+    `@typechecked` on EphemeralAWSProvider makes the annotations load-bearing at
+    runtime, so a signature narrower than the base class's is not a typing nit —
+    it raises TypeCheckError on inputs Parsl is entitled to pass.
+    """
+
+    @pytest.fixture
+    def tmp_dir(self):
+        with tempfile.TemporaryDirectory() as d:
+            yield d
+
+    def test_signatures_match_base_class(self):
+        """submit/status/cancel accept everything ExecutionProvider declares."""
+        import inspect
+
+        from parsl.providers.base import ExecutionProvider
+
+        for name in ("submit", "status", "cancel"):
+            base = inspect.signature(getattr(ExecutionProvider, name))
+            ours = inspect.signature(getattr(EphemeralAWSProvider, name))
+            assert list(ours.parameters) == list(base.parameters), (
+                f"{name}() parameter names diverge from ExecutionProvider"
+            )
+            for pname, bparam in base.parameters.items():
+                assert ours.parameters[pname].default == bparam.default, (
+                    f"{name}() default for {pname} diverges from ExecutionProvider"
+                )
+
+    def test_submit_default_job_name_accepted(self, tmp_dir):
+        """The base class's "parsl.auto" default is treated as "no name given"."""
+        provider, mode = _make_provider(tmp_dir)
+        mode.submit_job.return_value = "resource-auto"
+
+        job_id = provider.submit("echo hello", tasks_per_node=1)
+
+        # Not the literal sentinel: a generated per-job name.
+        assert provider.job_map[job_id]["job_name"] != "parsl.auto"
+        assert provider.job_map[job_id]["job_name"].startswith("parsl-job-")
+
+    def test_status_accepts_non_string_ids(self, tmp_dir):
+        """status() reports UNKNOWN for opaque IDs rather than raising.
+
+        `Sequence[object]` is what the base declares, so a non-string ID must
+        not reach the string-keyed job_map.
+        """
+        provider, _ = _make_provider(tmp_dir)
+
+        result = provider.status([1, None, object()])
+
+        assert len(result) == 3
+        assert all(s.state == JobState.UNKNOWN for s in result)
+
+    def test_cancel_accepts_non_string_ids(self, tmp_dir):
+        """cancel() reports False for opaque IDs rather than raising."""
+        provider, _ = _make_provider(tmp_dir)
+
+        result = provider.cancel([1, None])
+
+        assert result == [False, False]
+
+    def test_status_mixed_ids_preserves_order(self, tmp_dir):
+        """A real ID alongside opaque ones still resolves positionally."""
+        provider, mode = _make_provider(tmp_dir)
+        resource_id = "resource-mixed"
+        mode.submit_job.return_value = resource_id
+        mode.get_job_status.return_value = {resource_id: "RUNNING"}
+
+        job_id = provider.submit("echo hello", tasks_per_node=1)
+        result = provider.status([None, job_id, 42])
+
+        assert [s.state for s in result] == [
+            JobState.UNKNOWN,
+            JobState.RUNNING,
+            JobState.UNKNOWN,
+        ]
+
+    def test_scale_in_skips_resources_without_job_id(self, tmp_dir):
+        """A resource missing job_id is skipped, not passed to cancel() as None.
+
+        An interrupted submit or a partially-restored state document can leave
+        job_id absent; passing None into cancel() raised TypeCheckError.
+        """
+        provider, mode = _make_provider(tmp_dir)
+        # No "job_id" key at all — the partial-state shape.
+        provider.resources["r-orphan"] = {"status": "RUNNING"}
+        provider.resources["r-good"] = {"job_id": "j-good", "status": "RUNNING"}
+        provider.job_map["j-good"] = {"resource_id": "r-good", "status": "RUNNING"}
+        mode.cancel_jobs.return_value = {"r-good": "CANCELED"}
+
+        terminated = provider.scale_in(2)
+
+        assert None not in terminated
+        assert terminated == ["j-good"]
+
+    def test_cores_and_mem_per_node_resolved(self, tmp_dir):
+        """The base class declares both; EC2 modes populate them from the API."""
+        with patch(
+            "parsl_ephemeral_aws.provider.describe_instance_capacity",
+            return_value=(2, 1.0),
+        ):
+            provider, _ = _make_provider(tmp_dir)
+
+        assert provider.cores_per_node == 2
+        assert provider.mem_per_node == 1.0
+
+    def test_explicit_cores_and_mem_override_lookup(self, tmp_dir):
+        """Caller-supplied values win; no EC2 call is made."""
+        provider_id = f"test-{uuid.uuid4().hex[:8]}"
+        state_file = os.path.join(tmp_dir, f"{provider_id}.json")
+        state_store = FileStateStore(file_path=state_file, provider_id=provider_id)
+
+        with (
+            patch("parsl_ephemeral_aws.provider.create_session"),
+            patch(
+                "parsl_ephemeral_aws.provider.describe_instance_capacity"
+            ) as mock_lookup,
+            patch.object(
+                EphemeralAWSProvider,
+                "_initialize_state_store",
+                return_value=state_store,
+            ),
+            patch.object(
+                EphemeralAWSProvider,
+                "_initialize_operating_mode",
+                return_value=MagicMock(),
+            ),
+        ):
+            provider = EphemeralAWSProvider(
+                provider_id=provider_id,
+                region="us-east-1",
+                image_id="ami-12345678",
+                instance_type="t3.micro",
+                mode="standard",
+                init_blocks=0,
+                vpc_id="vpc-test00001",
+                subnet_id="subnet-test001",
+                security_group_id="sg-test00001",
+                cores_per_node=8,
+                mem_per_node=16.0,
+            )
+
+        assert provider.cores_per_node == 8
+        assert provider.mem_per_node == 16.0
+        mock_lookup.assert_not_called()

--- a/tests/unit/test_provider_interface.py
+++ b/tests/unit/test_provider_interface.py
@@ -381,6 +381,43 @@ class TestExecutionProviderConformance:
 
         assert result == [False, False]
 
+    def test_status_accepts_unhashable_ids(self, tmp_dir):
+        """An unhashable ID reports UNKNOWN instead of raising TypeError.
+
+        ``Sequence[object]`` permits unhashable objects, so results cannot be
+        collected in a dict keyed by the ID itself — that raised
+        ``TypeError: unhashable type: 'list'`` before results were keyed by
+        position.
+        """
+        provider, _ = _make_provider(tmp_dir)
+
+        result = provider.status([["a"], {"b": 1}])
+
+        assert [s.state for s in result] == [JobState.UNKNOWN, JobState.UNKNOWN]
+
+    def test_cancel_accepts_unhashable_ids(self, tmp_dir):
+        """cancel() reports False for unhashable IDs instead of raising."""
+        provider, _ = _make_provider(tmp_dir)
+
+        assert provider.cancel([["a"], {"b": 1}]) == [False, False]
+
+    def test_status_duplicate_ids_returns_one_entry_each(self, tmp_dir):
+        """Repeated IDs each get their own positional entry.
+
+        Keying results by ID would collapse duplicates; Parsl indexes the
+        returned list positionally, so the lengths must match.
+        """
+        provider, mode = _make_provider(tmp_dir)
+        resource_id = "resource-dup"
+        mode.submit_job.return_value = resource_id
+        mode.get_job_status.return_value = {resource_id: "RUNNING"}
+
+        job_id = provider.submit("echo hello", tasks_per_node=1)
+        result = provider.status([job_id, job_id, job_id])
+
+        assert len(result) == 3
+        assert all(s.state == JobState.RUNNING for s in result)
+
     def test_status_mixed_ids_preserves_order(self, tmp_dir):
         """A real ID alongside opaque ones still resolves positionally."""
         provider, mode = _make_provider(tmp_dir)

--- a/uv.lock
+++ b/uv.lock
@@ -665,19 +665,19 @@ wheels = [
 
 [[package]]
 name = "globus-compute-common"
-version = "0.7.1"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e9/d9/b23739cb26a7a9d71e0efede7092d2ba1ef505c0b4d0582ad582144ded2c/globus_compute_common-0.7.1.tar.gz", hash = "sha256:2797aa7fdc91e7f944dd072eec4625766511d26af559bac374b1fb34321c94cb", size = 25028, upload-time = "2025-06-06T20:00:29.68Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/30/5698213bb7994082c59df0724621d7f6a7cc115afdb6779c44d366ce6cff/globus_compute_common-1.0.0.tar.gz", hash = "sha256:ebe2d37da999cf056d2d651267414a523b56df603bc7a388e764a7179de41f0d", size = 24679, upload-time = "2026-06-22T19:59:29.02Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f5/48/200feced505df15ec60931d84d57f1dbc7b99a4749d190ea6eb9317eccab/globus_compute_common-0.7.1-py3-none-any.whl", hash = "sha256:48a2af1d5067ca18bc6a24dc2457fee23d5bf6285a1128a7cd28a4a5f5758c59", size = 35464, upload-time = "2025-06-06T20:00:28.01Z" },
+    { url = "https://files.pythonhosted.org/packages/89/3b/ac511729885a7e1863582b14bf54cb4d22dbf627d08a957e8d4cbcd287c2/globus_compute_common-1.0.0-py3-none-any.whl", hash = "sha256:27c256e9d89a4322529817a39cdfc7703056ddff810352bc4659fb2244840571", size = 34864, upload-time = "2026-06-22T19:59:28.107Z" },
 ]
 
 [[package]]
 name = "globus-compute-endpoint"
-version = "4.7.0"
+version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cachetools" },
@@ -700,14 +700,14 @@ dependencies = [
     { name = "texttable" },
     { name = "types-cachetools" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/75/8b/edda7a131741bc8621c63b7f88dd8c192ce255ff705c346b568781861cab/globus_compute_endpoint-4.7.0.tar.gz", hash = "sha256:b40b5e47c7566fb318dc6dd27cc2b3865ec38a734961fd673d6dc4f6a4b100a3", size = 119270, upload-time = "2026-02-25T15:37:56.323Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/36/e7b2170eaeee7ca1a13aeb898292b3fc6ccd3bc968b9e9e4c43f9f95b1d5/globus_compute_endpoint-4.15.0.tar.gz", hash = "sha256:d1b0d74cf04bfa402dab4d90211385fb0db44a045390bb9b0129208d44ac1b3d", size = 116717, upload-time = "2026-07-15T20:24:50.605Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/d5/14b94b0f1b0b11456c6f82d0cd07b097344e9d2d7586c81b5bc523613fec/globus_compute_endpoint-4.7.0-py3-none-any.whl", hash = "sha256:dd6f7c5dd570157b8acc2179cc56c1eadee29907917c6395c02220a90c01b512", size = 145439, upload-time = "2026-02-25T15:37:54.838Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/70/be6125bfa386f54b9b9a22d274d9652942ce2b909bc44d40f3abd1c2dfbf/globus_compute_endpoint-4.15.0-py3-none-any.whl", hash = "sha256:eb1c9de4a78f7e2477274082a528b021394f207fc8df7e0cde210f034ce2275e", size = 142050, upload-time = "2026-07-15T20:24:49.253Z" },
 ]
 
 [[package]]
 name = "globus-compute-sdk"
-version = "4.7.0"
+version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama" },
@@ -717,15 +717,14 @@ dependencies = [
     { name = "globus-sdk" },
     { name = "packaging" },
     { name = "pika" },
-    { name = "psutil" },
     { name = "requests" },
     { name = "rich" },
     { name = "tblib" },
     { name = "texttable" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ef/bc/11d7c9ebab9a70a5d9fb02f361eccf689c576a443d7754741d3c8d5d6764/globus_compute_sdk-4.7.0.tar.gz", hash = "sha256:0dc5724160b4f00d01a680e48dfe0d1f85d7fa171e0277d31f4fd9be9d4df53d", size = 71305, upload-time = "2026-02-25T15:37:50.805Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/f7/e2d1fdc02119be6a560cb610d86c34618e887b61c92c3e7c3940246acabf/globus_compute_sdk-4.15.0.tar.gz", hash = "sha256:6e4937756fd0769948296ba909029e3df81f802e6d59f216e7f90305f6624f34", size = 65713, upload-time = "2026-07-15T20:24:43.117Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/77/862e4bc558a0c7c762a8fa92853b89fe8caf989d4f4c93bdf643236bbe1c/globus_compute_sdk-4.7.0-py3-none-any.whl", hash = "sha256:2dbd3516b94f3bc64578afaa8e82ede57daf7e881ca93cd955631b449f2bf83a", size = 83748, upload-time = "2026-02-25T15:37:49.295Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ba/15e85dbc34e6aab5794165365ece4cc35621ea1ea91c11bda0bfe767e15a/globus_compute_sdk-4.15.0-py3-none-any.whl", hash = "sha256:ccde95af6711c62106353c4078429025b3f4f3d79e7f809f59876289ec9715bf", size = 74850, upload-time = "2026-07-15T20:24:41.67Z" },
 ]
 
 [[package]]
@@ -1456,7 +1455,7 @@ wheels = [
 
 [[package]]
 name = "parsl"
-version = "2026.1.5"
+version = "2026.4.20"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dill" },
@@ -1470,9 +1469,9 @@ dependencies = [
     { name = "typeguard" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/19/d7/7f8cc847bedde25f7f1e749d96c26e8808c3943a549f453591d5ae832c7e/parsl-2026.1.5.tar.gz", hash = "sha256:19ee5e0214a823c00e99e7499e48a38d88983782c8b92e0822657a8eda666eef", size = 374874, upload-time = "2026-01-05T22:46:12.447Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/af/7fa01798b133ed4fa56d68bfe42ab16782ee2af04b13f06c133c531ce37e/parsl-2026.4.20.tar.gz", hash = "sha256:ad118454b69d04ed3453d0553d6d4e02f7411d765843d5bc74c49cf857712bb5", size = 378356, upload-time = "2026-04-20T22:57:56.779Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/10/89cce0d37657347f509b7e2fbcce99561aa60f721504fe06d548dacbb9b6/parsl-2026.1.5-py3-none-any.whl", hash = "sha256:f4bc92206217e465ea5c17391ebb75e73598376ce283b56eaa62978c6c6d1aea", size = 557446, upload-time = "2026-01-05T22:46:10.334Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/e6/cda789b1039443ed07dbb25af72caacbf9c0f5aed5d8e0cdb205e8723bc9/parsl-2026.4.20-py3-none-any.whl", hash = "sha256:e6de61f96ab5fc1e8acb391f992d64d6ebc57486defe178261a6fa22ded52066", size = 561137, upload-time = "2026-04-20T22:57:55.058Z" },
 ]
 
 [[package]]
@@ -1531,7 +1530,7 @@ requires-dist = [
     { name = "moto", extras = ["cloudformation"], marker = "extra == 'test'", specifier = ">=5.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=0.812" },
     { name = "myst-parser", marker = "extra == 'docs'", specifier = ">=2.0.0" },
-    { name = "parsl", specifier = ">=2026.1.5" },
+    { name = "parsl", specifier = ">=2026.4.20" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=2.15.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=2.12.0" },


### PR DESCRIPTION
Phase 3 of the v0.7.0 repair plan. Aligns the provider with the current Parsl
`ExecutionProvider` and fixes the two runtime failures the mismatch was hiding.

## What was actually wrong

`#82` frames this as a typing problem, but `@typechecked` on
`EphemeralAWSProvider` makes the annotations load-bearing at runtime, so the
narrower signatures raised `TypeCheckError` on inputs the base class permits.
Two things follow from that, and the second is not in the issue.

**The non-string-ID hazard originates inside this package, not in Parsl.**
`BlockProviderExecutor.blocks_to_job_id` is `Dict[str, str]` and `submit()`
returns `str`, so Parsl round-trips strings safely. The failure came from our own
`scale_in()`, which built job IDs with `.get("job_id")` and passed `None` for any
resource missing one — aborting the whole scale-in instead of skipping that
resource. Reproduced directly before fixing.

**`Sequence[object]` admits *unhashable* IDs.** Both `status()` and `cancel()`
collected per-job results in a dict keyed by the ID itself, so a list or dict ID
raised `TypeError: unhashable type: 'list'` — and escaped the method, because the
`except` handler's `setdefault` used the same unhashable key. Results are now
collected by position, which also fixes duplicate IDs (they previously collapsed
to one dict entry while Parsl indexes the returned list positionally).

Found by mutation-testing the first commit: reverting the `isinstance` narrowing
left the new tests passing, because for *hashable* non-`str` IDs the narrowing is
a static guarantee only — a non-`str` key simply misses `job_map`. Probing an
unhashable ID exposed the real gap.

## Changes

- `submit`/`status`/`cancel` now carry Parsl's own signatures. `job_map` stays
  string-keyed per #82: each ID is narrowed to `str` once at the method boundary,
  and anything else resolves to `JobState.UNKNOWN` / `False` rather than raising.
- `self.resources` widened to `Dict[object, Any]` to match the base declaration,
  with `isinstance` narrowing at the two iteration sites so cleanup stays
  string-typed.
- `cores_per_node` / `mem_per_node` added. HTEX sizes its worker pool from these
  and takes its `# our best guess-- we do not have any provider hints` branch when
  both are `None`, running **one worker per node** however large the instance. A
  new `utils.aws.describe_instance_capacity()` resolves them from
  `ec2:DescribeInstanceTypes` and returns `(None, None)` on any failure — it runs
  during `__init__`, so an unreachable or unauthorized EC2 must not stop the
  provider constructing. Serverless leaves both `None` deliberately: Lambda and
  Fargate have no node to describe, and `memory_size` is a per-invocation
  allocation rather than the same concept.

## On the Parsl floor

#82 asks for `parsl>=2026.7`. **That is unachievable while the `globus` extra
exists** — `globus-compute-endpoint` pins Parsl *exactly* (4.15.0 →
`parsl==2026.4.20`), so any higher floor makes the extra unresolvable. `2026.4.20`
is the real ceiling and is what this PR sets.

This costs nothing: the three signatures are identical across the whole candidate
range. 2026.7.x only widened `status`/`cancel` from `List[object]` to
`Sequence[object]`, and `Sequence` is the wider type, so one declaration satisfies
every version.

## Verification

| Check | Before | After |
|---|---|---|
| `mypy parsl_ephemeral_aws` | 96 errors | **89**; `provider.py` clean |
| `pytest tests/unit tests/security` | 641 passed | **658** passed |
| coverage | 69.60% | 69.70% |
| `ruff check` / `format --check` | clean | clean |
| `bandit -r parsl_ephemeral_aws` | 0 issues | 0 issues |
| `pytest tests/integration` (substrate) | 30F/37P/11S/11E | **identical** |
| Emulator conformance | 5 passed | 5 passed |

The integration baseline was re-measured on a stashed tree to confirm those 30
failures are pre-existing #92 debt and not caused by this change.

Both Liskov errors mypy reported at `provider.py` are gone; the two remaining
`image_id` errors were fixed in passing with an explicit `Optional[str]`
annotation (the attribute genuinely is optional — mypy had inferred `str` from the
first assignment).

`describe_instance_capacity` was also verified against real AWS
(`AWS_PROFILE=aws`): `t3.micro → (2, 1.0)`, `c7g.4xlarge → (16, 32.0)`, and an
invalid type → `(None, None)`.

## Tests

- `TestExecutionProviderConformance` (11 tests) asserts the signatures against
  `inspect.signature(ExecutionProvider.*)` rather than restating them, so a future
  base-class change surfaces as a test failure instead of a runtime
  `TypeCheckError`. Also covers opaque, unhashable, duplicate, and mixed IDs, and
  the `scale_in` missing-`job_id` path.
- `tests/unit/test_instance_capacity.py` (6 tests) covers the capacity lookup
  against moto and against failing/credential-less clients.

Both behaviour fixes were mutation-tested: reverting each makes its test fail.