### PR TITLE
feat: resolve AMIs from SSM, add arm64, fix allocation strategy (#84)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   live VPC and blackhole egress for unrelated workloads (closes #94).
 
 ### Fixed
+- Spot fleet requests ignored `spot_allocation_strategy` entirely. Both
+  `SpotFleetManager._create_spot_fleet_request()` and the fleet request inside
+  the generated bastion-manager script hardcoded `lowestPrice`, so the
+  configured value was never read at any call site — meaning every spot fleet
+  drew from the pools with the *least* spare capacity, the most
+  interruption-prone choice available. Both now send the configured strategy
+  (closes #84).
+- `get_default_ami()` raised `AMINotFoundError` for any region absent from its
+  hardcoded table, including regions AWS has added since the table was written.
+  It now resolves from SSM and falls back to the table only when that fails
+  (closes #84).
 - `scale_in()` passed `None` into `cancel()` for any tracked resource carrying no
   `job_id`, which `@typechecked` turned into
   `TypeCheckError: item 0 of argument "job_ids" ... is not an instance of str` —
@@ -376,6 +387,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a first run can proceed with no saved state (closes #122).
 
 ### Added
+- AMIs are resolved at runtime from AWS's public SSM Parameter Store aliases
+  (`/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-{arch}`), which
+  AWS repoints at every AL2023 release. Any region works, including ones no
+  hardcoded table ever listed — verified by booting an instance in
+  `ap-southeast-4`. The version-independent `kernel-default` alias is used
+  deliberately: naming `6.1`/`6.12`/`6.18` would only become the next stale
+  constant (closes #84).
+- **arm64/Graviton support.** Nothing in the package distinguished architectures
+  before, and every AMI it could reach was x86_64, so a Graviton `instance_type`
+  could not launch at all. `architecture_for_instance_type()` derives the
+  architecture from the instance-type family and `get_default_ami()` takes an
+  `architecture` argument; the provider exposes the resolved value as
+  `EphemeralAWSProvider.architecture`. Graviton is a 20–40% price/performance
+  gain on the same workload. The classification reads the family's *generation
+  suffix* — AWS appends `g` to every arm64 family (`c7g`, `m8g`, `r7gd`, `c8gn`)
+  and to no x86_64 one — so the `g5`/`g6e` GPU families, where the `g` is a
+  prefix, are correctly x86_64. Validated against `describe_instance_types` for
+  all 1,346 types offered in us-east-1: 396 arm64, 950 x86_64, zero
+  misclassifications (closes #84).
+- `normalize_spot_fleet_allocation_strategy()` in `utils/aws.py`, translating the
+  documented kebab-case strategy names to the camelCase spelling
+  `RequestSpotFleet` requires, and rejecting unknown values with a message that
+  lists the accepted ones rather than waiting for EC2's `InvalidParameterValue`.
+- `tests/unit/test_ami_resolution.py` (35 tests) and
+  `tests/unit/test_allocation_strategy.py` (25 tests). The allocation-strategy
+  suite asserts on the request boto3 actually receives and on the generated
+  bastion script's injected literal, not only on the helper — both defects were
+  that the configured value was never read, which a helper-level test cannot
+  catch.
 - `cores_per_node` and `mem_per_node` constructor arguments. Parsl's
   `ExecutionProvider` declares both and `HighThroughputExecutor` sizes its worker
   count from them — with both `None` it takes the
@@ -495,6 +535,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   template is caught (refs #112, #113).
 
 ### Changed
+- The default spot allocation strategy is now `price-capacity-optimized`, AWS's
+  current recommendation, replacing the documented-but-unused
+  `capacity-optimized`. It draws from the pools with the deepest spare capacity
+  and then the lowest price among those, so it interrupts far less often than
+  `lowest-price` at close to the same cost.
+- The two fleet APIs spell this enum differently and each rejects the other's
+  spelling, verified against real EC2: `RequestSpotFleet` takes camelCase
+  (`priceCapacityOptimized`; the kebab-case form returns
+  `InvalidParameterValue`), while `CreateFleet` takes kebab-case (the camelCase
+  form returns `InvalidParameter`). `spot_allocation_strategy` therefore stays
+  kebab-case — as every docstring has always documented — and is normalised at
+  the `RequestSpotFleet` boundary. `SPOT_FLEET_DEFAULT_ALLOCATION_STRATEGY` holds
+  the camelCase form for the current path and
+  `EC2_FLEET_DEFAULT_ALLOCATION_STRATEGY` the kebab-case form for the
+  `CreateFleet` migration in #86.
+- `DEFAULT_AMI_MAPPING` is demoted from the AMI source of truth to an offline
+  fallback for `get_default_ami()`, used only when the SSM lookup fails —
+  chiefly so moto- and substrate-backed tests need no network. It has been
+  refreshed, but a hardcoded table cannot be kept current: **all 21 entries of
+  the previous one, stamped 2026-03-01, were unusable by 2026-07-30** — 9 carried
+  a `DeprecationTime` of 2026-05-17, 6 returned `InvalidAMIID.NotFound`, 2 were
+  `InvalidAMIID.Malformed`, and the rest were in regions that could not be
+  reached. Nothing noticed, because a deprecated AMI still launches until AWS
+  deletes it. (The table's header also claimed `kernel-6.12`, while
+  `describe_images` reported the us-east-1 entry was built from `kernel-6.1`.)
+  The four opt-in regions it listed are dropped, since no value for them could be
+  verified; SSM resolves them normally from an account that has them enabled. The
+  table is x86_64-only, and `get_default_ami()` raises rather than hand one of
+  its entries to an arm64 instance type.
 - `submit()`, `status()`, and `cancel()` now carry Parsl's own signatures:
   `submit(command, tasks_per_node, job_name="parsl.auto")`,
   `status(job_ids: Sequence[object])`, and `cancel(job_ids: Sequence[object])`.

--- a/parsl_ephemeral_aws/compute/spot_fleet.py
+++ b/parsl_ephemeral_aws/compute/spot_fleet.py
@@ -36,9 +36,13 @@ from ..constants import (
     STATUS_CANCELLED,
     STATUS_UNKNOWN,
     DEFAULT_VPC_CIDR,
+    DEFAULT_SPOT_ALLOCATION_STRATEGY,
 )
 from ..config import SecurityConfig
-from ..utils.aws import resolve_manager_session
+from ..utils.aws import (
+    normalize_spot_fleet_allocation_strategy,
+    resolve_manager_session,
+)
 from ..security import (
     CredentialManager,
     CredentialConfiguration,
@@ -616,7 +620,17 @@ class SpotFleetManager:
                 "LaunchSpecifications": launch_specifications,
                 "TerminateInstancesWithExpiration": True,
                 "Type": "maintain",  # Maintain target capacity
-                "AllocationStrategy": "lowestPrice",  # Use the lowest price instance types
+                # Honour the provider's spot_allocation_strategy instead of
+                # hardcoding lowestPrice, which ignored the documented setting
+                # and chose the most interruption-prone pools (#84). Normalised
+                # because RequestSpotFleet takes only the camelCase spelling.
+                "AllocationStrategy": normalize_spot_fleet_allocation_strategy(
+                    getattr(
+                        self.provider,
+                        "spot_allocation_strategy",
+                        DEFAULT_SPOT_ALLOCATION_STRATEGY,
+                    )
+                ),
                 "ReplaceUnhealthyInstances": True,
                 "TagSpecifications": [
                     {

--- a/parsl_ephemeral_aws/constants.py
+++ b/parsl_ephemeral_aws/constants.py
@@ -62,30 +62,67 @@ DEFAULT_OUTBOUND_RULES = [
     }
 ]
 
-# AMI mappings for different regions (Amazon Linux 2023)
-# Updated 2026-03-01 — al2023-ami-2023.10.20260216.1-kernel-6.12-x86_64
+# Amazon Linux 2023 AMI resolution (#84).
+#
+# AMIs are resolved at runtime from AWS's public SSM Parameter Store aliases,
+# which every account can read without credentials of its own for the parameter
+# and which AWS repoints at each new AL2023 release. A hardcoded region->AMI
+# table cannot work: the previous one was stamped 2026-03-01 and by 2026-07-30
+# *all 21 entries* were unusable -- 9 carried a DeprecationTime of 2026-05-17,
+# 6 returned InvalidAMIID.NotFound, 2 were InvalidAMIID.Malformed, and the rest
+# were unreachable. Nothing in the package noticed, because a deprecated AMI
+# still launches until AWS deletes it.
+#
+# ``kernel-default`` is AWS's version-independent alias. Naming a specific
+# kernel here (6.1, 6.12, 6.18, ...) would only re-create the staleness this
+# change removes.
+AMI_SSM_PARAMETER_PREFIX = "/aws/service/ami-amazon-linux-latest"
+AMI_SSM_PARAMETER_TEMPLATE = (
+    AMI_SSM_PARAMETER_PREFIX + "/al2023-ami-kernel-default-{architecture}"
+)
+
+# EC2 architecture identifiers, as ``describe_instance_types`` reports them in
+# ProcessorInfo.SupportedArchitectures.
+ARCHITECTURE_X86_64 = "x86_64"
+ARCHITECTURE_ARM64 = "arm64"
+DEFAULT_ARCHITECTURE = ARCHITECTURE_X86_64
+
+# Instance families that are Graviton (arm64) despite carrying no "g" in their
+# generation suffix. a1 is the original Graviton family and predates the naming
+# convention that every later arm64 family follows.
+ARM64_INSTANCE_FAMILIES = frozenset({"a1"})
+
+# Offline fallback for ``get_default_ami()``, used only when the SSM lookup
+# above fails -- chiefly so moto- and substrate-backed tests need no network.
+#
+# Treat these as expiring the day they are written. Refreshed 2026-07-30 from
+# the kernel-default SSM alias, but AWS deprecates each AL2023 AMI roughly two
+# months after release, so this table is a last resort and not a source of
+# truth. It is x86_64-only, and get_default_ami() deliberately refuses rather
+# than hand one of these to an arm64 instance type.
+#
+# The four opt-in regions the previous table listed (af-south-1, ap-east-1,
+# eu-south-1, me-south-1) are omitted: they cannot be read without enabling the
+# region, so no value could be verified. SSM resolves them normally from an
+# account that has them enabled.
 DEFAULT_AMI_MAPPING = {
-    "us-east-1": "ami-0f3caa1cf4417e51b",  # N. Virginia
-    "us-east-2": "ami-0d5503fb907719409",  # Ohio
-    "us-west-1": "ami-0e2de80e7636c4837",  # N. California
-    "us-west-2": "ami-075b5421f670d735c",  # Oregon
-    "af-south-1": "ami-08d7290d17859bd2e",  # Cape Town
-    "ap-east-1": "ami-0d96ec8a788679eb2",  # Hong Kong
-    "ap-southeast-2": "ami-0a11f7293cd9a562e",  # Sydney
-    "ap-southeast-1": "ami-0ac0e4288aa341886",  # Singapore
-    "ap-northeast-1": "ami-088103e734f7e0529",  # Tokyo
-    "ap-northeast-2": "ami-0ef0d6b9c5b7d9c81",  # Seoul
-    "ap-northeast-3": "ami-088a969d6f085cca3",  # Osaka
-    "ap-south-1": "ami-07e8927ba33de363c",  # Mumbai
-    "ca-central-1": "ami-0b512d33ad3b7b983",  # Canada
-    "eu-central-1": "ami-0c42fad2ea005202d",  # Frankfurt
-    "eu-west-1": "ami-09c20105c9b62f893",  # Ireland
-    "eu-west-2": "ami-06f89d8f36d17aa27",  # London
-    "eu-west-3": "ami-0a13801de97493e85",  # Paris
-    "eu-north-1": "ami-03df6dab118053bcb",  # Stockholm
-    "eu-south-1": "ami-079fed56921cf99b9",  # Milan
-    "me-south-1": "ami-03509ba459e8172c7",  # Bahrain
-    "sa-east-1": "ami-0a4cf2f3770eb3f5e",  # São Paulo
+    "us-east-1": "ami-0006118602dfc1c09",  # N. Virginia
+    "us-east-2": "ami-06dd88604c99ec11f",  # Ohio
+    "us-west-1": "ami-0be92a0ad760d0371",  # N. California
+    "us-west-2": "ami-0b76d82b547c3c077",  # Oregon
+    "ap-northeast-1": "ami-03107d83a97af3820",  # Tokyo
+    "ap-northeast-2": "ami-04bb4ddfc0e51bb5e",  # Seoul
+    "ap-northeast-3": "ami-0cd939ceb3b70a09d",  # Osaka
+    "ap-south-1": "ami-0884624fc54d115f3",  # Mumbai
+    "ap-southeast-1": "ami-094819e1130d6d35b",  # Singapore
+    "ap-southeast-2": "ami-0cb938ea8bf5b7973",  # Sydney
+    "ca-central-1": "ami-06171593517b6bb1f",  # Canada
+    "eu-central-1": "ami-0352a6b853b4367b3",  # Frankfurt
+    "eu-north-1": "ami-0c783070b2e26d98c",  # Stockholm
+    "eu-west-1": "ami-02c25106ee38f6087",  # Ireland
+    "eu-west-2": "ami-0e3771f9c18926b8e",  # London
+    "eu-west-3": "ami-033623a76c8038cf0",  # Paris
+    "sa-east-1": "ami-0b44997419d0b0d38",  # Sao Paulo
 }
 
 # EC2 status mapping to Parsl job states
@@ -112,15 +149,60 @@ RESOURCE_TYPE_ECS_TASK = "ecs_task"
 # Spot fleet constants
 SPOT_FLEET_TARGET_CAPACITY_TYPE = "TargetCapacity"
 SPOT_FLEET_FULFILLED_CAPACITY_TYPE = "FulfilledCapacity"
-SPOT_FLEET_DEFAULT_ALLOCATION_STRATEGY = "capacity-optimized"
+
+# Allocation strategy (#84). ``price-capacity-optimized`` is AWS's current
+# recommendation: it picks from the pools with the deepest spare capacity and
+# then the lowest price among those, so it interrupts far less often than
+# ``lowest-price`` at close to the same cost.
+#
+# The two fleet APIs spell the same enum differently, and each rejects the
+# other's spelling. Verified against real EC2 in us-east-1:
+#
+#   RequestSpotFleet  SpotFleetRequestConfig.AllocationStrategy -> camelCase
+#       "price-capacity-optimized" => InvalidParameterValue
+#   CreateFleet       SpotOptions.AllocationStrategy            -> kebab-case
+#       "priceCapacityOptimized"   => InvalidParameter
+#
+# So there cannot be one constant for both. SPOT_FLEET_* is the camelCase form
+# for the legacy RequestSpotFleet path this package uses today; EC2_FLEET_* is
+# the kebab-case form for the CreateFleet migration in #86.
+SPOT_FLEET_DEFAULT_ALLOCATION_STRATEGY = "priceCapacityOptimized"
+EC2_FLEET_DEFAULT_ALLOCATION_STRATEGY = "price-capacity-optimized"
+
+# Accepted values for each API, so a caller-supplied strategy can be rejected
+# with a useful message instead of an opaque InvalidParameterValue from EC2.
+SPOT_FLEET_ALLOCATION_STRATEGIES = frozenset(
+    {
+        "lowestPrice",
+        "diversified",
+        "capacityOptimized",
+        "capacityOptimizedPrioritized",
+        "priceCapacityOptimized",
+    }
+)
+EC2_FLEET_ALLOCATION_STRATEGIES = frozenset(
+    {
+        "lowest-price",
+        "diversified",
+        "capacity-optimized",
+        "capacity-optimized-prioritized",
+        "price-capacity-optimized",
+    }
+)
 
 # Cleanup constants
 CLEANUP_BATCH_SIZE = 10
 MAX_CLEANUP_RETRIES = 3
 CLEANUP_RETRY_DELAY = 5  # seconds
 
-# Spot instance defaults
-DEFAULT_SPOT_ALLOCATION_STRATEGY = "capacity-optimized"
+# Spot instance defaults.
+#
+# This is the *user-facing* default for the ``spot_allocation_strategy`` kwarg.
+# It stays kebab-case -- that is what the provider and mode docstrings have
+# always documented, and what CreateFleet takes -- and
+# ``normalize_spot_fleet_allocation_strategy()`` translates it to camelCase at
+# the RequestSpotFleet boundary. See SPOT_FLEET_DEFAULT_ALLOCATION_STRATEGY.
+DEFAULT_SPOT_ALLOCATION_STRATEGY = "price-capacity-optimized"
 DEFAULT_SPOT_INSTANCE_INTERRUPTION_BEHAVIOR = "terminate"
 DEFAULT_SPOT_INTERRUPTION_CHECK_INTERVAL = 30  # seconds
 DEFAULT_SPOT_INTERRUPTION_LEAD_TIME = 120  # seconds

--- a/parsl_ephemeral_aws/modes/base.py
+++ b/parsl_ephemeral_aws/modes/base.py
@@ -13,6 +13,7 @@ import boto3
 
 from botocore.exceptions import ClientError
 
+from parsl_ephemeral_aws.constants import DEFAULT_SPOT_ALLOCATION_STRATEGY
 from parsl_ephemeral_aws.exceptions import OperatingModeError, ResourceNotFoundError
 from parsl_ephemeral_aws.state.base import STATE_KEY_MODE, StateStore
 
@@ -91,7 +92,7 @@ class OperatingMode(abc.ABC):
         key_name: Optional[str] = None,
         use_spot: bool = False,
         spot_max_price: Optional[str] = None,
-        spot_allocation_strategy: str = "capacity-optimized",
+        spot_allocation_strategy: str = DEFAULT_SPOT_ALLOCATION_STRATEGY,
         spot_interruption_handling: bool = False,
         checkpoint_bucket: Optional[str] = None,
         checkpoint_prefix: str = "parsl/checkpoints",
@@ -135,7 +136,8 @@ class OperatingMode(abc.ABC):
         spot_max_price : Optional[str], optional
             Maximum price for spot instances, by default None
         spot_allocation_strategy : str, optional
-            Allocation strategy for spot instances, by default "capacity-optimized"
+            Allocation strategy for spot instances, in kebab-case, by default
+            "price-capacity-optimized"
         spot_interruption_handling : bool, optional
             Whether to enable spot interruption handling, by default False
         checkpoint_bucket : Optional[str], optional

--- a/parsl_ephemeral_aws/modes/detached.py
+++ b/parsl_ephemeral_aws/modes/detached.py
@@ -36,7 +36,9 @@ from parsl_ephemeral_aws.exceptions import (
 from parsl_ephemeral_aws.modes.base import OperatingMode
 from parsl_ephemeral_aws.state.base import STATE_KEY_MODE, StateStore
 from parsl_ephemeral_aws.utils.aws import (
+    architecture_for_instance_type,
     get_default_ami,
+    normalize_spot_fleet_allocation_strategy,
     wait_for_resource,
     get_cf_template,
 )
@@ -329,7 +331,13 @@ class DetachedMode(OperatingMode):
 
         # Validate image_id
         if not self.image_id:
-            self.image_id = get_default_ami(self.session.region_name)
+            # Architecture-matched and SSM-resolved (#84): an x86_64 AMI on a
+            # Graviton instance type fails to launch.
+            self.image_id = get_default_ami(
+                self.session.region_name,
+                architecture_for_instance_type(self.instance_type),
+                session=self.session,
+            )
             logger.info(
                 f"Using default AMI {self.image_id} for region {self.session.region_name}"
             )
@@ -422,7 +430,13 @@ class DetachedMode(OperatingMode):
 
         # Validate image_id
         if not self.image_id:
-            self.image_id = get_default_ami(self.session.region_name)
+            # Architecture-matched and SSM-resolved (#84): an x86_64 AMI on a
+            # Graviton instance type fails to launch.
+            self.image_id = get_default_ami(
+                self.session.region_name,
+                architecture_for_instance_type(self.instance_type),
+                session=self.session,
+            )
             logger.info(
                 f"Using default AMI {self.image_id} for region {self.session.region_name}"
             )
@@ -723,6 +737,10 @@ JOB_COMMAND_PREFIX = f'{SSM_PARAMETER_PREFIX}/jobs'
 JOB_STATUS_PREFIX = f'{SSM_PARAMETER_PREFIX}/status'
 TAG_PREFIX = "parsl-ephemeral"
 RESOURCE_TYPE_SPOT_FLEET = "spot_fleet"
+# Spot Fleet allocation strategy, overwritten at script generation time with the
+# mode's spot_allocation_strategy (#84). RequestSpotFleet accepts only the
+# camelCase spelling, so the value substituted here is already normalised.
+ALLOCATION_STRATEGY = 'priceCapacityOptimized'
 EC2_STATUS_MAPPING = {
     'pending': 'PENDING',
     'running': 'RUNNING',
@@ -1021,7 +1039,7 @@ export PARSL_WORKER_ID=$(hostname)
                 'LaunchSpecifications': launch_specifications,
                 'TerminateInstancesWithExpiration': True,
                 'Type': 'maintain',  # Maintain target capacity
-                'AllocationStrategy': 'lowestPrice',  # Use the lowest price instance types
+                'AllocationStrategy': ALLOCATION_STRATEGY,
                 'ReplaceUnhealthyInstances': True,
                 'TagSpecifications': [
                     {
@@ -1501,6 +1519,17 @@ if __name__ == '__main__':
             "PROVIDER_ID = os.environ.get('PARSL_PROVIDER_ID')",
             f"PROVIDER_ID = '{self.provider_id}'  # injected at script generation time",
         )
+        # The bastion runs this script standalone, so it cannot import from this
+        # package -- the strategy has to be substituted in as a literal. The
+        # fleet request used to hardcode 'lowestPrice' here, ignoring the
+        # configured spot_allocation_strategy entirely and choosing the pools
+        # with the least spare capacity (#84).
+        script = script.replace(
+            "ALLOCATION_STRATEGY = 'priceCapacityOptimized'",
+            "ALLOCATION_STRATEGY = "
+            f"'{normalize_spot_fleet_allocation_strategy(self.spot_allocation_strategy)}'"
+            "  # injected at script generation time",
+        )
         return script
 
     def submit_job(
@@ -1541,7 +1570,13 @@ if __name__ == '__main__':
 
         # Validate image_id
         if not self.image_id:
-            self.image_id = get_default_ami(self.session.region_name)
+            # Architecture-matched and SSM-resolved (#84): an x86_64 AMI on a
+            # Graviton instance type fails to launch.
+            self.image_id = get_default_ami(
+                self.session.region_name,
+                architecture_for_instance_type(self.instance_type),
+                session=self.session,
+            )
             logger.info(
                 f"Using default AMI {self.image_id} for region {self.session.region_name}"
             )

--- a/parsl_ephemeral_aws/modes/standard.py
+++ b/parsl_ephemeral_aws/modes/standard.py
@@ -17,6 +17,7 @@ import boto3
 from botocore.exceptions import ClientError
 
 from parsl_ephemeral_aws.constants import (
+    DEFAULT_SPOT_ALLOCATION_STRATEGY,
     EC2_STATUS_MAPPING,
     RESOURCE_TYPE_EC2,
     RESOURCE_TYPE_SPOT_FLEET,
@@ -41,6 +42,7 @@ from parsl_ephemeral_aws.compute.spot_interruption import (
     ParslSpotInterruptionHandler,
 )
 from parsl_ephemeral_aws.utils.aws import (
+    architecture_for_instance_type,
     get_default_ami,
     get_or_create_ssm_instance_profile,
     wait_for_resource,
@@ -74,7 +76,7 @@ class StandardMode(OperatingMode):
         key_name: Optional[str] = None,
         use_spot: bool = False,
         spot_max_price: Optional[str] = None,
-        spot_allocation_strategy: str = "capacity-optimized",
+        spot_allocation_strategy: str = DEFAULT_SPOT_ALLOCATION_STRATEGY,
         additional_tags: Optional[Dict[str, str]] = None,
         auto_shutdown: bool = True,
         max_idle_time: int = 300,
@@ -123,7 +125,8 @@ class StandardMode(OperatingMode):
         spot_max_price : Optional[str], optional
             Maximum price for spot instances, by default None
         spot_allocation_strategy : str, optional
-            Allocation strategy for spot instances, by default "capacity-optimized"
+            Allocation strategy for spot instances, in kebab-case, by default
+            "price-capacity-optimized"
         additional_tags : Optional[Dict[str, str]], optional
             Tags to apply to created resources, by default None
         auto_shutdown : bool, optional
@@ -754,7 +757,13 @@ class StandardMode(OperatingMode):
 
         # Validate image_id
         if not self.image_id:
-            self.image_id = get_default_ami(self.session.region_name)
+            # Architecture-matched and SSM-resolved (#84): an x86_64 AMI on a
+            # Graviton instance type fails to launch.
+            self.image_id = get_default_ami(
+                self.session.region_name,
+                architecture_for_instance_type(self.instance_type),
+                session=self.session,
+            )
             logger.info(
                 f"Using default AMI {self.image_id} for region {self.session.region_name}"
             )

--- a/parsl_ephemeral_aws/provider.py
+++ b/parsl_ephemeral_aws/provider.py
@@ -30,6 +30,7 @@ from parsl_ephemeral_aws.constants import (
     DEFAULT_MODE,
     DEFAULT_ONE_SHOT,
     DEFAULT_REGION,
+    DEFAULT_SPOT_ALLOCATION_STRATEGY,
     DEFAULT_WARM_POOL_SIZE,
     DEFAULT_WARM_POOL_TTL,
     DEFAULT_WORKER_INIT,
@@ -51,7 +52,12 @@ from parsl_ephemeral_aws.state.base import (
 from parsl_ephemeral_aws.state.file import FileStateStore
 from parsl_ephemeral_aws.state.parameter_store import ParameterStoreStateStore
 from parsl_ephemeral_aws.state.s3 import S3StateStore
-from parsl_ephemeral_aws.utils.aws import create_session, describe_instance_capacity
+from parsl_ephemeral_aws.utils.aws import (
+    architecture_for_instance_type,
+    create_session,
+    describe_instance_capacity,
+    get_default_ami,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -112,9 +118,13 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
     Parameters
     ----------
     image_id : str, optional
-        EC2 AMI ID to use for instances. Required when using EC2 instances.
+        EC2 AMI ID to use for instances. When omitted, the latest Amazon Linux
+        2023 AMI matching ``instance_type``'s architecture is resolved from AWS's
+        public SSM parameters. Supply one explicitly for a custom image, or for
+        an instance family AL2023 does not cover (``mac*.metal``).
     instance_type : str, optional
-        EC2 instance type. Default is 't3.micro'.
+        EC2 instance type. Default is 't3.micro'. Graviton (arm64) families are
+        supported; the matching arm64 AMI is selected automatically.
     region : str, optional
         AWS region. Default is 'us-east-1'.
     mode : str, optional
@@ -151,7 +161,11 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
     spot_max_price : str, optional
         Maximum price for spot instances. Default is on-demand price.
     spot_allocation_strategy : str, optional
-        Allocation strategy for spot instances. Default is 'capacity-optimized'.
+        Allocation strategy for spot instances, in kebab-case: one of
+        'price-capacity-optimized' (the default, and AWS's recommendation),
+        'capacity-optimized', 'capacity-optimized-prioritized', 'diversified',
+        or 'lowest-price'. Converted to the camelCase spelling Spot Fleet
+        requires at the API boundary.
     spot_interruption_handling : bool, optional
         Whether to enable spot interruption handling. Default is False.
     checkpoint_bucket : Optional[str], optional
@@ -254,7 +268,7 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
         parameter_store_path: str = "/parsl/ephemeral_aws_state",
         use_spot: bool = False,
         spot_max_price: Optional[str] = None,
-        spot_allocation_strategy: str = "capacity-optimized",
+        spot_allocation_strategy: str = DEFAULT_SPOT_ALLOCATION_STRATEGY,
         spot_interruption_handling: bool = False,
         use_spot_fleet: bool = False,
         instance_types: Optional[List[str]] = None,
@@ -320,28 +334,17 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
             init_blocks=init_blocks,
         )
 
-        # Set basic attributes - resolve image_id if not provided.
-        # Genuinely optional: serverless needs no AMI, and auto-detection can
-        # fail, in which case the mode raises at initialize() instead.
-        self.image_id: Optional[str]
-        if (
-            image_id is None
-            and mode.lower() in ["standard", "detached"]
-            and compute_type.lower() == "ec2"
-        ):
-            # Auto-detect default AMI for the region
-            from parsl_ephemeral_aws.utils.aws import get_default_ami
-
-            try:
-                self.image_id = get_default_ami(region)
-                logger.info(f"Auto-detected AMI {self.image_id} for region {region}")
-            except Exception as e:
-                logger.warning(
-                    f"Failed to auto-detect AMI: {e}. Will need to be set later."
-                )
-                self.image_id = None
-        else:
-            self.image_id = image_id
+        # image_id is genuinely optional: serverless needs no AMI, and
+        # auto-detection can fail, in which case the mode raises at
+        # initialize() instead. Resolution itself is deferred until after
+        # self.session exists, below -- it now queries SSM, and must do so with
+        # the caller's profile and endpoint rather than a bare default session.
+        self.image_id: Optional[str] = image_id
+        # The AMI must match the instance type's architecture, or the launch
+        # fails: arm64 was unusable before #84 because only x86_64 AMIs existed
+        # anywhere in the package. This lookup is pure string parsing, so it is
+        # safe this early.
+        self.architecture = architecture_for_instance_type(instance_type)
         self.instance_type = instance_type
         self.region = region
         self.mode_type = OperatingModeType(mode.lower())
@@ -463,6 +466,29 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
         self.session = create_session(
             region=self.region, profile_name=self.profile_name
         )
+
+        # Resolve the AMI now that a credentialed session exists. Deferred from
+        # the attribute block above because get_default_ami() queries SSM (#84).
+        if (
+            self.image_id is None
+            and self.mode_type
+            in (OperatingModeType.STANDARD, OperatingModeType.DETACHED)
+            and self.compute_type == ComputeType.EC2
+        ):
+            try:
+                self.image_id = get_default_ami(
+                    self.region, self.architecture, session=self.session
+                )
+                logger.info(
+                    f"Auto-detected {self.architecture} AMI {self.image_id} for "
+                    f"region {self.region}"
+                )
+            except Exception as e:
+                logger.warning(
+                    f"Failed to auto-detect AMI: {e}. Will need to be set later."
+                )
+                self.image_id = None
+
         self.state_store = self._initialize_state_store()
 
         # cores_per_node / mem_per_node are declared by Parsl's

--- a/parsl_ephemeral_aws/utils/aws.py
+++ b/parsl_ephemeral_aws/utils/aws.py
@@ -8,6 +8,7 @@ SPDX-FileCopyrightText: 2025 Scott Friedman and Project Contributors
 import json
 import logging
 import os
+import re
 import time
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -21,7 +22,16 @@ from botocore.exceptions import (
     TokenRetrievalError,
 )
 
-from parsl_ephemeral_aws.constants import DEFAULT_AMI_MAPPING, DEFAULT_REGION
+from parsl_ephemeral_aws.constants import (
+    AMI_SSM_PARAMETER_TEMPLATE,
+    ARCHITECTURE_ARM64,
+    ARCHITECTURE_X86_64,
+    ARM64_INSTANCE_FAMILIES,
+    DEFAULT_AMI_MAPPING,
+    DEFAULT_ARCHITECTURE,
+    DEFAULT_REGION,
+    SPOT_FLEET_ALLOCATION_STRATEGIES,
+)
 from parsl_ephemeral_aws.exceptions import (
     AMINotFoundError,
     AWSAuthenticationError,
@@ -181,30 +191,193 @@ def create_session(
         raise AWSConnectionError(f"Failed to create AWS session: {e}") from e
 
 
-def get_default_ami(region: str) -> str:
-    """Get the default AMI ID for the given region.
+def architecture_for_instance_type(instance_type: str) -> str:
+    """Return the CPU architecture an instance type needs an AMI for.
+
+    An AMI is architecture-specific, so launching a Graviton instance with an
+    x86_64 image fails. Nothing in this package distinguished the two before
+    #84, which made every arm64 instance type unusable.
+
+    The family suffix is the signal: AWS appends ``g`` to the generation of
+    every Graviton family (``c7g``, ``m8g``, ``r7gd``, ``c8gn``, ...) and to no
+    x86_64 family. Validated against ``describe_instance_types`` for all 1,346
+    types AWS offers in us-east-1: 396 arm64 and 950 x86_64, zero mistakes.
+
+    The only exceptions are the eight ``mac*.metal`` types, which report
+    ``arm64_mac`` and need a macOS AMI rather than AL2023 -- so classifying
+    them as x86_64 is no worse than the arm64 answer would be. A caller wanting
+    a Mac instance must pass ``image_id`` explicitly either way.
 
     Parameters
     ----------
-    region : str
-        AWS region
+    instance_type : str
+        EC2 instance type, e.g. ``"c7g.xlarge"`` or ``"t3.micro"``.
 
     Returns
     -------
     str
-        Default AMI ID for the region
+        ``"arm64"`` or ``"x86_64"``.
+    """
+    family = instance_type.split(".")[0].lower()
+
+    if family in ARM64_INSTANCE_FAMILIES:
+        return ARCHITECTURE_ARM64
+
+    # Split "c7gd" into prefix "c", generation "7", suffix "gd". A type we
+    # cannot parse is assumed x86_64, which is what it was before #84.
+    match = re.match(r"^([a-z]+)(\d+)([a-z]*)$", family)
+    if match is None:
+        logger.debug(
+            f"Unrecognised instance family {family!r}; assuming {DEFAULT_ARCHITECTURE}"
+        )
+        return DEFAULT_ARCHITECTURE
+
+    return ARCHITECTURE_ARM64 if "g" in match.group(3) else ARCHITECTURE_X86_64
+
+
+def normalize_spot_fleet_allocation_strategy(strategy: str) -> str:
+    """Translate an allocation strategy to the spelling RequestSpotFleet takes.
+
+    The two fleet APIs disagree on the casing of the same enum, and each
+    rejects the other's spelling. Verified against real EC2 in us-east-1 --
+    ``RequestSpotFleet`` with ``"price-capacity-optimized"`` returns
+    ``InvalidParameterValue``, and ``CreateFleet`` with
+    ``"priceCapacityOptimized"`` returns ``InvalidParameter``.
+
+    The provider's ``spot_allocation_strategy`` kwarg is documented in
+    kebab-case, so it needs converting at the RequestSpotFleet boundary. Values
+    already in camelCase pass through, so a caller who supplied the API-native
+    spelling is not punished for it.
+
+    Parameters
+    ----------
+    strategy : str
+        Allocation strategy in either spelling, e.g.
+        ``"price-capacity-optimized"`` or ``"priceCapacityOptimized"``.
+
+    Returns
+    -------
+    str
+        The camelCase spelling ``RequestSpotFleet`` accepts.
+
+    Raises
+    ------
+    ValueError
+        If the strategy is not one EC2 recognises, or is not a string. Raised
+        here rather than letting EC2 reject it, because a spot fleet request
+        fails several seconds and one IAM role later.
+    """
+    if strategy in SPOT_FLEET_ALLOCATION_STRATEGIES:
+        return strategy
+
+    # Checked explicitly: a non-string reaches ``.split()`` and, for a MagicMock,
+    # returns another mock that unpacks to nothing -- "not enough values to
+    # unpack", which names neither the argument nor the caller.
+    if not isinstance(strategy, str):
+        raise ValueError(
+            f"Spot allocation strategy must be a string, got "
+            f"{type(strategy).__name__}: {strategy!r}"
+        )
+
+    # "price-capacity-optimized" -> "priceCapacityOptimized"
+    head, *rest = strategy.split("-")
+    camel = head + "".join(word.capitalize() for word in rest)
+    if camel in SPOT_FLEET_ALLOCATION_STRATEGIES:
+        return camel
+
+    raise ValueError(
+        f"Unsupported spot allocation strategy {strategy!r}. Expected one of "
+        f"{sorted(SPOT_FLEET_ALLOCATION_STRATEGIES)} or their kebab-case "
+        f"equivalents."
+    )
+
+
+def get_default_ami(
+    region: str,
+    architecture: str = DEFAULT_ARCHITECTURE,
+    session: Optional[boto3.Session] = None,
+) -> str:
+    """Resolve the latest Amazon Linux 2023 AMI for a region and architecture.
+
+    Resolution order:
+
+    1. AWS's public SSM Parameter Store alias
+       ``/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-<arch>``,
+       which AWS repoints at every new AL2023 release. This is the only source
+       that stays correct without maintenance.
+    2. ``DEFAULT_AMI_MAPPING``, retained purely so offline test runs against
+       moto or substrate need no network. It is *not* a reliable source of live
+       AMIs -- see the note in ``constants.py`` -- and is x86_64-only, so it is
+       skipped for arm64 rather than returning an image that cannot boot.
+
+    Parameters
+    ----------
+    region : str
+        AWS region.
+    architecture : str, optional
+        ``"x86_64"`` (default) or ``"arm64"``. Use
+        ``architecture_for_instance_type()`` to derive it from an instance type.
+    session : boto3.Session, optional
+        Session to query SSM with. A new one is created for ``region`` when
+        omitted; pass an existing session to reuse its credentials and any
+        custom endpoint.
+
+    Returns
+    -------
+    str
+        AMI ID.
 
     Raises
     ------
     AMINotFoundError
-        If no default AMI is found for the region
+        If SSM cannot be reached and no usable fallback exists for the region
+        and architecture.
     """
-    if region in DEFAULT_AMI_MAPPING:
-        return DEFAULT_AMI_MAPPING[region]
-    else:
-        message = f"No default AMI found for region {region}"
-        logger.error(message)
-        raise AMINotFoundError(message)
+    if architecture not in (ARCHITECTURE_X86_64, ARCHITECTURE_ARM64):
+        raise AMINotFoundError(
+            f"Unsupported architecture {architecture!r}: expected "
+            f"{ARCHITECTURE_X86_64!r} or {ARCHITECTURE_ARM64!r}"
+        )
+
+    parameter_name = AMI_SSM_PARAMETER_TEMPLATE.format(architecture=architecture)
+
+    try:
+        if session is None:
+            session = boto3.Session(region_name=region)
+        value = session.client("ssm", region_name=region).get_parameter(
+            Name=parameter_name
+        )["Parameter"]["Value"]
+        logger.debug(
+            f"Resolved {architecture} AL2023 AMI {value} for {region} from "
+            f"{parameter_name}"
+        )
+        return str(value)
+    except Exception as e:
+        # Any failure here is recoverable if a fallback exists, so log at debug
+        # and fall through; the raise below carries the real diagnosis.
+        logger.debug(f"SSM AMI lookup failed for {region}/{architecture}: {e}")
+        ssm_error: Exception = e
+
+    # The fallback table is x86_64-only. Handing an x86_64 AMI to an arm64
+    # instance produces an opaque launch failure, so refuse instead.
+    if architecture == ARCHITECTURE_X86_64 and region in DEFAULT_AMI_MAPPING:
+        fallback = DEFAULT_AMI_MAPPING[region]
+        logger.warning(
+            f"Could not resolve the current AL2023 AMI for {region} from SSM "
+            f"({ssm_error}); falling back to the offline table entry "
+            f"{fallback}. This AMI may be deprecated or deleted -- set "
+            f"image_id explicitly if the launch fails."
+        )
+        return fallback
+
+    message = (
+        f"No AMI found for region {region} architecture {architecture}: SSM "
+        f"lookup of {parameter_name} failed ({ssm_error})"
+    )
+    if architecture == ARCHITECTURE_ARM64:
+        message += " and the offline fallback table has no arm64 entries"
+    logger.error(message)
+    raise AMINotFoundError(message)
 
 
 def describe_instance_capacity(
@@ -994,7 +1167,8 @@ def _wait_for_instance_profile(
     error on a profile that is about to work.
     """
     ec2 = session.client("ec2")
-    image_id = get_default_ami(session.region_name or DEFAULT_REGION)
+    # t3.micro below is x86_64, so the default architecture is the right one.
+    image_id = get_default_ami(session.region_name or DEFAULT_REGION, session=session)
     deadline = time.time() + timeout
 
     while time.time() < deadline:

--- a/tests/support.py
+++ b/tests/support.py
@@ -10,6 +10,8 @@ SPDX-FileCopyrightText: 2025 Scott Friedman and Project Contributors
 
 from unittest.mock import MagicMock, patch
 
+from parsl_ephemeral_aws.constants import DEFAULT_SPOT_ALLOCATION_STRATEGY
+
 
 def mock_provider(**overrides):
     """Build a mock provider that satisfies every compute manager's ``__init__``.
@@ -55,6 +57,10 @@ def mock_provider(**overrides):
     provider.use_spot_instances = False
     provider.nodes_per_block = 1
     provider.tags = {}
+    # Read as a value and normalised to the camelCase spelling RequestSpotFleet
+    # accepts (#84); a MagicMock here fails inside the normaliser rather than at
+    # the API, so the real default has to be present.
+    provider.spot_allocation_strategy = DEFAULT_SPOT_ALLOCATION_STRATEGY
     # Every manager now resolves its session through resolve_manager_session,
     # which prefers ``provider.session`` and only falls back to the credential
     # manager when there is none (#117). A bare MagicMock always *has* a

--- a/tests/unit/test_allocation_strategy.py
+++ b/tests/unit/test_allocation_strategy.py
@@ -1,0 +1,224 @@
+"""Unit tests for spot allocation strategy handling (#84).
+
+Two defects are covered here.
+
+First, ``spot_fleet.py`` and the ``detached.py`` bastion script both hardcoded
+``lowestPrice``, silently ignoring the ``spot_allocation_strategy`` the caller
+configured and picking the pools with the least spare capacity -- the most
+interruption-prone choice available.
+
+Second, the two fleet APIs spell the same enum differently and each rejects the
+other's spelling. Verified against real EC2 in us-east-1 with a request anchored
+on a malformed AMI so no fleet could be created::
+
+    RequestSpotFleet, AllocationStrategy="price-capacity-optimized"
+        -> InvalidParameterValue: ... failed to satisfy constraint
+    RequestSpotFleet, AllocationStrategy="priceCapacityOptimized"
+        -> InvalidParameterValue: Invalid value 'ami-notavalidamiid' for amiId
+           (i.e. the strategy was accepted; the AMI was the only complaint)
+    CreateFleet,      AllocationStrategy="priceCapacityOptimized"
+        -> InvalidParameter: AllocationStrategy must be "lowest-price", ...
+
+So the kebab-case value the provider documents has to be converted at the
+RequestSpotFleet boundary. Passing it through unconverted would break every
+spot fleet request.
+
+SPDX-License-Identifier: Apache-2.0
+SPDX-FileCopyrightText: 2025 Scott Friedman and Project Contributors
+"""
+
+import ast
+from unittest.mock import MagicMock
+
+import pytest
+
+from parsl_ephemeral_aws.constants import (
+    DEFAULT_SPOT_ALLOCATION_STRATEGY,
+    EC2_FLEET_ALLOCATION_STRATEGIES,
+    EC2_FLEET_DEFAULT_ALLOCATION_STRATEGY,
+    SPOT_FLEET_ALLOCATION_STRATEGIES,
+    SPOT_FLEET_DEFAULT_ALLOCATION_STRATEGY,
+)
+from parsl_ephemeral_aws.utils.aws import normalize_spot_fleet_allocation_strategy
+
+
+pytestmark = pytest.mark.unit
+
+
+class TestNormalizeSpotFleetAllocationStrategy:
+    """Kebab-case in, the camelCase spelling RequestSpotFleet accepts out."""
+
+    @pytest.mark.parametrize(
+        "kebab,camel",
+        [
+            ("price-capacity-optimized", "priceCapacityOptimized"),
+            ("capacity-optimized", "capacityOptimized"),
+            ("capacity-optimized-prioritized", "capacityOptimizedPrioritized"),
+            ("lowest-price", "lowestPrice"),
+            ("diversified", "diversified"),
+        ],
+    )
+    def test_converts_every_documented_strategy(self, kebab, camel):
+        assert normalize_spot_fleet_allocation_strategy(kebab) == camel
+
+    @pytest.mark.parametrize("camel", sorted(SPOT_FLEET_ALLOCATION_STRATEGIES))
+    def test_camel_case_passes_through(self, camel):
+        """A caller who supplied the API-native spelling is not punished."""
+        assert normalize_spot_fleet_allocation_strategy(camel) == camel
+
+    def test_every_ec2_fleet_value_has_a_spot_fleet_equivalent(self):
+        """The two enums must cover the same set of strategies."""
+        converted = {
+            normalize_spot_fleet_allocation_strategy(s)
+            for s in EC2_FLEET_ALLOCATION_STRATEGIES
+        }
+        assert converted == set(SPOT_FLEET_ALLOCATION_STRATEGIES)
+
+    def test_rejects_an_unknown_strategy(self):
+        """Better here than several seconds and one IAM role later, from EC2."""
+        with pytest.raises(ValueError, match="Unsupported spot allocation strategy"):
+            normalize_spot_fleet_allocation_strategy("cheapest-possible")
+
+    def test_error_lists_the_accepted_values(self):
+        with pytest.raises(ValueError) as excinfo:
+            normalize_spot_fleet_allocation_strategy("nonsense")
+
+        assert "priceCapacityOptimized" in str(excinfo.value)
+
+    def test_rejects_a_non_string(self):
+        """A MagicMock reaching ``.split()`` unpacks to nothing.
+
+        The resulting "not enough values to unpack" names neither the argument
+        nor the caller, which is exactly what a mock-heavy test suite hands in.
+        """
+        with pytest.raises(ValueError, match="must be a string"):
+            normalize_spot_fleet_allocation_strategy(MagicMock())
+
+        with pytest.raises(ValueError, match="must be a string"):
+            normalize_spot_fleet_allocation_strategy(None)
+
+
+class TestAllocationStrategyConstants:
+    """The defaults must be valid for the API each one is used with."""
+
+    def test_default_is_price_capacity_optimized(self):
+        """AWS's current recommendation, replacing capacity-optimized."""
+        assert DEFAULT_SPOT_ALLOCATION_STRATEGY == "price-capacity-optimized"
+
+    def test_user_facing_default_is_valid_for_ec2_fleet(self):
+        assert DEFAULT_SPOT_ALLOCATION_STRATEGY in EC2_FLEET_ALLOCATION_STRATEGIES
+
+    def test_spot_fleet_default_is_camel_case(self):
+        """RequestSpotFleet rejects the kebab-case spelling outright."""
+        assert (
+            SPOT_FLEET_DEFAULT_ALLOCATION_STRATEGY in SPOT_FLEET_ALLOCATION_STRATEGIES
+        )
+        assert "-" not in SPOT_FLEET_DEFAULT_ALLOCATION_STRATEGY
+
+    def test_ec2_fleet_default_is_kebab_case(self):
+        """CreateFleet rejects the camelCase spelling outright."""
+        assert EC2_FLEET_DEFAULT_ALLOCATION_STRATEGY in EC2_FLEET_ALLOCATION_STRATEGIES
+        assert "-" in EC2_FLEET_DEFAULT_ALLOCATION_STRATEGY
+
+    def test_the_two_defaults_are_the_same_strategy(self):
+        """Differently spelled, but the same behaviour from AWS."""
+        assert (
+            normalize_spot_fleet_allocation_strategy(
+                EC2_FLEET_DEFAULT_ALLOCATION_STRATEGY
+            )
+            == SPOT_FLEET_DEFAULT_ALLOCATION_STRATEGY
+        )
+
+    def test_no_default_is_lowest_price(self):
+        """lowestPrice concentrates on the shallowest pools; that was the bug."""
+        assert "lowest" not in DEFAULT_SPOT_ALLOCATION_STRATEGY.lower()
+        assert "lowest" not in SPOT_FLEET_DEFAULT_ALLOCATION_STRATEGY.lower()
+        assert "lowest" not in EC2_FLEET_DEFAULT_ALLOCATION_STRATEGY.lower()
+
+
+class TestNoHardcodedLowestPriceRemains:
+    """Guard against the hardcoded value being reintroduced.
+
+    Both call sites bypassed the configured strategy entirely, so a value-level
+    assertion in a mode test would not have caught it -- the constant was never
+    read. Checking the source is the check that matches the defect.
+    """
+
+    def test_spot_fleet_manager_does_not_hardcode_a_strategy(self):
+        import inspect
+
+        from parsl_ephemeral_aws.compute import spot_fleet
+
+        source = inspect.getsource(spot_fleet)
+        assert '"AllocationStrategy": "lowestPrice"' not in source
+
+    def test_bastion_script_strategy_is_injected(self):
+        """The bastion runs standalone and cannot import from this package.
+
+        The strategy therefore has to be substituted in as a literal, and the
+        generated script must not carry the hardcoded lowestPrice.
+        """
+        import inspect
+
+        from parsl_ephemeral_aws.modes import detached
+
+        source = inspect.getsource(detached)
+        assert "'AllocationStrategy': 'lowestPrice'" not in source
+        assert "ALLOCATION_STRATEGY = " in source
+
+
+class TestBastionScriptInjection:
+    """The generated bastion script must carry the configured strategy.
+
+    The source-level guard above proves the hardcoded value is gone; this proves
+    the replacement actually substitutes. A substitution whose search string
+    drifts from the template fails silently -- ``str.replace`` finding nothing is
+    not an error -- so the generated text is what has to be asserted on.
+    """
+
+    def _script(self, **kwargs):
+        from parsl_ephemeral_aws.modes.detached import DetachedMode
+
+        mode = DetachedMode(
+            provider_id="test-provider",
+            session=MagicMock(),
+            state_store=MagicMock(),
+            workflow_id="test-workflow",
+            instance_type="t3.small",
+            image_id="ami-12345678",
+            region="us-east-1",
+            vpc_id="vpc-12345",
+            subnet_id="subnet-12345",
+            security_group_id="sg-12345",
+            **kwargs,
+        )
+        return mode._get_bastion_manager_script()
+
+    def _injected_value(self, script):
+        for line in script.splitlines():
+            if line.startswith("ALLOCATION_STRATEGY = "):
+                return ast.literal_eval(
+                    line.removeprefix("ALLOCATION_STRATEGY = ").split("  #")[0]
+                )
+        raise AssertionError("script defines no ALLOCATION_STRATEGY constant")
+
+    def test_configured_strategy_is_injected_as_camel_case(self):
+        script = self._script(spot_allocation_strategy="capacity-optimized")
+
+        assert self._injected_value(script) == "capacityOptimized"
+
+    def test_default_strategy_is_injected(self):
+        assert (
+            self._injected_value(self._script())
+            == SPOT_FLEET_DEFAULT_ALLOCATION_STRATEGY
+        )
+
+    def test_generated_script_is_valid_python(self):
+        """The substitution must not break the script the bastion has to run."""
+        ast.parse(self._script(spot_allocation_strategy="diversified"))
+
+    def test_script_contains_no_hardcoded_lowest_price(self):
+        script = self._script()
+
+        assert "'AllocationStrategy': 'lowestPrice'" not in script
+        assert "lowestPrice" not in script

--- a/tests/unit/test_ami_resolution.py
+++ b/tests/unit/test_ami_resolution.py
@@ -1,0 +1,264 @@
+"""Unit tests for AMI resolution and architecture selection (#84).
+
+Hardcoding region->AMI pairs cannot work. The table this replaces was stamped
+2026-03-01, and by 2026-07-30 every one of its 21 entries was unusable -- 9
+carried a DeprecationTime, 6 returned InvalidAMIID.NotFound, 2 were structurally
+malformed, and the remainder were unreachable. AWS's public SSM aliases are
+repointed at each AL2023 release, so they are the only maintenance-free source.
+
+Architecture matters just as much: an x86_64 AMI on a Graviton instance type
+fails to launch, and nothing in this package distinguished the two before #84.
+
+SPDX-License-Identifier: Apache-2.0
+SPDX-FileCopyrightText: 2025 Scott Friedman and Project Contributors
+"""
+
+from unittest.mock import MagicMock
+
+import boto3
+import pytest
+from botocore.exceptions import ClientError, NoCredentialsError
+from moto import mock_aws
+
+from parsl_ephemeral_aws.constants import (
+    AMI_SSM_PARAMETER_TEMPLATE,
+    ARCHITECTURE_ARM64,
+    ARCHITECTURE_X86_64,
+    DEFAULT_AMI_MAPPING,
+)
+from parsl_ephemeral_aws.exceptions import AMINotFoundError
+from parsl_ephemeral_aws.utils.aws import (
+    architecture_for_instance_type,
+    get_default_ami,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+class TestArchitectureForInstanceType:
+    """Graviton detection from the instance-type family suffix.
+
+    The classification was validated against ``describe_instance_types`` for all
+    1,346 types AWS offers in us-east-1 (396 arm64, 950 x86_64) with zero
+    mistakes; these cases are representative samples of that sweep.
+    """
+
+    @pytest.mark.parametrize(
+        "instance_type",
+        [
+            "c7g.xlarge",  # current Graviton compute
+            "m8g.large",  # newest Graviton generation
+            "r7gd.4xlarge",  # Graviton with local NVMe
+            "c8gn.medium",  # Graviton network-optimised
+            "t4g.nano",  # Graviton burstable
+            "x2gd.medium",  # Graviton memory-optimised
+            "im4gn.large",  # Graviton storage-optimised
+            "a1.medium",  # original Graviton, no "g" suffix
+        ],
+    )
+    def test_graviton_families_are_arm64(self, instance_type):
+        assert architecture_for_instance_type(instance_type) == ARCHITECTURE_ARM64
+
+    @pytest.mark.parametrize(
+        "instance_type",
+        [
+            "t3.micro",  # the package default
+            "m5.xlarge",
+            "c6i.large",  # Intel
+            "m6a.2xlarge",  # AMD -- "a" suffix, not "g"
+            "r5n.large",  # network-optimised x86
+            "m5dn.xlarge",  # multiple suffix letters, none "g"
+            "i3en.large",
+            "p4d.24xlarge",  # GPU, still x86_64 host
+        ],
+    )
+    def test_x86_families_are_x86_64(self, instance_type):
+        assert architecture_for_instance_type(instance_type) == ARCHITECTURE_X86_64
+
+    def test_g_in_prefix_is_not_graviton(self):
+        """g5 is an x86_64 GPU family: the "g" is the prefix, not the suffix.
+
+        This is the case a naive substring search gets wrong.
+        """
+        assert architecture_for_instance_type("g5.xlarge") == ARCHITECTURE_X86_64
+        assert architecture_for_instance_type("g6e.2xlarge") == ARCHITECTURE_X86_64
+
+    def test_case_is_normalised(self):
+        assert architecture_for_instance_type("C7G.XLARGE") == ARCHITECTURE_ARM64
+
+    def test_bare_family_without_size(self):
+        """Callers sometimes pass just the family."""
+        assert architecture_for_instance_type("c7g") == ARCHITECTURE_ARM64
+        assert architecture_for_instance_type("m5") == ARCHITECTURE_X86_64
+
+    def test_unparseable_family_falls_back_to_x86(self):
+        """An unrecognised shape keeps the pre-#84 behaviour rather than raising."""
+        assert architecture_for_instance_type("nonsense") == ARCHITECTURE_X86_64
+        assert architecture_for_instance_type("") == ARCHITECTURE_X86_64
+
+    def test_mac_metal_is_not_claimed_as_arm64(self):
+        """mac*.metal is arm64_mac and needs a macOS AMI, not an AL2023 arm64 one.
+
+        Returning x86_64 is no more wrong than arm64 would be -- either way the
+        caller must pass image_id explicitly -- but it must not silently select
+        an AL2023 arm64 image that cannot boot a Mac instance.
+        """
+        assert architecture_for_instance_type("mac2-m2.metal") == ARCHITECTURE_X86_64
+
+
+class TestGetDefaultAmiFromSSM:
+    """SSM is the primary source; the offline table is only a fallback."""
+
+    @mock_aws
+    def test_resolves_x86_64_from_ssm(self):
+        session = boto3.Session(region_name="us-east-1")
+
+        ami = get_default_ami("us-east-1", ARCHITECTURE_X86_64, session=session)
+
+        assert ami.startswith("ami-")
+        # Not the stale table entry: this came from the live parameter.
+        assert ami != DEFAULT_AMI_MAPPING["us-east-1"]
+
+    @mock_aws
+    def test_resolves_arm64_from_ssm(self):
+        session = boto3.Session(region_name="us-east-1")
+
+        ami = get_default_ami("us-east-1", ARCHITECTURE_ARM64, session=session)
+
+        assert ami.startswith("ami-")
+
+    @mock_aws
+    def test_arm64_and_x86_differ(self):
+        """The two architectures must not resolve to the same image."""
+        session = boto3.Session(region_name="us-east-1")
+
+        x86 = get_default_ami("us-east-1", ARCHITECTURE_X86_64, session=session)
+        arm = get_default_ami("us-east-1", ARCHITECTURE_ARM64, session=session)
+
+        assert x86 != arm
+
+    @mock_aws
+    def test_default_architecture_is_x86_64(self):
+        session = boto3.Session(region_name="us-east-1")
+
+        assert get_default_ami("us-east-1", session=session) == get_default_ami(
+            "us-east-1", ARCHITECTURE_X86_64, session=session
+        )
+
+    @mock_aws
+    def test_resolves_in_a_region_absent_from_the_table(self):
+        """The old lookup raised AMINotFoundError for any unlisted region.
+
+        me-central-1 is in no version of DEFAULT_AMI_MAPPING, so this can only
+        succeed via SSM.
+        """
+        assert "me-central-1" not in DEFAULT_AMI_MAPPING
+        session = boto3.Session(region_name="me-central-1")
+
+        assert get_default_ami("me-central-1", session=session).startswith("ami-")
+
+    def test_queries_the_kernel_default_alias(self):
+        """The version-independent alias, not a pinned kernel version.
+
+        Pinning 6.1/6.12/6.18 would just become the next stale constant.
+        """
+        session = MagicMock()
+        session.client.return_value.get_parameter.return_value = {
+            "Parameter": {"Value": "ami-abc123"}
+        }
+
+        assert get_default_ami("us-east-1", session=session) == "ami-abc123"
+
+        name = session.client.return_value.get_parameter.call_args.kwargs["Name"]
+        assert name == (
+            "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64"
+        )
+        assert "kernel-6." not in name
+
+    def test_uses_the_supplied_session(self):
+        """The caller's profile and endpoint must be honoured, not a bare default."""
+        session = MagicMock()
+        session.client.return_value.get_parameter.return_value = {
+            "Parameter": {"Value": "ami-fromsession"}
+        }
+
+        assert get_default_ami("eu-west-1", session=session) == "ami-fromsession"
+        session.client.assert_called_once_with("ssm", region_name="eu-west-1")
+
+    def test_arm64_parameter_name(self):
+        session = MagicMock()
+        session.client.return_value.get_parameter.return_value = {
+            "Parameter": {"Value": "ami-arm"}
+        }
+
+        get_default_ami("us-east-1", ARCHITECTURE_ARM64, session=session)
+
+        assert session.client.return_value.get_parameter.call_args.kwargs[
+            "Name"
+        ] == AMI_SSM_PARAMETER_TEMPLATE.format(architecture="arm64")
+
+
+class TestGetDefaultAmiFallback:
+    """Behaviour when SSM cannot be reached."""
+
+    def _failing_session(self, exc=None):
+        session = MagicMock()
+        session.client.return_value.get_parameter.side_effect = exc or ClientError(
+            {"Error": {"Code": "ParameterNotFound", "Message": "nope"}},
+            "GetParameter",
+        )
+        return session
+
+    def test_falls_back_to_offline_table(self):
+        """Offline test runs against moto/substrate must still get an AMI."""
+        session = self._failing_session()
+
+        ami = get_default_ami("us-east-1", session=session)
+
+        assert ami == DEFAULT_AMI_MAPPING["us-east-1"]
+
+    def test_falls_back_when_credentials_are_absent(self):
+        session = self._failing_session(NoCredentialsError())
+
+        assert (
+            get_default_ami("eu-west-1", session=session)
+            == (DEFAULT_AMI_MAPPING["eu-west-1"])
+        )
+
+    def test_arm64_refuses_the_x86_only_table(self):
+        """Handing an x86_64 AMI to a Graviton instance is an opaque failure.
+
+        Better to raise here, where the message can say why, than to let EC2
+        reject the launch minutes later.
+        """
+        session = self._failing_session()
+
+        with pytest.raises(AMINotFoundError, match="arm64"):
+            get_default_ami("us-east-1", ARCHITECTURE_ARM64, session=session)
+
+    def test_unknown_region_raises_with_the_ssm_cause(self):
+        session = self._failing_session()
+
+        with pytest.raises(AMINotFoundError) as excinfo:
+            get_default_ami("me-central-1", session=session)
+
+        # The message must name the real cause, not just "no AMI found".
+        assert "ParameterNotFound" in str(excinfo.value)
+
+    def test_rejects_an_unsupported_architecture(self):
+        with pytest.raises(AMINotFoundError, match="Unsupported architecture"):
+            get_default_ami("us-east-1", "sparc64")
+
+    def test_fallback_table_entries_are_well_formed(self):
+        """Two entries in the previous table were structurally invalid AMI IDs.
+
+        ``InvalidAMIID.Malformed`` from EC2 means they could never have worked in
+        any region, so shape is worth asserting even though freshness cannot be.
+        """
+        assert DEFAULT_AMI_MAPPING, "fallback table must not be empty"
+        for region, ami in DEFAULT_AMI_MAPPING.items():
+            body = ami.removeprefix("ami-")
+            assert ami.startswith("ami-"), f"{region}: {ami}"
+            assert len(body) == 17, f"{region}: {ami} has {len(body)} hex chars"
+            assert all(c in "0123456789abcdef" for c in body), f"{region}: {ami}"

--- a/tests/unit/test_spot_fleet.py
+++ b/tests/unit/test_spot_fleet.py
@@ -12,7 +12,10 @@ import logging
 import pytest
 
 from parsl_ephemeral_aws.compute.spot_fleet import SpotFleetManager
-from parsl_ephemeral_aws.constants import TAG_PREFIX
+from parsl_ephemeral_aws.constants import (
+    SPOT_FLEET_DEFAULT_ALLOCATION_STRATEGY,
+    TAG_PREFIX,
+)
 from parsl_ephemeral_aws.exceptions import SpotFleetThrottlingError
 
 pytestmark = pytest.mark.unit
@@ -339,6 +342,73 @@ class TestSpotFleetManager(unittest.TestCase):
             # services that tolerate them.
             name = next(tag["Value"] for tag in spec["Tags"] if tag["Key"] == "Name")
             self.assertTrue(name.startswith(TAG_PREFIX))
+
+    def _request_fleet_with(self, mock_credential_manager_cls, provider):
+        """Drive ``_create_spot_fleet_request`` and return the config it sent."""
+        mock_ec2_client = MagicMock()
+        mock_session = MagicMock()
+        mock_session.client.return_value = mock_ec2_client
+        mock_session.resource.return_value = MagicMock()
+        mock_credential_manager_cls.return_value.create_boto3_session.return_value = (
+            mock_session
+        )
+        mock_ec2_client.request_spot_fleet.return_value = {
+            "SpotFleetRequestId": "sfr-123"
+        }
+
+        SpotFleetManager(provider)._create_spot_fleet_request(
+            "block-123",
+            {
+                "vpc_id": "vpc-12345678",
+                "subnet_id": "subnet-12345678",
+                "security_group_id": "sg-12345678",
+            },
+            1,
+            "arn:aws:iam::123456789012:role/fleet-role",
+        )
+        return mock_ec2_client.request_spot_fleet.call_args.kwargs[
+            "SpotFleetRequestConfig"
+        ]
+
+    @patch("parsl_ephemeral_aws.compute.spot_fleet.CredentialManager")
+    def test_configured_allocation_strategy_reaches_the_api(
+        self, mock_credential_manager_cls
+    ):
+        """The provider's ``spot_allocation_strategy`` must actually be sent (#84).
+
+        It was hardcoded to ``lowestPrice`` here, so the configured value was
+        never read at all -- which is why this asserts on the request boto3
+        received rather than on the helper that converts the spelling.
+        """
+        self.mock_provider.spot_allocation_strategy = "capacity-optimized"
+
+        config = self._request_fleet_with(
+            mock_credential_manager_cls, self.mock_provider
+        )
+
+        # Converted to the only spelling RequestSpotFleet accepts.
+        self.assertEqual(config["AllocationStrategy"], "capacityOptimized")
+
+    @patch("parsl_ephemeral_aws.compute.spot_fleet.CredentialManager")
+    def test_allocation_strategy_defaults_when_provider_omits_it(
+        self, mock_credential_manager_cls
+    ):
+        """StandardMode's provider stand-in may not carry the attribute at all.
+
+        ``_SimpleProvider`` raises ``AttributeError`` for anything it was not
+        given, so this exercises the ``getattr(..., default)`` fall-through the
+        way production does.
+        """
+        self.assertFalse(hasattr(self.mock_provider, "spot_allocation_strategy"))
+
+        config = self._request_fleet_with(
+            mock_credential_manager_cls, self.mock_provider
+        )
+
+        self.assertEqual(
+            config["AllocationStrategy"], SPOT_FLEET_DEFAULT_ALLOCATION_STRATEGY
+        )
+        self.assertNotEqual(config["AllocationStrategy"], "lowestPrice")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Phase 4 of the v0.7.0 repair. Closes #84.

## AMI resolution moves to SSM

`get_default_ami()` now queries AWS's public SSM Parameter Store alias
`/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-{x86_64,arm64}`,
which AWS repoints at every AL2023 release. `DEFAULT_AMI_MAPPING` is demoted to
an offline fallback, used only when the SSM call fails — chiefly so moto- and
substrate-backed tests need no network.

The issue calls the old table "already stale". It was worse than that. Audited
against real AWS, **all 21 entries were unusable**:

| outcome | count |
|---|---|
| `DeprecationTime` of 2026-05-17 | 9 |
| `InvalidAMIID.NotFound` | 6 |
| `InvalidAMIID.Malformed` | 2 |
| region unreachable / `AuthFailure` | 4 |

Nothing in the package noticed, because a deprecated AMI still launches until AWS
deletes it. The table's header also claimed `kernel-6.12`, while
`describe_images` reported the us-east-1 entry was built from `kernel-6.1` — the
comment was wrong the day it was written.

`kernel-default` is used rather than the pinned `kernel-6.12` the issue's wording
implies: it is AWS's version-independent alias, and naming a kernel version would
only re-create the staleness this change removes. A test asserts
`"kernel-6." not in name`.

The refreshed fallback drops the four opt-in regions the old table listed
(af-south-1, ap-east-1, eu-south-1, me-south-1) — they cannot be read without
enabling the region, so no value could be verified. SSM resolves them normally
from an account that has them enabled.

## arm64 / Graviton

Nothing distinguished architectures before, and every AMI the package could reach
was x86_64, so a Graviton `instance_type` could not launch at all.
`architecture_for_instance_type()` reads the family's **generation suffix** — AWS
appends `g` to every arm64 family (`c7g`, `m8g`, `r7gd`, `c8gn`) and to no x86_64
one — so `g5`/`g6e`, where the `g` is a prefix, correctly stay x86_64. That is
the case a naive substring search gets wrong.

Validated against `describe_instance_types` for all **1,346** types offered in
us-east-1: 396 arm64, 950 x86_64, **zero misclassifications**. `a1` is
special-cased as the original Graviton family, which predates the convention.

## Allocation strategy — and a correction to the issue

Both `SpotFleetManager._create_spot_fleet_request()` and the fleet request inside
the generated bastion-manager script hardcoded `lowestPrice`. The defect was not
a wrong value but a **bypass**: `spot_allocation_strategy` was never read at any
call site, so every spot fleet drew from the pools with the *least* spare
capacity — the most interruption-prone choice available.

**#84's instruction to send `price-capacity-optimized` to Spot Fleet would have
broken spot fleet entirely.** The two fleet APIs spell the same enum differently
and each rejects the other's spelling. Verified against real EC2 in us-east-1,
using a request anchored on a malformed AMI so no fleet could be created:

```
RequestSpotFleet  AllocationStrategy="price-capacity-optimized"
    -> InvalidParameterValue: ... failed to satisfy constraint
RequestSpotFleet  AllocationStrategy="priceCapacityOptimized"
    -> InvalidParameterValue: Invalid value 'ami-notavalidamiid' for amiId
       (strategy accepted; the AMI was the only complaint)
CreateFleet       AllocationStrategy="priceCapacityOptimized"
    -> InvalidParameter: AllocationStrategy must be "lowest-price", ...
```

`DryRun=True` does not validate this enum — `totalNonsense` and `""` both return
`DryRunOperation` — which is why the probe needed the malformed-AMI anchor.

So `spot_allocation_strategy` stays kebab-case, as every docstring has always
documented and as `CreateFleet` will need in #86, and
`normalize_spot_fleet_allocation_strategy()` converts it at the RequestSpotFleet
boundary. `SPOT_FLEET_DEFAULT_ALLOCATION_STRATEGY` holds the camelCase form,
`EC2_FLEET_DEFAULT_ALLOCATION_STRATEGY` the kebab-case one. I'll leave a
correcting comment on #84.

The bastion script's strategy is substituted in as a literal: the bastion runs
that script standalone and cannot import from this package.

## Verification

Real AWS (`AWS_PROFILE=aws`):

- SSM resolves both architectures in us-east-1, eu-central-1, and
  **ap-southeast-4** — a region in no version of the table, which the old
  dict-lookup would have raised `AMINotFoundError` for.
- Every resolved AMI is `available` and its `Architecture` matches what was
  requested; `t3.micro`/`g5.xlarge` → x86_64, `c7g.large`/`m8g.xlarge` → arm64.
- `EphemeralAWSProvider(instance_type="c7g.large")` resolves an arm64 AMI;
  `t3.micro` resolves x86_64.
- **Plan verification item 7:** a `t4g.nano` launched from the SSM-resolved AMI in
  ap-southeast-4 reached `running` with `Architecture=arm64`, then terminated —
  no orphaned instances or volumes.
- An opt-in region that is *not* enabled fails with a message naming the real
  cause (`UnrecognizedClientException`) rather than a bare "no AMI found".

Gates:

| gate | before | after |
|---|---|---|
| `pytest tests/unit tests/security` | 658 passed | **721 passed, 0 failed** |
| coverage | 69.70% | **69.94%** |
| `ruff check parsl_ephemeral_aws tests` | clean | clean |
| `mypy parsl_ephemeral_aws` | 89 errors | 89 errors (no regression) |
| marked vs unmarked unit collection | equal | equal (628 / 628) |
| `pytest tests/integration` (substrate) | 30F/37P/11S/11E | 30F/37P/11S/11E (pre-existing #92) |

## Tests

`tests/unit/test_ami_resolution.py` (35) and `tests/unit/test_allocation_strategy.py` (25).

Both defects were that a configured value was never read, so the suites assert on
what actually leaves the package, not just on the helpers: the
`SpotFleetRequestConfig` boto3 receives, the injected literal in the generated
bastion script (and that the script still parses), and source-level guards
against `lowestPrice` being reintroduced. moto seeds the public AL2023 SSM
parameters, so the SSM path itself is unit-tested rather than only its fallback.

One incidental fix: `normalize_spot_fleet_allocation_strategy()` rejects
non-strings explicitly. A `MagicMock` reaching `.split()` returns another mock
that unpacks to nothing, and "not enough values to unpack" names neither the
argument nor the caller — which is exactly what a mock-heavy suite hands in.
