### PR TITLE
feat: launch templates and IMDSv2 on every launch path (closes #85)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Security
+- **IMDSv2 is now required on every instance the package launches.** Nothing set
+  `MetadataOptions` anywhere before, so every worker, bastion, spot instance, and
+  fleet instance accepted unauthenticated IMDSv1 requests — the shape that turns
+  any SSRF in user code into instance-credential theft, and the workers run
+  arbitrary submitted commands. `HttpTokens=required` is carried by the launch
+  template, so it applies to the on-demand, spot, and fleet paths at once; the
+  bastion's own `RunInstances` call and the bastion-manager script's worker
+  launches set it directly. `HttpEndpoint` stays `enabled` (SSM reads the instance
+  identity document from IMDS, so disabling it would break dispatch), and the hop
+  limit is deliberately left at EC2's default of 2 rather than tightened to 1 —
+  a request from inside a container spawned by `worker_init` traverses the host
+  network namespace and costs a hop. No IMDSv1 fetch exists anywhere in the
+  package, so nothing internal depended on the old default (closes #85).
 - `ServerlessMode.cleanup_infrastructure()` no longer deletes the caller's
   security group. The code was guarded only by a comment claiming "if we created
   it directly" — nothing verified ownership, and after #69 the ID is always
@@ -27,6 +40,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   live VPC and blackhole egress for unrelated workloads (closes #94).
 
 ### Fixed
+- A spot instance that shut itself down was left `stopped` with a billed EBS
+  volume that the provider had already forgotten about. `InstanceInitiatedShutdownBehavior`
+  is not a member of the `LaunchSpecification` shape `RequestSpotInstances`
+  accepts, so the spot path could not set it and EC2's `stop` default applied to
+  the `shutdown -h now` that `_prepare_init_script` appends — while
+  `EC2_STATUS_MAPPING` maps `stopped` to COMPLETED, so `_cleanup_resources()`
+  dropped the tracking record and the volume was orphaned *and* untracked. This is
+  the same leak Phase 1.3a closed on the on-demand path, still open on spot. The
+  spot path now launches through `RunInstances` with
+  `InstanceMarketOptions={"MarketType": "spot"}`, which does accept both
+  `InstanceInitiatedShutdownBehavior` and `MetadataOptions` — verified against
+  real EC2: the instance reports `InstanceLifecycle=spot` with a spot request ID,
+  shutdown behaviour `terminate`, and `HttpTokens=required` (closes #85).
+- `SpotFleetManager.terminate_block()` leaked the block's launch template whenever
+  no fleet request ID had been recorded for the block. It logged a warning and
+  returned before the template was deleted, so a block whose request failed
+  between creation and bookkeeping held its template until
+  `cleanup_all_resources()` ran — or forever, if the process died first. The
+  template belongs to the block, not to the fleet request, and is now deleted on
+  that path too (refs #85).
+- The `SpotFleetManager` provider stand-in that `StandardMode` builds never
+  carried `iam_instance_profile_arn`, so the manager's `getattr` fell through to
+  `None` and every fleet instance launched with no instance profile — SSM never
+  came online and dispatch silently fell back to UserData. The stand-in is built
+  in `__init__`, before `_resolve_instance_profile()` runs, so the resolved ARN is
+  now also propagated to it once known (refs #85).
 - Spot fleet requests ignored `spot_allocation_strategy` entirely. Both
   `SpotFleetManager._create_spot_fleet_request()` and the fleet request inside
   the generated bastion-manager script hardcoded `lowestPrice`, so the
@@ -387,6 +426,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a first run can proceed with no saved state (closes #122).
 
 ### Added
+- **Launch templates.** `StandardMode.initialize()` now builds one launch template
+  that every launch path shares — on-demand, spot, and spot fleet — carrying the
+  AMI, instance type, network interface, key pair, IMDSv2 settings,
+  `InstanceInitiatedShutdownBehavior`, and the resolved IAM instance profile.
+  Per-job `UserData` and tags stay per-launch overrides. The template is tagged
+  with the provider ID and deleted by `cleanup_infrastructure()`; its ID and
+  version are persisted, and a state document written before this change gets a
+  template on resume. This is the hard prerequisite for the EC2 Fleet/ASG
+  migration in #86: those APIs accept a template reference and nothing resembling
+  `RunInstances` kwargs (closes #85).
+- `build_launch_template_data()`, `create_launch_template()`,
+  `delete_launch_template()`, and `encode_user_data()` in `utils/aws.py`, plus
+  `IMDSV2_METADATA_OPTIONS` and `LAUNCH_TEMPLATE_NAME_PREFIX` in `constants.py`.
+  `create_launch_template()` is idempotent: `initialize()` may run again after a
+  partial failure, and a duplicate name is rejected with
+  `InvalidLaunchTemplateName.AlreadyExistsException`, so an existing template is
+  adopted by adding a *new version* rather than reusing the old one — otherwise a
+  resumed provider whose AMI or instance type had changed would silently keep
+  launching the previous definition.
+- Spot Fleet builds a launch template per block. `SpotFleetLaunchSpecification`
+  has no `MetadataOptions` member, so a template is the only route to IMDSv2 on
+  the fleet path, and `LaunchTemplateConfig.Overrides` carries no `UserData` — the
+  per-block user data has to live in a per-block template rather than in
+  overrides. If template creation fails the manager falls back to
+  `LaunchSpecifications` and logs that IMDSv2 will not be enforced.
+- `tests/aws/test_launch_template_e2e.py` — real-AWS coverage for what only a live
+  launch can show: that the stored template carries IMDSv2 and `terminate`, that
+  an instance launched from it inherits both, that the spot instance really is
+  spot rather than a silent on-demand downgrade, and that `shutdown()` deletes the
+  template.
 - AMIs are resolved at runtime from AWS's public SSM Parameter Store aliases
   (`/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-{arch}`), which
   AWS repoints at every AL2023 release. Any region works, including ones no
@@ -535,6 +604,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   template is caught (refs #112, #113).
 
 ### Changed
+- Plain spot instances are requested with `RunInstances` +
+  `InstanceMarketOptions` instead of `RequestSpotInstances`. The old API cannot
+  express either IMDSv2 or the shutdown behaviour, as above. `RequestSpotInstances`
+  remains the fallback for accounts without `ec2:CreateLaunchTemplate`, where the
+  provider keeps working without IMDSv2 on that one path.
+- Four API asymmetries drove the shape of this work and are recorded here because
+  each is invisible in a mock and expensive to rediscover, all verified against
+  the botocore service model and real EC2:
+  - **botocore base64-encodes `UserData` for `RunInstances` only.** The two
+    built-in handlers are `before-parameter-build.ec2.RunInstances` and
+    `before-parameter-build.autoscaling.CreateLaunchConfiguration`;
+    `CreateLaunchTemplate` is not among them. Plaintext user data in a template is
+    stored verbatim, base64-*decoded* by cloud-init, and fails silently — the
+    instance boots fine and never runs the worker. Encoding twice is the
+    mirror-image trap, which is why `encode_user_data()` exists and is applied to
+    template data only.
+  - **The `InstanceStopped` waiter lists `terminated` as an explicit *failure*
+    acceptor.** The AMI-baking builder instance must therefore keep
+    `InstanceInitiatedShutdownBehavior="stop"`; inheriting the template's
+    `terminate` would fail the bake outright, not merely slow it. The builder
+    deliberately does not use the launch template.
+  - **`RequestSpotFleet` accepts both `LaunchSpecifications` and
+    `LaunchTemplateConfigs` in one request** — a DryRun with both returns
+    `DryRunOperation`. The template would silently lose to the specifications,
+    taking IMDSv2 with it, so exactly one launch form is sent.
+  - **A launch template rejects a `NetworkInterfaces` entry together with
+    top-level `SecurityGroupIds`.** The interface form is required for
+    `AssociatePublicIpAddress`, so it wins whenever a subnet is known.
 - The default spot allocation strategy is now `price-capacity-optimized`, AWS's
   current recommendation, replacing the documented-but-unused
   `capacity-optimized`. It draws from the pools with the deepest spare capacity

--- a/parsl_ephemeral_aws/compute/spot_fleet.py
+++ b/parsl_ephemeral_aws/compute/spot_fleet.py
@@ -11,7 +11,6 @@ import logging
 import uuid
 import time
 import json
-import base64
 from typing import Dict, List, Optional, Any
 
 from botocore.exceptions import ClientError, NoCredentialsError
@@ -24,6 +23,7 @@ from ..exceptions import (
     SpotFleetThrottlingError,
 )
 from ..constants import (
+    LAUNCH_TEMPLATE_NAME_PREFIX,
     TAG_PREFIX,
     TAG_MANAGED,
     TAG_WORKFLOW_ID,
@@ -40,6 +40,10 @@ from ..constants import (
 )
 from ..config import SecurityConfig
 from ..utils.aws import (
+    build_launch_template_data,
+    create_launch_template,
+    delete_launch_template,
+    encode_user_data,
     normalize_spot_fleet_allocation_strategy,
     resolve_manager_session,
 )
@@ -173,6 +177,9 @@ class SpotFleetManager:
         self.fleet_requests: Dict[str, Any] = {}
         self.instances: Dict[str, Any] = {}
         self.blocks: Dict[str, Any] = {}
+        # block_id -> launch template ID, so each block's template is deleted
+        # when the block is terminated (#85).
+        self.launch_templates: Dict[str, str] = {}
 
     def _setup_security_config(self) -> None:
         """Set up security configuration from provider settings."""
@@ -522,6 +529,112 @@ class SpotFleetManager:
 
             raise ResourceCreationError(f"Failed to create blocks: {e}")
 
+    def _build_launch_template_config(
+        self,
+        block_id: str,
+        network: Dict[str, str],
+        instance_types: List[str],
+        instance_tags: List[Dict[str, str]],
+    ) -> Optional[Dict[str, Any]]:
+        """Build a ``LaunchTemplateConfig`` for this block, or None on failure.
+
+        One template per block, because the user data is per-block and the
+        ``Overrides`` shape cannot carry it -- it accepts only
+        ``InstanceType``/``SubnetId``/price/priority. The instance types become
+        overrides so a single template still covers every pool the fleet may
+        draw from.
+
+        Returns None if the template cannot be created, in which case the caller
+        falls back to ``LaunchSpecifications``. That fallback launches without
+        IMDSv2, which is unavoidable: ``SpotFleetLaunchSpecification`` has no
+        ``MetadataOptions`` member.
+
+        Parameters
+        ----------
+        block_id : str
+            Block this template serves; also names the template.
+        network : Dict[str, str]
+            Resolved ``subnet_id`` and ``security_group_id``.
+        instance_types : List[str]
+            Types to emit as overrides.
+        instance_tags : List[Dict[str, str]]
+            Tags applied to launched instances.
+
+        Returns
+        -------
+        Optional[Dict[str, Any]]
+            A ``LaunchTemplateConfig``, or None to use the legacy form.
+        """
+        name = f"{LAUNCH_TEMPLATE_NAME_PREFIX}-fleet-{block_id}"
+        try:
+            template_data = build_launch_template_data(
+                image_id=self.provider.image_id,
+                instance_type=instance_types[0],
+                subnet_id=network["subnet_id"],
+                security_group_id=network["security_group_id"],
+                associate_public_ip=getattr(self.provider, "use_public_ips", True),
+                key_name=getattr(self.provider, "key_name", None),
+                iam_instance_profile_arn=getattr(
+                    self.provider, "iam_instance_profile_arn", None
+                ),
+                # Fleet instances are reclaimed by cancelling the fleet request
+                # with TerminateInstances=True, so an instance that shuts itself
+                # down should terminate rather than linger as a billed volume.
+                shutdown_behavior="terminate",
+                user_data=self._generate_user_data(),
+            )
+            # Instances launched from the template carry the block tags; the
+            # template resource itself carries them too, so a leaked template is
+            # traceable to the workflow that made it.
+            template_data["TagSpecifications"] = [
+                {"ResourceType": "instance", "Tags": list(instance_tags)}
+            ]
+
+            template_id, version = create_launch_template(
+                self.ec2_client, name, template_data, list(instance_tags)
+            )
+            self.launch_templates[block_id] = template_id
+            logger.debug(
+                f"Created launch template {template_id} for fleet block {block_id}"
+            )
+            return {
+                "LaunchTemplateSpecification": {
+                    "LaunchTemplateId": template_id,
+                    "Version": version,
+                },
+                "Overrides": [
+                    {
+                        "InstanceType": instance_type,
+                        "SubnetId": network["subnet_id"],
+                    }
+                    for instance_type in instance_types
+                ],
+            }
+        except Exception as e:
+            logger.warning(
+                f"Could not create launch template for block {block_id}: {e}. "
+                "Falling back to LaunchSpecifications; IMDSv2 will not be "
+                "enforced on these instances."
+            )
+            return None
+
+    def _delete_launch_template_for_block(self, block_id: str) -> None:
+        """Delete the launch template created for *block_id*, if any.
+
+        Deleting a template does not affect instances already launched from it,
+        so this is safe as soon as the fleet request is cancelled.
+        """
+        template_id = self.launch_templates.pop(block_id, None)
+        if not template_id:
+            return
+        try:
+            delete_launch_template(self.ec2_client, template_id)
+        except Exception as e:
+            logger.warning(
+                f"Failed to delete launch template {template_id} for block "
+                f"{block_id}: {e}"
+            )
+
     def _create_spot_fleet_request(
         self,
         block_id: str,
@@ -564,6 +677,25 @@ class SpotFleetManager:
             else [self.provider.instance_type]
         )
 
+        instance_tags = [
+            {"Key": "Name", "Value": f"{TAG_PREFIX}-node-{block_id[:8]}"},
+            {"Key": TAG_MANAGED, "Value": "true"},
+            {"Key": TAG_WORKFLOW_ID, "Value": self.provider.workflow_id},
+            {"Key": TAG_BLOCK_ID, "Value": block_id},
+        ]
+        for key, value in self.provider.tags.items():
+            instance_tags.append({"Key": key, "Value": value})
+
+        # Prefer a launch template (#85). This is the only way to get IMDSv2 onto
+        # Spot Fleet instances at all: SpotFleetLaunchSpecification has no
+        # MetadataOptions member, and the LaunchTemplateConfig Overrides shape
+        # carries only InstanceType/SubnetId/price/priority -- no UserData or
+        # TagSpecifications -- so the per-block user data has to live in a
+        # per-block template rather than in the overrides.
+        launch_template_config = self._build_launch_template_config(
+            block_id, network, instance_types, instance_tags
+        )
+
         # Generate specs for each instance type
         for instance_type in instance_types:
             try:
@@ -572,33 +704,14 @@ class SpotFleetManager:
                     "InstanceType": instance_type,
                     "SubnetId": network["subnet_id"],
                     "SecurityGroups": [{"GroupId": network["security_group_id"]}],
-                    "UserData": base64.b64encode(
-                        self._generate_user_data().encode()
-                    ).decode(),
+                    "UserData": encode_user_data(self._generate_user_data()),
                     "TagSpecifications": [
                         {
                             "ResourceType": "instance",
-                            "Tags": [
-                                {
-                                    "Key": "Name",
-                                    "Value": f"{TAG_PREFIX}-node-{block_id[:8]}",
-                                },
-                                {"Key": TAG_MANAGED, "Value": "true"},
-                                {
-                                    "Key": TAG_WORKFLOW_ID,
-                                    "Value": self.provider.workflow_id,
-                                },
-                                {"Key": TAG_BLOCK_ID, "Value": block_id},
-                            ],
+                            "Tags": list(instance_tags),
                         }
                     ],
                 }
-
-                # Add provider tags
-                for key, value in self.provider.tags.items():
-                    launch_spec["TagSpecifications"][0]["Tags"].append(
-                        {"Key": key, "Value": value}
-                    )
 
                 # Add key name if provided
                 if self.provider.key_name:
@@ -617,7 +730,6 @@ class SpotFleetManager:
                 "TargetCapacity": target_capacity,
                 "OnDemandTargetCapacity": 0,  # Use only spot instances
                 "IamFleetRole": fleet_role_arn,
-                "LaunchSpecifications": launch_specifications,
                 "TerminateInstancesWithExpiration": True,
                 "Type": "maintain",  # Maintain target capacity
                 # Honour the provider's spot_allocation_strategy instead of
@@ -651,6 +763,18 @@ class SpotFleetManager:
                 ],
             }
         }
+
+        # Exactly one of the two launch forms. EC2 tolerates both keys being
+        # present, but then the template silently loses to the specifications --
+        # and with it IMDSv2 -- so only the preferred one is sent (#85).
+        if launch_template_config:
+            request_params["SpotFleetRequestConfig"]["LaunchTemplateConfigs"] = [
+                launch_template_config
+            ]
+        else:
+            request_params["SpotFleetRequestConfig"]["LaunchSpecifications"] = (
+                launch_specifications
+            )
 
         # Add provider tags to fleet request
         for key, value in self.provider.tags.items():
@@ -1025,6 +1149,10 @@ class SpotFleetManager:
         fleet_request_id = self.blocks[block_id].get("fleet_request_id")
         if not fleet_request_id:
             logger.warning(f"No fleet request ID found for block {block_id}")
+            # Still drop the template: it belongs to the block, not to the fleet
+            # request, and a block whose request never got recorded would
+            # otherwise leak it until cleanup_all_resources runs (#85).
+            self._delete_launch_template_for_block(block_id)
             return
 
         try:
@@ -1050,6 +1178,11 @@ class SpotFleetManager:
             for instance_id in instance_ids:
                 if instance_id in self.instances:
                     self.instances[instance_id]["status"] = "terminated"
+
+            # The block's launch template has no further use once the request is
+            # cancelled, and deleting it does not disturb instances still
+            # shutting down (#85).
+            self._delete_launch_template_for_block(block_id)
 
         except ClientError as e:
             error_code = e.response["Error"]["Code"]
@@ -1125,6 +1258,11 @@ class SpotFleetManager:
                                 )
                 except Exception as e:
                     logger.error(f"Error cancelling Spot Fleet requests: {e}")
+
+            # Delete every per-block launch template (#85). Iterated over a copy
+            # of the keys because the helper pops from the dict as it goes.
+            for block_id in list(self.launch_templates):
+                self._delete_launch_template_for_block(block_id)
 
             # Clean up IAM role if we created one
             if self.iam_fleet_role_arn:

--- a/parsl_ephemeral_aws/constants.py
+++ b/parsl_ephemeral_aws/constants.py
@@ -145,6 +145,28 @@ RESOURCE_TYPE_BASTION = "bastion"
 RESOURCE_TYPE_CLOUDFORMATION = "cloudformation"
 RESOURCE_TYPE_LAMBDA_FUNCTION = "lambda_function"
 RESOURCE_TYPE_ECS_TASK = "ecs_task"
+RESOURCE_TYPE_LAUNCH_TEMPLATE = "launch-template"
+
+# Instance metadata service options applied to every launch (#85).
+#
+# IMDSv2 ("HttpTokens": "required") makes the metadata service reject the
+# unauthenticated IMDSv1 GET, which is the request an SSRF-ed application can be
+# tricked into making on the instance's behalf to read its role credentials.
+# IMDSv2 requires a PUT to obtain a token first, and browsers and most proxies
+# will not issue one.
+#
+# HttpEndpoint stays "enabled" because the SSM agent reads the instance identity
+# document from it; disabling the endpoint outright would break the warm-pool
+# and one-shot dispatch paths, which run over SSM.
+#
+# The hop limit stays at EC2's default of 2 rather than being lowered to 1:
+# worker_init may run containers, and a container's request traverses the
+# host's network namespace, which costs a hop. A limit of 1 would leave
+# metadata unreachable from inside a container.
+IMDSV2_METADATA_OPTIONS = {
+    "HttpTokens": "required",
+    "HttpEndpoint": "enabled",
+}
 
 # Spot fleet constants
 SPOT_FLEET_TARGET_CAPACITY_TYPE = "TargetCapacity"
@@ -213,6 +235,9 @@ DEFAULT_SPOT_MAX_RECOVERY_ATTEMPTS = 3
 DEFAULT_TAG_PREFIX = "parsl-ephemeral"
 TAG_PREFIX = DEFAULT_TAG_PREFIX  # Alias for compatibility
 TAG_NAME = "Name"
+# Launch template naming (#85). The provider ID is appended, keeping the whole
+# name unique per provider instance and well inside EC2's 128-character limit.
+LAUNCH_TEMPLATE_NAME_PREFIX = f"{DEFAULT_TAG_PREFIX}-lt"
 # Marker tag identifying a resource as created by this provider (#109).
 #
 # This used to be TAG_NAME, which is the EC2-reserved "Name" key. Every tag list

--- a/parsl_ephemeral_aws/modes/detached.py
+++ b/parsl_ephemeral_aws/modes/detached.py
@@ -20,6 +20,7 @@ import boto3
 from botocore.exceptions import ClientError
 
 from parsl_ephemeral_aws.constants import (
+    IMDSV2_METADATA_OPTIONS,
     RESOURCE_TYPE_EC2,
     RESOURCE_TYPE_BASTION,
     RESOURCE_TYPE_CLOUDFORMATION,
@@ -379,6 +380,12 @@ class DetachedMode(OperatingMode):
                 NetworkInterfaces=[network_interface],
                 InstanceInitiatedShutdownBehavior="terminate",
                 Monitoring={"Enabled": True},
+                # IMDSv2 required (#85). This matters more here than on a
+                # worker: the bastion is long-lived and its instance profile
+                # carries the permissions to launch and terminate instances, so
+                # an SSRF against anything running on it would otherwise hand
+                # over role credentials through an unauthenticated IMDSv1 GET.
+                MetadataOptions=dict(IMDSV2_METADATA_OPTIONS),
             )
 
             instance_id = response["Instances"][0]["InstanceId"]
@@ -741,6 +748,10 @@ RESOURCE_TYPE_SPOT_FLEET = "spot_fleet"
 # mode's spot_allocation_strategy (#84). RequestSpotFleet accepts only the
 # camelCase spelling, so the value substituted here is already normalised.
 ALLOCATION_STRATEGY = 'priceCapacityOptimized'
+# IMDSv2 options for workers this bastion launches, overwritten at script
+# generation time from the package constant (#85). Defined as a literal because
+# the bastion runs this script standalone and cannot import from the package.
+METADATA_OPTIONS = {'HttpTokens': 'required', 'HttpEndpoint': 'enabled'}
 EC2_STATUS_MAPPING = {
     'pending': 'PENDING',
     'running': 'RUNNING',
@@ -1219,6 +1230,7 @@ export PARSL_WORKER_ID=$(hostname)
                 ],
                 'Monitoring': {'Enabled': True},
                 'InstanceInitiatedShutdownBehavior': 'terminate',
+                'MetadataOptions': METADATA_OPTIONS,
             }
 
             # Add key name if provided
@@ -1528,6 +1540,14 @@ if __name__ == '__main__':
             "ALLOCATION_STRATEGY = 'priceCapacityOptimized'",
             "ALLOCATION_STRATEGY = "
             f"'{normalize_spot_fleet_allocation_strategy(self.spot_allocation_strategy)}'"
+            "  # injected at script generation time",
+        )
+        # Same reason as above: injected as a literal so the workers the bastion
+        # launches get IMDSv2 from the one definition in constants.py, rather
+        # than a copy here that drifts the next time it changes (#85).
+        script = script.replace(
+            "METADATA_OPTIONS = {'HttpTokens': 'required', 'HttpEndpoint': 'enabled'}",
+            f"METADATA_OPTIONS = {IMDSV2_METADATA_OPTIONS!r}"
             "  # injected at script generation time",
         )
         return script

--- a/parsl_ephemeral_aws/modes/standard.py
+++ b/parsl_ephemeral_aws/modes/standard.py
@@ -19,6 +19,8 @@ from botocore.exceptions import ClientError
 from parsl_ephemeral_aws.constants import (
     DEFAULT_SPOT_ALLOCATION_STRATEGY,
     EC2_STATUS_MAPPING,
+    IMDSV2_METADATA_OPTIONS,
+    LAUNCH_TEMPLATE_NAME_PREFIX,
     RESOURCE_TYPE_EC2,
     RESOURCE_TYPE_SPOT_FLEET,
     STATUS_CANCELED,
@@ -43,6 +45,9 @@ from parsl_ephemeral_aws.compute.spot_interruption import (
 )
 from parsl_ephemeral_aws.utils.aws import (
     architecture_for_instance_type,
+    build_launch_template_data,
+    create_launch_template,
+    delete_launch_template,
     get_default_ami,
     get_or_create_ssm_instance_profile,
     wait_for_resource,
@@ -213,6 +218,12 @@ class StandardMode(OperatingMode):
         # One-shot mode: each instance runs exactly one command then terminates
         self.one_shot = one_shot
 
+        # Launch template (#85). Built in initialize() so every launch path --
+        # on-demand, spot, and fleet -- shares one definition carrying IMDSv2,
+        # the shutdown behaviour, and the resolved instance profile.
+        self._launch_template_id: Optional[str] = None
+        self._launch_template_version: Optional[str] = None
+
         # Initialize SpotFleetManager if using spot fleet
         self.spot_fleet_manager = None
         self.spot_interruption_monitor = None
@@ -240,6 +251,12 @@ class StandardMode(OperatingMode):
                     "spot_max_price_percentage": self.spot_max_price_percentage,
                     "worker_init": self.worker_init,
                     "tags": self.additional_tags,
+                    # Read by _build_launch_template_config (#85). Without it the
+                    # manager's getattr fell through to None and every fleet
+                    # instance launched with no instance profile, so SSM never
+                    # came online. Still None here on the auto-create path --
+                    # _resolve_instance_profile() overwrites it once resolved.
+                    "iam_instance_profile_arn": self.iam_instance_profile_arn,
                 },
             )
 
@@ -377,6 +394,19 @@ class StandardMode(OperatingMode):
             "MinCount": 1,
             "MaxCount": 1,
             "UserData": user_data,
+            # IMDSv2 on the builder as well: whatever worker_init fetches from
+            # the metadata service must work under the same rules the baked
+            # image will boot under, or a script that works here breaks on
+            # every worker launched from the resulting AMI (#85).
+            "MetadataOptions": dict(IMDSV2_METADATA_OPTIONS),
+            # Explicitly *stop*, not terminate. This is the one launch in the
+            # mode that must not inherit the launch template's terminate
+            # behaviour: the UserData ends in `shutdown -h now`, and create_image
+            # needs the stopped instance to snapshot. The InstanceStopped waiter
+            # names "terminated" as an explicit failure acceptor, so inheriting
+            # terminate here would fail the bake rather than merely slow it --
+            # which is why this path does not use the launch template.
+            "InstanceInitiatedShutdownBehavior": "stop",
             "TagSpecifications": [
                 {
                     "ResourceType": "instance",
@@ -441,6 +471,107 @@ class StandardMode(OperatingMode):
             except Exception as e:
                 logger.warning(f"Failed to delete snapshot {snapshot_id}: {e}")
 
+    # ------------------------------------------------------------------
+    # Launch template helpers (#85)
+    # ------------------------------------------------------------------
+
+    @property
+    def launch_template_name(self) -> str:
+        """Name of this mode's launch template, unique per provider."""
+        return f"{LAUNCH_TEMPLATE_NAME_PREFIX}-{self.provider_id}"
+
+    def _create_launch_template(self) -> None:
+        """Create the launch template every launch path in this mode uses.
+
+        Carries the settings that must not vary per launch: IMDSv2,
+        ``InstanceInitiatedShutdownBehavior``, the network interface, the key
+        pair, and the IAM instance profile resolved by
+        :meth:`_resolve_instance_profile`. ``UserData`` and ``TagSpecifications``
+        are deliberately left out -- they are per-job and are passed as
+        overrides at launch.
+
+        A failure here is not fatal. The launch paths fall back to raw
+        ``RunInstances`` kwargs when no template ID is set, so an account
+        without ``ec2:CreateLaunchTemplate`` keeps working, just without IMDSv2
+        on the plain-spot path (``RequestSpotInstances`` has no
+        ``MetadataOptions`` member at all, so a template is the only way to get
+        IMDSv2 there).
+        """
+        ec2 = self.session.client("ec2")
+        tags = [
+            {"Key": "Name", "Value": self.launch_template_name},
+            {"Key": "CreatedBy", "Value": "ParslEphemeralAWSProvider"},
+            {"Key": "ProviderId", "Value": self.provider_id},
+        ]
+        for key, value in self.additional_tags.items():
+            tags.append({"Key": key, "Value": value})
+
+        try:
+            template_data = build_launch_template_data(
+                image_id=self.image_id,
+                instance_type=self.instance_type,
+                subnet_id=self.subnet_id,
+                security_group_id=self.security_group_id,
+                associate_public_ip=self.use_public_ips,
+                key_name=self.key_name,
+                iam_instance_profile_arn=self.iam_instance_profile_arn,
+                shutdown_behavior="terminate",
+            )
+            (
+                self._launch_template_id,
+                self._launch_template_version,
+            ) = create_launch_template(
+                ec2, self.launch_template_name, template_data, tags
+            )
+            logger.info(
+                f"Created launch template {self._launch_template_id} "
+                f"version {self._launch_template_version} with IMDSv2 required"
+            )
+        except Exception as e:
+            logger.error(
+                f"Failed to create launch template: {e}. Falling back to "
+                "per-launch RunInstances parameters; IMDSv2 will not be "
+                "enforced on spot instance requests."
+            )
+            self._launch_template_id = None
+            self._launch_template_version = None
+
+    def _delete_launch_template(self) -> None:
+        """Delete this mode's launch template if it created one.
+
+        Safe to call while instances launched from the template are still
+        terminating -- deleting a template does not affect running instances.
+        """
+        if not self._launch_template_id:
+            return
+
+        try:
+            delete_launch_template(self.session.client("ec2"), self._launch_template_id)
+            logger.info(f"Deleted launch template {self._launch_template_id}")
+        except Exception as e:
+            logger.error(
+                f"Failed to delete launch template {self._launch_template_id}: {e}"
+            )
+        finally:
+            # Cleared either way: a template that could not be deleted must not
+            # be referenced by a later launch, and cleanup is not retried.
+            self._launch_template_id = None
+            self._launch_template_version = None
+
+    def _launch_template_reference(self) -> Optional[Dict[str, str]]:
+        """Return the ``LaunchTemplate`` kwarg for a launch, or None.
+
+        The version is pinned rather than sent as ``$Latest``: a template
+        adopted from a previous run may carry several versions, and the launch
+        has to use the one this mode built.
+        """
+        if not self._launch_template_id:
+            return None
+        return {
+            "LaunchTemplateId": self._launch_template_id,
+            "Version": self._launch_template_version or "$Latest",
+        }
+
     def save_state(self) -> None:
         """Save the current state to the state store."""
         # Default state
@@ -457,6 +588,8 @@ class StandardMode(OperatingMode):
             "warm_instances": list(self._warm_instances),
             "baked_ami_id": self._baked_ami_id,
             "owns_baked_ami": self._owns_baked_ami,
+            "launch_template_id": self._launch_template_id,
+            "launch_template_version": self._launch_template_version,
         }
 
         # Include spot fleet state if applicable
@@ -507,6 +640,12 @@ class StandardMode(OperatingMode):
                         for rid, r in self.resources.items()
                         if r.get("warm_pool") and r.get("status") == STATUS_WARM
                     ]
+
+                # Restore the launch template so a resumed provider launches
+                # from the same definition instead of leaking it and building a
+                # second one (#85).
+                self._launch_template_id = state.get("launch_template_id")
+                self._launch_template_version = state.get("launch_template_version")
 
                 # Restore baked AMI state
                 saved_baked_ami = state.get("baked_ami_id")
@@ -630,6 +769,12 @@ class StandardMode(OperatingMode):
         # Try to load state first
         if self.load_state():
             logger.debug("Loaded state, resources already verified")
+            # A state document written before #85, or one whose template
+            # creation failed, carries no template ID. Build one now rather
+            # than leaving a resumed provider permanently on the fallback path.
+            if not self._launch_template_id:
+                self._create_launch_template()
+                self.save_state()
             return
 
         logger.debug("Initializing standard mode infrastructure")
@@ -647,6 +792,10 @@ class StandardMode(OperatingMode):
                 self._baked_ami_id = self.baked_ami_id
                 self.image_id = self.baked_ami_id
                 logger.info(f"Using pre-supplied baked AMI {self.baked_ami_id}")
+
+            # After baking, so the template references the baked AMI rather than
+            # the base one -- self.image_id is reassigned above (#85).
+            self._create_launch_template()
 
             # Save state
             self.save_state()
@@ -713,6 +862,14 @@ class StandardMode(OperatingMode):
                 f"Resolved IAM instance profile {self.iam_instance_profile_arn} "
                 "for SSM command dispatch"
             )
+            # The SpotFleetManager's provider stand-in was built in __init__,
+            # before this ran, so its copy of the ARN is still None. Its launch
+            # template reads that copy (#85), so without this every fleet
+            # instance launches with no profile.
+            if self.spot_fleet_manager:
+                self.spot_fleet_manager.provider.iam_instance_profile_arn = (
+                    self.iam_instance_profile_arn
+                )
         except Exception as e:
             logger.error(
                 f"Failed to create IAM instance profile: {e}. SSM command "
@@ -1134,52 +1291,68 @@ class StandardMode(OperatingMode):
         for key, value in self.additional_tags.items():
             tags.append({"Key": key, "Value": value})
 
-        # Prepare network configuration
-        network_interfaces = []
-        if self.subnet_id:
-            network_interface = {
-                "DeviceIndex": 0,
-                "SubnetId": self.subnet_id,
-                "AssociatePublicIpAddress": self.use_public_ips,
+        # Prefer the launch template built in initialize(): it carries IMDSv2,
+        # the shutdown behaviour, the network interface, the key pair, and the
+        # IAM profile, leaving only the per-job UserData and tags here (#85).
+        launch_template = self._launch_template_reference()
+        run_args: Dict[str, Any]
+        if launch_template:
+            run_args = {
+                "LaunchTemplate": launch_template,
+                "MaxCount": 1,
+                "MinCount": 1,
+                "UserData": init_script,
+                "TagSpecifications": [{"ResourceType": "instance", "Tags": tags}],
+            }
+        else:
+            # Fallback for an account that cannot create launch templates.
+            # Every setting the template would have carried has to be repeated
+            # here, which is exactly the duplication #85 removes.
+            network_interfaces = []
+            if self.subnet_id:
+                network_interface = {
+                    "DeviceIndex": 0,
+                    "SubnetId": self.subnet_id,
+                    "AssociatePublicIpAddress": self.use_public_ips,
+                }
+
+                if self.security_group_id:
+                    network_interface["Groups"] = [self.security_group_id]
+
+                network_interfaces.append(network_interface)
+
+            run_args = {
+                "ImageId": self.image_id,
+                "InstanceType": self.instance_type,
+                "MaxCount": 1,
+                "MinCount": 1,
+                "UserData": init_script,
+                "TagSpecifications": [{"ResourceType": "instance", "Tags": tags}],
+                # The init script runs `shutdown -h now` when auto_shutdown or
+                # one_shot is set, and EC2's default for an instance-initiated
+                # shutdown is *stop*, not terminate — leaving a stopped instance
+                # with a billed EBS volume. Worse, EC2_STATUS_MAPPING maps
+                # "stopped" to COMPLETED, so the provider drops the tracking
+                # record and the volume is orphaned as well as billed.
+                # DetachedMode already sets this on all of its launch paths.
+                "InstanceInitiatedShutdownBehavior": "terminate",
+                "MetadataOptions": dict(IMDSV2_METADATA_OPTIONS),
             }
 
-            if self.security_group_id:
-                network_interface["Groups"] = [self.security_group_id]
+            # Add network configuration if available
+            if network_interfaces:
+                run_args["NetworkInterfaces"] = network_interfaces
+            elif self.security_group_id:
+                run_args["SecurityGroupIds"] = [self.security_group_id]
 
-            network_interfaces.append(network_interface)
+            # Add key pair if specified
+            if self.key_name:
+                run_args["KeyName"] = self.key_name
 
-        # Prepare run configuration
-        run_args = {
-            "ImageId": self.image_id,
-            "InstanceType": self.instance_type,
-            "MaxCount": 1,
-            "MinCount": 1,
-            "UserData": init_script,
-            "TagSpecifications": [{"ResourceType": "instance", "Tags": tags}],
-            # The init script runs `shutdown -h now` when auto_shutdown or
-            # one_shot is set, and EC2's default for an instance-initiated
-            # shutdown is *stop*, not terminate — leaving a stopped instance
-            # with a billed EBS volume. Worse, EC2_STATUS_MAPPING maps
-            # "stopped" to COMPLETED, so the provider drops the tracking record
-            # and the volume is orphaned as well as billed. DetachedMode already
-            # sets this on all of its launch paths.
-            "InstanceInitiatedShutdownBehavior": "terminate",
-        }
-
-        # Add network configuration if available
-        if network_interfaces:
-            run_args["NetworkInterfaces"] = network_interfaces
-        elif self.security_group_id:
-            run_args["SecurityGroupIds"] = [self.security_group_id]
-
-        # Add key pair if specified
-        if self.key_name:
-            run_args["KeyName"] = self.key_name
-
-        # Attach the IAM instance profile whenever one is available. SSM
-        # SendCommand needs it, and an unused profile costs nothing.
-        if self.iam_instance_profile_arn:
-            run_args["IamInstanceProfile"] = {"Arn": self.iam_instance_profile_arn}
+            # Attach the IAM instance profile whenever one is available. SSM
+            # SendCommand needs it, and an unused profile costs nothing.
+            if self.iam_instance_profile_arn:
+                run_args["IamInstanceProfile"] = {"Arn": self.iam_instance_profile_arn}
 
         # Use spot instances if requested
         if self.use_spot:
@@ -1225,6 +1398,16 @@ class StandardMode(OperatingMode):
         # Check if using spot fleet
         if self.use_spot_fleet and self.spot_fleet_manager:
             return self._create_spot_fleet_instance(run_args)
+
+        # With a launch template available, request spot through RunInstances
+        # instead of the older RequestSpotInstances (#85). Verified against the
+        # botocore service model: RequestSpotInstances accepts no LaunchTemplate,
+        # and its LaunchSpecification shape has no MetadataOptions member at all,
+        # so IMDSv2 cannot be set on that path by any means. RunInstances with
+        # InstanceMarketOptions accepts both, and DryRun against real EC2
+        # confirms the combination.
+        if "LaunchTemplate" in run_args:
+            return self._create_spot_instance_via_run_instances(run_args)
 
         # Traditional spot instance request
         ec2 = self.session.client("ec2")
@@ -1287,23 +1470,87 @@ class StandardMode(OperatingMode):
             )
 
             # Register with spot interruption monitor if enabled
-            if (
-                self.spot_interruption_handling
-                and self.spot_interruption_monitor
-                and self.spot_interruption_handler
-            ):
-                self.spot_interruption_monitor.register_instance(
-                    instance_id,
-                    self.spot_interruption_handler.handle_instance_interruption,
-                )
-                logger.info(
-                    f"Registered spot instance {instance_id} for interruption handling"
-                )
+            self._register_spot_instance(instance_id)
 
             return instance_id
         except Exception as e:
             logger.error(f"Failed to create spot instance: {e}")
             raise ResourceCreationError(f"Failed to create spot instance: {e}") from e
+
+    def _create_spot_instance_via_run_instances(self, run_args: Dict[str, Any]) -> str:
+        """Request a spot instance through ``RunInstances`` (#85).
+
+        The modern spelling: ``InstanceMarketOptions`` on ``RunInstances``
+        instead of ``RequestSpotInstances``. Preferred whenever a launch
+        template exists, because it is the only route that gets IMDSv2 onto a
+        spot instance -- ``RequestSpotInstances`` has no ``MetadataOptions``
+        member -- and because it returns the instance ID directly, with no
+        intermediate request to poll or tag.
+
+        Parameters
+        ----------
+        run_args : Dict[str, Any]
+            ``RunInstances`` arguments, already carrying ``LaunchTemplate``.
+
+        Returns
+        -------
+        str
+            The EC2 instance ID.
+
+        Raises
+        ------
+        ResourceCreationError
+            If the request fails.
+        """
+        ec2 = self.session.client("ec2")
+        spot_options: Dict[str, Any] = {}
+        if self.spot_max_price:
+            spot_options["MaxPrice"] = self.spot_max_price
+
+        market_options: Dict[str, Any] = {"MarketType": "spot"}
+        if spot_options:
+            market_options["SpotOptions"] = spot_options
+
+        # The template's InstanceInitiatedShutdownBehavior="terminate" is
+        # deliberately left in place. RequestSpotInstances could not express it
+        # -- its LaunchSpecification has no such member -- so the old path left
+        # a self-shutting-down spot instance *stopped*, with a billed EBS volume
+        # that EC2_STATUS_MAPPING then reported as COMPLETED, dropping the
+        # tracking record. Verified against real EC2 that RunInstances accepts
+        # terminate alongside InstanceMarketOptions: a one-time spot instance
+        # launched this way reports InstanceLifecycle=spot and shutdown
+        # behaviour terminate. So this path closes on spot the same leak #66
+        # closed on demand.
+        run_args = dict(run_args)
+        run_args["InstanceMarketOptions"] = market_options
+
+        try:
+            response = ec2.run_instances(**run_args)
+            instance_id = response["Instances"][0]["InstanceId"]
+
+            wait_for_resource(
+                instance_id, "instance_running", ec2, resource_name="EC2 spot instance"
+            )
+            self._register_spot_instance(instance_id)
+            return instance_id
+        except Exception as e:
+            logger.error(f"Failed to create spot instance: {e}")
+            raise ResourceCreationError(f"Failed to create spot instance: {e}") from e
+
+    def _register_spot_instance(self, instance_id: str) -> None:
+        """Register *instance_id* with the interruption monitor, if enabled."""
+        if (
+            self.spot_interruption_handling
+            and self.spot_interruption_monitor
+            and self.spot_interruption_handler
+        ):
+            self.spot_interruption_monitor.register_instance(
+                instance_id,
+                self.spot_interruption_handler.handle_instance_interruption,
+            )
+            logger.info(
+                f"Registered spot instance {instance_id} for interruption handling"
+            )
 
     def _create_spot_fleet_instance(self, run_args: Dict[str, Any]) -> str:
         """Create a spot fleet instance.
@@ -1775,6 +2022,11 @@ class StandardMode(OperatingMode):
                     logger.error(
                         f"Failed to deregister baked AMI {self._baked_ami_id}: {e}"
                     )
+
+            # Delete the launch template (#85). After the AMI deregistration
+            # above and before the state save below, so a failure to delete it
+            # still leaves the ID cleared in the persisted state.
+            self._delete_launch_template()
 
             # Clean up Spot Fleet resources if using spot fleet
             if self.use_spot_fleet and self.spot_fleet_manager:

--- a/parsl_ephemeral_aws/utils/aws.py
+++ b/parsl_ephemeral_aws/utils/aws.py
@@ -5,6 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 SPDX-FileCopyrightText: 2025 Scott Friedman and Project Contributors
 """
 
+import base64
 import json
 import logging
 import os
@@ -30,6 +31,8 @@ from parsl_ephemeral_aws.constants import (
     DEFAULT_AMI_MAPPING,
     DEFAULT_ARCHITECTURE,
     DEFAULT_REGION,
+    IMDSV2_METADATA_OPTIONS,
+    RESOURCE_TYPE_LAUNCH_TEMPLATE,
     SPOT_FLEET_ALLOCATION_STRATEGIES,
 )
 from parsl_ephemeral_aws.exceptions import (
@@ -290,6 +293,228 @@ def normalize_spot_fleet_allocation_strategy(strategy: str) -> str:
         f"{sorted(SPOT_FLEET_ALLOCATION_STRATEGIES)} or their kebab-case "
         f"equivalents."
     )
+
+
+def encode_user_data(user_data: str) -> str:
+    """Base64-encode *user_data* for an API that does not do it for you.
+
+    botocore installs ``base64_encode_user_data`` on
+    ``before-parameter-build.ec2.RunInstances`` only -- verified by inspecting
+    ``botocore.handlers.BUILTIN_HANDLERS``, where that operation and
+    ``autoscaling.CreateLaunchConfiguration`` are the sole entries.
+    ``CreateLaunchTemplate`` is *not* among them, so a plaintext script passed
+    there is stored verbatim, handed to cloud-init base64-decoded, and produces
+    garbage that fails silently -- the instance boots fine and simply never runs
+    the worker.
+
+    Encoding twice is the other half of the trap, so callers must not hand
+    already-encoded data to ``RunInstances``.
+
+    Parameters
+    ----------
+    user_data : str
+        The plaintext user data script.
+
+    Returns
+    -------
+    str
+        The base64-encoded form.
+    """
+    return base64.b64encode(user_data.encode()).decode()
+
+
+def build_launch_template_data(
+    image_id: str,
+    instance_type: str,
+    subnet_id: Optional[str] = None,
+    security_group_id: Optional[str] = None,
+    associate_public_ip: bool = True,
+    key_name: Optional[str] = None,
+    iam_instance_profile_arn: Optional[str] = None,
+    shutdown_behavior: str = "terminate",
+    user_data: Optional[str] = None,
+    monitoring: bool = False,
+) -> Dict[str, Any]:
+    """Build the ``LaunchTemplateData`` shared by every launch path (#85).
+
+    One definition serves the on-demand, spot, and fleet paths, which is what
+    makes the Phase 6 EC2 Fleet/ASG migration possible -- those APIs accept a
+    template reference and nothing resembling ``RunInstances`` kwargs.
+
+    Every field is optional except the image and instance type, because the
+    template is a *baseline*: ``RunInstances`` overrides ``UserData`` and
+    ``TagSpecifications`` per launch, and Spot Fleet overrides ``InstanceType``
+    and ``SubnetId`` per pool.
+
+    Parameters
+    ----------
+    image_id : str
+        AMI to launch.
+    instance_type : str
+        Default instance type; fleet paths override it per pool.
+    subnet_id : Optional[str]
+        Subnet for the primary network interface.
+    security_group_id : Optional[str]
+        Security group for the primary network interface.
+    associate_public_ip : bool
+        Whether the primary interface gets a public IP.
+    key_name : Optional[str]
+        EC2 key pair for SSH access.
+    iam_instance_profile_arn : Optional[str]
+        Instance profile ARN; required for SSM command dispatch.
+    shutdown_behavior : str
+        ``"terminate"`` or ``"stop"`` for an instance-initiated shutdown.
+    user_data : Optional[str]
+        Plaintext user data; base64-encoded here, since
+        ``CreateLaunchTemplate`` does not do it.
+    monitoring : bool
+        Whether to enable detailed CloudWatch monitoring.
+
+    Returns
+    -------
+    Dict[str, Any]
+        A ``LaunchTemplateData`` document.
+    """
+    data: Dict[str, Any] = {
+        "ImageId": image_id,
+        "InstanceType": instance_type,
+        "InstanceInitiatedShutdownBehavior": shutdown_behavior,
+        # Copied, not referenced: the caller must not be able to mutate the
+        # module-level default through the document it gets back.
+        "MetadataOptions": dict(IMDSV2_METADATA_OPTIONS),
+    }
+
+    # A network interface and top-level SecurityGroupIds are mutually exclusive
+    # -- EC2 rejects a template carrying both. The interface form is required
+    # for AssociatePublicIpAddress, so it wins whenever a subnet is known.
+    if subnet_id:
+        interface: Dict[str, Any] = {
+            "DeviceIndex": 0,
+            "SubnetId": subnet_id,
+            "AssociatePublicIpAddress": associate_public_ip,
+        }
+        if security_group_id:
+            interface["Groups"] = [security_group_id]
+        data["NetworkInterfaces"] = [interface]
+    elif security_group_id:
+        data["SecurityGroupIds"] = [security_group_id]
+
+    if key_name:
+        data["KeyName"] = key_name
+    if iam_instance_profile_arn:
+        data["IamInstanceProfile"] = {"Arn": iam_instance_profile_arn}
+    if user_data is not None:
+        data["UserData"] = encode_user_data(user_data)
+    if monitoring:
+        data["Monitoring"] = {"Enabled": True}
+
+    return data
+
+
+def create_launch_template(
+    ec2_client: Any,
+    name: str,
+    launch_template_data: Dict[str, Any],
+    tags: Optional[List[Dict[str, str]]] = None,
+) -> Tuple[str, str]:
+    """Create a launch template, reusing one that already exists under *name*.
+
+    Idempotent because ``initialize()`` may run again after a partial failure,
+    and a second ``CreateLaunchTemplate`` under the same name is rejected with
+    ``InvalidLaunchTemplateName.AlreadyExistsException``. Rather than fail, the
+    existing template is adopted -- its name encodes the provider ID, so it can
+    only be one this provider made.
+
+    Parameters
+    ----------
+    ec2_client : Any
+        A boto3 EC2 client.
+    name : str
+        Launch template name; must be unique within the account and region.
+    launch_template_data : Dict[str, Any]
+        As returned by :func:`build_launch_template_data`.
+    tags : Optional[List[Dict[str, str]]]
+        Tags applied to the template resource itself, for cleanup tracking.
+
+    Returns
+    -------
+    Tuple[str, str]
+        The template ID and version number, the latter as the string
+        ``RunInstances`` expects.
+
+    Raises
+    ------
+    ResourceCreationError
+        If the template can neither be created nor found.
+    """
+    kwargs: Dict[str, Any] = {
+        "LaunchTemplateName": name,
+        "LaunchTemplateData": launch_template_data,
+    }
+    if tags:
+        kwargs["TagSpecifications"] = [
+            {"ResourceType": RESOURCE_TYPE_LAUNCH_TEMPLATE, "Tags": tags}
+        ]
+
+    try:
+        template = ec2_client.create_launch_template(**kwargs)["LaunchTemplate"]
+        logger.debug(
+            f"Created launch template {template['LaunchTemplateId']} ({name}) "
+            f"version {template['LatestVersionNumber']}"
+        )
+        return str(template["LaunchTemplateId"]), str(template["LatestVersionNumber"])
+    except ClientError as e:
+        if (
+            e.response["Error"]["Code"]
+            != "InvalidLaunchTemplateName.AlreadyExistsException"
+        ):
+            raise ResourceCreationError(
+                f"Failed to create launch template {name}: {e}"
+            ) from e
+
+    # Adopt the existing one. A new version is added rather than the old one
+    # reused, so a changed AMI or instance type actually takes effect -- a
+    # resumed provider whose config has moved on must not silently keep
+    # launching the previous definition.
+    try:
+        version = ec2_client.create_launch_template_version(
+            LaunchTemplateName=name,
+            LaunchTemplateData=launch_template_data,
+        )["LaunchTemplateVersion"]
+        logger.debug(
+            f"Launch template {name} already existed; added version "
+            f"{version['VersionNumber']}"
+        )
+        return str(version["LaunchTemplateId"]), str(version["VersionNumber"])
+    except ClientError as e:
+        raise ResourceCreationError(
+            f"Launch template {name} exists but could not be updated: {e}"
+        ) from e
+
+
+def delete_launch_template(ec2_client: Any, template_id: str) -> None:
+    """Delete a launch template, tolerating one that is already gone.
+
+    Deleting the template does not affect instances launched from it, so this is
+    safe to call before those instances have terminated.
+
+    Parameters
+    ----------
+    ec2_client : Any
+        A boto3 EC2 client.
+    template_id : str
+        ID of the template to delete.
+    """
+    try:
+        ec2_client.delete_launch_template(LaunchTemplateId=template_id)
+        logger.debug(f"Deleted launch template {template_id}")
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "InvalidLaunchTemplateId.NotFound":
+            logger.debug(f"Launch template {template_id} already deleted")
+            return
+        raise ResourceDeletionError(
+            f"Failed to delete launch template {template_id}: {e}"
+        ) from e
 
 
 def get_default_ami(

--- a/tests/aws/test_launch_template_e2e.py
+++ b/tests/aws/test_launch_template_e2e.py
@@ -1,0 +1,255 @@
+"""Real-AWS end-to-end tests for launch templates and IMDSv2 (issue #85).
+
+Unit tests can only assert what this package *sends*. Every claim below is about
+what EC2 actually *does* with it:
+
+* ``MetadataOptions.HttpTokens="required"`` reaches the template and the
+  instances launched from it, on the on-demand *and* spot paths. On spot there is
+  no other route: ``RequestSpotInstances`` accepts no ``LaunchTemplate``, and its
+  ``LaunchSpecification`` shape has no ``MetadataOptions`` member at all -- which
+  is why the spot path moved to ``RunInstances`` + ``InstanceMarketOptions``.
+* ``InstanceInitiatedShutdownBehavior="terminate"`` survives on a *spot*
+  instance. ``LaunchSpecification`` has no such member either, so the old path
+  silently kept EC2's ``stop`` default: a self-shutting-down spot instance was
+  left ``stopped`` with a billed EBS volume, which ``EC2_STATUS_MAPPING`` reports
+  as COMPLETED -- orphaning the volume and its tracking record together. A mock
+  cannot tell you EC2 accepts ``terminate`` on a one-time spot request; a real
+  launch can.
+* The hop limit is left at EC2's default of 2 rather than tightened to 1, so
+  metadata stays reachable from a container spawned by ``worker_init``. EC2 does
+  not echo an unset template field back, so the template omits it and the
+  instance reports 2.
+* The template is tagged with the provider ID and deleted on shutdown, so it does
+  not accumulate against the account's per-region limit.
+
+``InstanceInitiatedShutdownBehavior`` is not part of the ``describe_instances``
+response -- it is an instance *attribute* and has to be fetched separately, which
+is what ``_shutdown_behavior`` below is for.
+
+The provider constructor initialises the operating mode, so the fixtures yield a
+provider whose launch template already exists; there is no ``initialize()`` to
+call on the provider itself.
+
+Run with::
+
+    AWS_TEST_REGION=us-east-1 AWS_TEST_VPC_ID=vpc-xxx \\
+    AWS_TEST_SUBNET_ID=subnet-xxx AWS_TEST_SG_ID=sg-xxx \\
+    AWS_PROFILE=aws uv run pytest tests/aws/test_launch_template_e2e.py \\
+        -m aws --no-cov -v
+
+SPDX-License-Identifier: Apache-2.0
+SPDX-FileCopyrightText: 2025 Scott Friedman and Project Contributors
+"""
+
+import logging
+
+import pytest
+from botocore.exceptions import ClientError
+
+from parsl_ephemeral_aws.constants import LAUNCH_TEMPLATE_NAME_PREFIX
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [pytest.mark.aws, pytest.mark.slow]
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+
+def _template_data(ec2, mode):
+    """Return the template document as EC2 stored it.
+
+    The version is pinned to the one the mode built -- a template adopted from a
+    previous run can carry several, and ``$Default`` need not be ours.
+    """
+    versions = ec2.describe_launch_template_versions(
+        LaunchTemplateId=mode._launch_template_id,
+        Versions=[mode._launch_template_version],
+    )["LaunchTemplateVersions"]
+    return versions[0]["LaunchTemplateData"]
+
+
+def _instance(ec2, instance_id):
+    return ec2.describe_instances(InstanceIds=[instance_id])["Reservations"][0][
+        "Instances"
+    ][0]
+
+
+def _shutdown_behavior(ec2, instance_id):
+    """Fetch the shutdown behaviour, which describe_instances does not return."""
+    return ec2.describe_instance_attribute(
+        InstanceId=instance_id, Attribute="instanceInitiatedShutdownBehavior"
+    )["InstanceInitiatedShutdownBehavior"]["Value"]
+
+
+def _cancel_quietly(provider, job_id):
+    try:
+        provider.cancel([job_id])
+    except Exception as exc:
+        logger.warning("teardown cancel raised (ignored): %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# TestLaunchTemplateCreation
+# ---------------------------------------------------------------------------
+
+
+class TestLaunchTemplateCreation:
+    """The template EC2 stores has to carry what the mode meant to set."""
+
+    def test_template_is_created_and_tagged(
+        self, aws_provider, aws_session, aws_region, test_run_id
+    ):
+        """Initialisation creates exactly one template, tagged for cleanup."""
+        mode = aws_provider.operating_mode
+        assert mode._launch_template_id, (
+            "mode initialisation created no launch template; the spot path "
+            "cannot enforce IMDSv2 without one"
+        )
+
+        ec2 = aws_session.client("ec2", region_name=aws_region)
+        described = ec2.describe_launch_templates(
+            LaunchTemplateIds=[mode._launch_template_id]
+        )["LaunchTemplates"][0]
+
+        assert described["LaunchTemplateName"] == mode.launch_template_name
+        assert described["LaunchTemplateName"].startswith(LAUNCH_TEMPLATE_NAME_PREFIX)
+        # EC2 caps the name at 128 characters and a UUID provider ID is appended.
+        assert len(described["LaunchTemplateName"]) <= 128
+
+        tags = {t["Key"]: t["Value"] for t in described.get("Tags", [])}
+        assert tags.get("ProviderId") == aws_provider.provider_id
+        assert tags.get("CreatedBy") == "ParslEphemeralAWSProvider"
+        # additional_tags must reach the template too, or the E2E sweep and any
+        # account-level cost allocation cannot see it.
+        assert tags.get("E2ETestRunId") == test_run_id
+
+    def test_template_requires_imdsv2(self, aws_provider, aws_session, aws_region):
+        """IMDSv2 is the point of the exercise; assert EC2 recorded it."""
+        ec2 = aws_session.client("ec2", region_name=aws_region)
+
+        data = _template_data(ec2, aws_provider.operating_mode)
+
+        assert data["MetadataOptions"]["HttpTokens"] == "required"
+        # The endpoint itself must stay reachable: SSM reads the instance
+        # identity document from IMDS, and one-shot dispatch depends on SSM.
+        assert data["MetadataOptions"]["HttpEndpoint"] == "enabled"
+
+    def test_template_leaves_the_hop_limit_at_the_default(
+        self, aws_provider, aws_session, aws_region
+    ):
+        """Deliberately unset, so containers can still reach metadata."""
+        ec2 = aws_session.client("ec2", region_name=aws_region)
+
+        data = _template_data(ec2, aws_provider.operating_mode)
+
+        assert "HttpPutResponseHopLimit" not in data["MetadataOptions"]
+
+    def test_template_carries_shutdown_network_and_profile(
+        self, aws_provider, aws_session, aws_region, network_ids
+    ):
+        """The three per-call kwargs #85 folded into the template."""
+        ec2 = aws_session.client("ec2", region_name=aws_region)
+
+        data = _template_data(ec2, aws_provider.operating_mode)
+
+        assert data["InstanceInitiatedShutdownBehavior"] == "terminate"
+        # The interface form, not top-level SecurityGroupIds: EC2 rejects a
+        # template carrying both, and only the interface takes a public IP.
+        interface = data["NetworkInterfaces"][0]
+        assert interface["SubnetId"] == network_ids["subnet_id"]
+        assert interface["Groups"] == [network_ids["security_group_id"]]
+        # Resolved by _resolve_instance_profile() during initialisation, which
+        # runs *after* __init__ -- so this cannot have been read in __init__.
+        assert data.get("IamInstanceProfile", {}).get("Arn"), (
+            "no IAM instance profile in the template; SSM will never come "
+            "online and every dispatch falls back to UserData"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestOnDemandLaunchFromTemplate
+# ---------------------------------------------------------------------------
+
+
+class TestOnDemandLaunchFromTemplate:
+    """A submitted job has to inherit the template's hardening."""
+
+    def test_instance_inherits_imdsv2_profile_and_terminate(
+        self, aws_provider, aws_session, aws_region
+    ):
+        ec2 = aws_session.client("ec2", region_name=aws_region)
+        job_id = aws_provider.submit("echo launch-template-e2e", tasks_per_node=1)
+        try:
+            instance_id = aws_provider.job_map[job_id]["resource_id"]
+            instance = _instance(ec2, instance_id)
+
+            assert instance["MetadataOptions"]["HttpTokens"] == "required"
+            # AWS's default, not tightened to 1: a request from inside a
+            # container traverses the host network namespace, costing a hop.
+            assert instance["MetadataOptions"]["HttpPutResponseHopLimit"] == 2
+            assert _shutdown_behavior(ec2, instance_id) == "terminate"
+            assert instance.get("IamInstanceProfile"), "no instance profile attached"
+        finally:
+            _cancel_quietly(aws_provider, job_id)
+
+
+# ---------------------------------------------------------------------------
+# TestSpotLaunchFromTemplate
+# ---------------------------------------------------------------------------
+
+
+class TestSpotLaunchFromTemplate:
+    """The spot path is why a template is mandatory rather than merely tidy."""
+
+    def test_spot_instance_gets_imdsv2_and_keeps_terminate(
+        self, spot_provider, aws_session, aws_region
+    ):
+        """Neither property is expressible through ``RequestSpotInstances``.
+
+        Also asserts the instance really is spot -- the move to ``RunInstances``
+        + ``InstanceMarketOptions`` must not have silently downgraded it to
+        on-demand, which would cost roughly 3x and pass every other assertion
+        here.
+        """
+        ec2 = aws_session.client("ec2", region_name=aws_region)
+        job_id = spot_provider.submit("echo spot-launch-template-e2e", tasks_per_node=1)
+        try:
+            instance_id = spot_provider.job_map[job_id]["resource_id"]
+            instance = _instance(ec2, instance_id)
+
+            assert instance.get("InstanceLifecycle") == "spot", (
+                "instance is not spot; InstanceMarketOptions did not take effect"
+            )
+            assert instance.get("SpotInstanceRequestId")
+            assert instance["MetadataOptions"]["HttpTokens"] == "required"
+            # Reverting to "stop" here would recreate the EBS cost leak that
+            # Phase 1.3a closed on the on-demand path.
+            assert _shutdown_behavior(ec2, instance_id) == "terminate"
+        finally:
+            _cancel_quietly(spot_provider, job_id)
+
+
+# ---------------------------------------------------------------------------
+# TestLaunchTemplateCleanup
+# ---------------------------------------------------------------------------
+
+
+class TestLaunchTemplateCleanup:
+    """A leaked template counts against the per-region limit indefinitely."""
+
+    def test_shutdown_deletes_the_template(self, aws_provider, aws_session, aws_region):
+        template_id = aws_provider.operating_mode._launch_template_id
+        assert template_id
+        ec2 = aws_session.client("ec2", region_name=aws_region)
+
+        aws_provider.shutdown()
+
+        with pytest.raises(ClientError) as exc_info:
+            ec2.describe_launch_templates(LaunchTemplateIds=[template_id])
+        assert "NotFound" in exc_info.value.response["Error"]["Code"]
+        # And the mode must forget it, so a later launch cannot reference a
+        # template that no longer exists.
+        assert aws_provider.operating_mode._launch_template_id is None

--- a/tests/unit/test_launch_templates.py
+++ b/tests/unit/test_launch_templates.py
@@ -1,0 +1,903 @@
+"""Unit tests for launch templates and IMDSv2 (#85).
+
+Two things are being pinned down here.
+
+**IMDSv2.** ``MetadataOptions`` was set on no launch path at all, so every
+instance this package created accepted the unauthenticated IMDSv1 GET that an
+SSRF-ed application can be tricked into making to read the instance's role
+credentials. The setting has to reach EC2 on *every* path, and the paths do not
+all accept it the same way -- verified against the botocore service model and
+real EC2 in us-east-1:
+
+- ``RunInstances`` takes ``MetadataOptions`` directly, and also takes a
+  ``LaunchTemplate`` reference.
+- ``RequestSpotInstances`` takes neither: it has no ``LaunchTemplate`` parameter,
+  and its ``LaunchSpecification`` shape has no ``MetadataOptions`` member. IMDSv2
+  cannot be set on that path by any means, which is why the spot path moves to
+  ``RunInstances`` + ``InstanceMarketOptions`` whenever a template exists.
+- ``RequestSpotFleet`` likewise: ``SpotFleetLaunchSpecification`` has no
+  ``MetadataOptions``, so a launch template is the only route.
+
+**The launch template itself**, which Phase 6's EC2 Fleet/ASG migration needs --
+those APIs accept a template reference and nothing resembling ``RunInstances``
+kwargs. Three traps are covered:
+
+1. ``CreateLaunchTemplate`` does *not* base64-encode ``UserData``. botocore
+   installs that handler on ``RunInstances`` and
+   ``CreateLaunchConfiguration`` only, so plaintext user data passed to
+   ``CreateLaunchTemplate`` is stored verbatim, base64-*decoded* by cloud-init,
+   and produces garbage -- the instance boots fine and never runs the worker.
+2. ``RequestSpotFleet`` accepts ``LaunchSpecifications`` and
+   ``LaunchTemplateConfigs`` together (DryRun returns ``DryRunOperation``, not an
+   error), but then the template silently loses -- taking IMDSv2 with it. Exactly
+   one key may be sent.
+3. The AMI builder must keep ``InstanceInitiatedShutdownBehavior="stop"``. The
+   ``InstanceStopped`` waiter names ``terminated`` as an explicit *failure*
+   acceptor, so inheriting the template's ``terminate`` would fail the bake, not
+   merely slow it.
+
+SPDX-License-Identifier: Apache-2.0
+SPDX-FileCopyrightText: 2025 Scott Friedman and Project Contributors
+"""
+
+import ast
+import base64
+from unittest.mock import MagicMock, patch
+
+import boto3
+import pytest
+from botocore.exceptions import ClientError
+
+from parsl_ephemeral_aws.compute.spot_fleet import SpotFleetManager
+from parsl_ephemeral_aws.constants import (
+    IMDSV2_METADATA_OPTIONS,
+    LAUNCH_TEMPLATE_NAME_PREFIX,
+)
+from parsl_ephemeral_aws.exceptions import (
+    ResourceCreationError,
+    ResourceDeletionError,
+)
+from parsl_ephemeral_aws.modes.standard import StandardMode
+from parsl_ephemeral_aws.utils.aws import (
+    build_launch_template_data,
+    create_launch_template,
+    delete_launch_template,
+    encode_user_data,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _client_error(code, operation):
+    return ClientError({"Error": {"Code": code, "Message": code}}, operation)
+
+
+class TestEncodeUserData:
+    """botocore encodes user data for RunInstances only."""
+
+    def test_round_trips_through_base64(self):
+        script = "#!/bin/bash\necho hello\n"
+
+        assert base64.b64decode(encode_user_data(script)).decode() == script
+
+    def test_output_is_not_the_input(self):
+        """The failure mode is silent, so assert the transform actually happened.
+
+        Handing plaintext to ``CreateLaunchTemplate`` produces an instance that
+        boots normally and simply never runs the worker -- nothing raises.
+        """
+        script = "#!/bin/bash\necho hello\n"
+
+        assert encode_user_data(script) != script
+
+
+class TestBuildLaunchTemplateData:
+    """The document every launch path shares."""
+
+    def test_imdsv2_is_required(self):
+        data = build_launch_template_data("ami-1", "t3.micro")
+
+        assert data["MetadataOptions"]["HttpTokens"] == "required"
+
+    def test_metadata_endpoint_stays_enabled(self):
+        """SSM reads the instance identity document from IMDS.
+
+        Disabling the endpoint outright would break warm-pool and one-shot
+        dispatch, both of which run over SSM ``SendCommand``.
+        """
+        data = build_launch_template_data("ami-1", "t3.micro")
+
+        assert data["MetadataOptions"]["HttpEndpoint"] == "enabled"
+
+    def test_hop_limit_is_not_lowered_to_one(self):
+        """A hop limit of 1 leaves metadata unreachable from a container.
+
+        ``worker_init`` may run containers, and a container's request traverses
+        the host network namespace, which costs a hop. AWS's default of 2 is left
+        alone rather than tightened, so the key must be absent.
+        """
+        data = build_launch_template_data("ami-1", "t3.micro")
+
+        assert "HttpPutResponseHopLimit" not in data["MetadataOptions"]
+
+    def test_metadata_options_are_copied_not_shared(self):
+        """A caller must not be able to mutate the module-level constant."""
+        data = build_launch_template_data("ami-1", "t3.micro")
+        data["MetadataOptions"]["HttpTokens"] = "optional"
+
+        assert IMDSV2_METADATA_OPTIONS["HttpTokens"] == "required"
+
+    def test_shutdown_behavior_defaults_to_terminate(self):
+        """A stopped instance still bills for its EBS volume (#66, 1.3a)."""
+        data = build_launch_template_data("ami-1", "t3.micro")
+
+        assert data["InstanceInitiatedShutdownBehavior"] == "terminate"
+
+    def test_shutdown_behavior_is_overridable(self):
+        data = build_launch_template_data("ami-1", "t3.micro", shutdown_behavior="stop")
+
+        assert data["InstanceInitiatedShutdownBehavior"] == "stop"
+
+    def test_subnet_produces_a_network_interface(self):
+        data = build_launch_template_data(
+            "ami-1", "t3.micro", subnet_id="subnet-1", security_group_id="sg-1"
+        )
+
+        assert data["NetworkInterfaces"] == [
+            {
+                "DeviceIndex": 0,
+                "SubnetId": "subnet-1",
+                "AssociatePublicIpAddress": True,
+                "Groups": ["sg-1"],
+            }
+        ]
+
+    def test_network_interface_and_top_level_groups_are_exclusive(self):
+        """EC2 rejects a template carrying both.
+
+        The interface form is required for ``AssociatePublicIpAddress``, so it
+        wins whenever a subnet is known.
+        """
+        data = build_launch_template_data(
+            "ami-1", "t3.micro", subnet_id="subnet-1", security_group_id="sg-1"
+        )
+
+        assert "SecurityGroupIds" not in data
+
+    def test_security_group_without_subnet_goes_top_level(self):
+        data = build_launch_template_data("ami-1", "t3.micro", security_group_id="sg-1")
+
+        assert data["SecurityGroupIds"] == ["sg-1"]
+        assert "NetworkInterfaces" not in data
+
+    def test_public_ip_can_be_disabled(self):
+        data = build_launch_template_data(
+            "ami-1", "t3.micro", subnet_id="subnet-1", associate_public_ip=False
+        )
+
+        assert data["NetworkInterfaces"][0]["AssociatePublicIpAddress"] is False
+
+    def test_user_data_is_base64_encoded(self):
+        script = "#!/bin/bash\necho hi\n"
+
+        data = build_launch_template_data("ami-1", "t3.micro", user_data=script)
+
+        assert base64.b64decode(data["UserData"]).decode() == script
+
+    def test_absent_user_data_is_omitted(self):
+        """The mode leaves it out on purpose -- it is per-job, not per-template."""
+        data = build_launch_template_data("ami-1", "t3.micro")
+
+        assert "UserData" not in data
+
+    def test_iam_profile_is_wrapped_in_arn(self):
+        data = build_launch_template_data(
+            "ami-1", "t3.micro", iam_instance_profile_arn="arn:aws:iam::1:x/y"
+        )
+
+        assert data["IamInstanceProfile"] == {"Arn": "arn:aws:iam::1:x/y"}
+
+    def test_optional_fields_are_omitted_when_unset(self):
+        data = build_launch_template_data("ami-1", "t3.micro")
+
+        for key in ("KeyName", "IamInstanceProfile", "Monitoring"):
+            assert key not in data
+
+
+class TestCreateLaunchTemplate:
+    """Creation has to be idempotent and has to publish a new version."""
+
+    def test_returns_id_and_version_as_strings(self):
+        ec2 = MagicMock()
+        ec2.create_launch_template.return_value = {
+            "LaunchTemplate": {"LaunchTemplateId": "lt-1", "LatestVersionNumber": 1}
+        }
+
+        assert create_launch_template(ec2, "n", {"ImageId": "ami-1"}) == ("lt-1", "1")
+
+    def test_tags_are_attached_to_the_template_resource(self):
+        """Cleanup and orphan-hunting both key off the provider ID tag."""
+        ec2 = MagicMock()
+        ec2.create_launch_template.return_value = {
+            "LaunchTemplate": {"LaunchTemplateId": "lt-1", "LatestVersionNumber": 1}
+        }
+        tags = [{"Key": "ProviderId", "Value": "p-1"}]
+
+        create_launch_template(ec2, "n", {"ImageId": "ami-1"}, tags)
+
+        assert ec2.create_launch_template.call_args.kwargs["TagSpecifications"] == [
+            {"ResourceType": "launch-template", "Tags": tags}
+        ]
+
+    def test_existing_template_gets_a_new_version(self):
+        """``initialize()`` may run again after a partial failure.
+
+        A second ``CreateLaunchTemplate`` under the same name is rejected with
+        ``InvalidLaunchTemplateName.AlreadyExistsException``. A *new version* is
+        published rather than the old one reused, so a changed AMI or instance
+        type actually takes effect.
+        """
+        ec2 = MagicMock()
+        ec2.create_launch_template.side_effect = _client_error(
+            "InvalidLaunchTemplateName.AlreadyExistsException", "CreateLaunchTemplate"
+        )
+        ec2.create_launch_template_version.return_value = {
+            "LaunchTemplateVersion": {
+                "LaunchTemplateId": "lt-1",
+                "VersionNumber": 4,
+            }
+        }
+
+        assert create_launch_template(ec2, "n", {"ImageId": "ami-2"}) == ("lt-1", "4")
+        assert ec2.create_launch_template_version.call_args.kwargs[
+            "LaunchTemplateData"
+        ] == {"ImageId": "ami-2"}
+
+    def test_other_client_errors_raise(self):
+        ec2 = MagicMock()
+        ec2.create_launch_template.side_effect = _client_error(
+            "UnauthorizedOperation", "CreateLaunchTemplate"
+        )
+
+        with pytest.raises(ResourceCreationError):
+            create_launch_template(ec2, "n", {"ImageId": "ami-1"})
+
+    def test_failed_version_creation_raises(self):
+        ec2 = MagicMock()
+        ec2.create_launch_template.side_effect = _client_error(
+            "InvalidLaunchTemplateName.AlreadyExistsException", "CreateLaunchTemplate"
+        )
+        ec2.create_launch_template_version.side_effect = _client_error(
+            "UnauthorizedOperation", "CreateLaunchTemplateVersion"
+        )
+
+        with pytest.raises(ResourceCreationError):
+            create_launch_template(ec2, "n", {"ImageId": "ami-1"})
+
+
+class TestDeleteLaunchTemplate:
+    """Deletion must tolerate a template that is already gone."""
+
+    def test_deletes_by_id(self):
+        ec2 = MagicMock()
+
+        delete_launch_template(ec2, "lt-1")
+
+        ec2.delete_launch_template.assert_called_once_with(LaunchTemplateId="lt-1")
+
+    def test_missing_template_is_not_an_error(self):
+        ec2 = MagicMock()
+        ec2.delete_launch_template.side_effect = _client_error(
+            "InvalidLaunchTemplateId.NotFound", "DeleteLaunchTemplate"
+        )
+
+        delete_launch_template(ec2, "lt-1")
+
+    def test_other_errors_raise(self):
+        ec2 = MagicMock()
+        ec2.delete_launch_template.side_effect = _client_error(
+            "UnauthorizedOperation", "DeleteLaunchTemplate"
+        )
+
+        with pytest.raises(ResourceDeletionError):
+            delete_launch_template(ec2, "lt-1")
+
+
+class TestStandardModeLaunchTemplate:
+    """The mode builds one template in initialize() and deletes it on cleanup."""
+
+    @pytest.fixture
+    def ec2(self):
+        client = MagicMock()
+        client.create_launch_template.return_value = {
+            "LaunchTemplate": {"LaunchTemplateId": "lt-1", "LatestVersionNumber": 3}
+        }
+        client.run_instances.return_value = {
+            "Instances": [{"InstanceId": "i-1", "State": {"Name": "pending"}}]
+        }
+        client.describe_instances.return_value = {
+            "Reservations": [
+                {"Instances": [{"InstanceId": "i-1", "State": {"Name": "running"}}]}
+            ]
+        }
+        return client
+
+    @pytest.fixture
+    def mode(self, ec2):
+        session = MagicMock(spec=boto3.Session)
+        session.region_name = "us-east-1"
+        session.client.return_value = ec2
+        store = MagicMock()
+        store.load_state.return_value = None
+        return StandardMode(
+            provider_id="test-provider",
+            session=session,
+            state_store=store,
+            instance_type="t3.micro",
+            image_id="ami-12345678",
+            region="us-east-1",
+            vpc_id="vpc-12345",
+            subnet_id="subnet-12345",
+            security_group_id="sg-12345",
+        )
+
+    def _initialize(self, mode):
+        with patch.object(mode, "_verify_resources"):
+            mode.initialize()
+
+    def test_initialize_creates_the_template(self, mode, ec2):
+        self._initialize(mode)
+
+        ec2.create_launch_template.assert_called_once()
+        assert mode._launch_template_id == "lt-1"
+        assert mode._launch_template_version == "3"
+
+    def test_template_requires_imdsv2(self, mode, ec2):
+        self._initialize(mode)
+
+        data = ec2.create_launch_template.call_args.kwargs["LaunchTemplateData"]
+        assert data["MetadataOptions"]["HttpTokens"] == "required"
+
+    def test_template_carries_shutdown_behavior(self, mode, ec2):
+        self._initialize(mode)
+
+        data = ec2.create_launch_template.call_args.kwargs["LaunchTemplateData"]
+        assert data["InstanceInitiatedShutdownBehavior"] == "terminate"
+
+    def test_template_is_named_for_the_provider(self, mode, ec2):
+        self._initialize(mode)
+
+        name = ec2.create_launch_template.call_args.kwargs["LaunchTemplateName"]
+        assert name == f"{LAUNCH_TEMPLATE_NAME_PREFIX}-test-provider"
+        assert len(name) <= 128
+
+    def test_template_is_tagged_with_the_provider_id(self, mode, ec2):
+        """Nothing else identifies the template as ours during orphan cleanup."""
+        self._initialize(mode)
+
+        tags = ec2.create_launch_template.call_args.kwargs["TagSpecifications"][0][
+            "Tags"
+        ]
+        assert {"Key": "ProviderId", "Value": "test-provider"} in tags
+
+    def test_template_omits_per_job_fields(self, mode, ec2):
+        """UserData and tags are per-job and are passed at launch instead."""
+        self._initialize(mode)
+
+        data = ec2.create_launch_template.call_args.kwargs["LaunchTemplateData"]
+        assert "UserData" not in data
+        assert "TagSpecifications" not in data
+
+    def test_template_references_the_baked_ami(self, mode, ec2):
+        """Order matters: baking reassigns ``self.image_id``.
+
+        Building the template first would pin the base AMI and every worker
+        would launch without the baked-in ``worker_init``.
+        """
+        mode.bake_ami = True
+        with patch.object(mode, "_bake_ami", return_value="ami-baked"):
+            self._initialize(mode)
+
+        data = ec2.create_launch_template.call_args.kwargs["LaunchTemplateData"]
+        assert data["ImageId"] == "ami-baked"
+
+    def test_template_carries_the_resolved_iam_profile(self, ec2):
+        """Resolved in initialize(), so it cannot be read in __init__."""
+        session = MagicMock(spec=boto3.Session)
+        session.region_name = "us-east-1"
+        session.client.return_value = ec2
+        store = MagicMock()
+        store.load_state.return_value = None
+        mode = StandardMode(
+            provider_id="test-provider",
+            session=session,
+            state_store=store,
+            image_id="ami-12345678",
+            vpc_id="vpc-12345",
+            subnet_id="subnet-12345",
+            security_group_id="sg-12345",
+            auto_create_instance_profile=True,
+        )
+        with patch(
+            "parsl_ephemeral_aws.modes.standard.get_or_create_ssm_instance_profile",
+            return_value="arn:aws:iam::1:instance-profile/p",
+        ):
+            self._initialize(mode)
+
+        data = ec2.create_launch_template.call_args.kwargs["LaunchTemplateData"]
+        assert data["IamInstanceProfile"] == {
+            "Arn": "arn:aws:iam::1:instance-profile/p"
+        }
+
+    def test_template_creation_failure_is_not_fatal(self, mode, ec2):
+        """An account without ec2:CreateLaunchTemplate must keep working."""
+        ec2.create_launch_template.side_effect = _client_error(
+            "UnauthorizedOperation", "CreateLaunchTemplate"
+        )
+
+        self._initialize(mode)
+
+        assert mode.initialized is True
+        assert mode._launch_template_id is None
+
+    def test_cleanup_deletes_the_template(self, mode, ec2):
+        self._initialize(mode)
+
+        mode.cleanup_infrastructure()
+
+        ec2.delete_launch_template.assert_called_once_with(LaunchTemplateId="lt-1")
+        assert mode._launch_template_id is None
+
+    def test_failed_deletion_still_clears_the_id(self, mode, ec2):
+        """Cleanup is not retried, so a stale ID would be used by a later launch."""
+        self._initialize(mode)
+        ec2.delete_launch_template.side_effect = _client_error(
+            "UnauthorizedOperation", "DeleteLaunchTemplate"
+        )
+
+        mode.cleanup_infrastructure()
+
+        assert mode._launch_template_id is None
+
+    def test_template_survives_a_state_round_trip(self, mode, ec2):
+        """Otherwise a resumed provider leaks the old one and builds a second."""
+        self._initialize(mode)
+        state = mode.state_store.save_state.call_args.args[1]
+        assert state["launch_template_id"] == "lt-1"
+        assert state["launch_template_version"] == "3"
+
+        mode._launch_template_id = None
+        mode._launch_template_version = None
+        mode.state_store.load_state.return_value = state
+        assert mode.load_state() is True
+
+        assert mode._launch_template_id == "lt-1"
+        assert mode._launch_template_version == "3"
+
+    def test_resumed_pre_85_state_gets_a_template(self, mode, ec2):
+        """A v0.6.0 state document carries no template ID.
+
+        Without this the resumed provider would sit on the fallback path
+        permanently, so its spot launches would never get IMDSv2.
+        """
+        mode.state_store.load_state.return_value = {
+            "provider_id": "test-provider",
+            "resources": {},
+            "initialized": True,
+            "vpc_id": "vpc-12345",
+            "subnet_id": "subnet-12345",
+            "security_group_id": "sg-12345",
+        }
+
+        self._initialize(mode)
+
+        assert mode._launch_template_id == "lt-1"
+        ec2.create_launch_template.assert_called_once()
+
+    def test_version_is_pinned_not_latest(self, mode):
+        """An adopted template may carry versions this mode did not build."""
+        mode._launch_template_id = "lt-1"
+        mode._launch_template_version = "3"
+
+        assert mode._launch_template_reference() == {
+            "LaunchTemplateId": "lt-1",
+            "Version": "3",
+        }
+
+    def test_no_reference_without_a_template(self, mode):
+        assert mode._launch_template_reference() is None
+
+
+class TestStandardModeLaunchPaths:
+    """Each launch path has to send the template rather than raw kwargs."""
+
+    @pytest.fixture
+    def ec2(self):
+        client = MagicMock()
+        client.create_launch_template.return_value = {
+            "LaunchTemplate": {"LaunchTemplateId": "lt-1", "LatestVersionNumber": 3}
+        }
+        client.run_instances.return_value = {
+            "Instances": [{"InstanceId": "i-1", "State": {"Name": "pending"}}]
+        }
+        return client
+
+    def _mode(self, ec2, **kwargs):
+        session = MagicMock(spec=boto3.Session)
+        session.region_name = "us-east-1"
+        session.client.return_value = ec2
+        store = MagicMock()
+        store.load_state.return_value = None
+        mode = StandardMode(
+            provider_id="test-provider",
+            session=session,
+            state_store=store,
+            instance_type="t3.micro",
+            image_id="ami-12345678",
+            region="us-east-1",
+            vpc_id="vpc-12345",
+            subnet_id="subnet-12345",
+            security_group_id="sg-12345",
+            **kwargs,
+        )
+        with patch.object(mode, "_verify_resources"):
+            mode.initialize()
+        return mode
+
+    def test_on_demand_launch_uses_the_template(self, ec2):
+        mode = self._mode(ec2)
+
+        with patch("parsl_ephemeral_aws.modes.standard.wait_for_resource"):
+            mode._create_instance("#!/bin/bash\necho hi\n", "job-1")
+
+        kwargs = ec2.run_instances.call_args.kwargs
+        assert kwargs["LaunchTemplate"] == {
+            "LaunchTemplateId": "lt-1",
+            "Version": "3",
+        }
+        # The template owns these now; repeating them would be the duplication
+        # #85 removes, and a stale copy here would silently win.
+        for key in (
+            "ImageId",
+            "InstanceType",
+            "NetworkInterfaces",
+            "MetadataOptions",
+            "InstanceInitiatedShutdownBehavior",
+        ):
+            assert key not in kwargs
+
+    def test_on_demand_launch_still_overrides_per_job_fields(self, ec2):
+        mode = self._mode(ec2)
+
+        with patch("parsl_ephemeral_aws.modes.standard.wait_for_resource"):
+            mode._create_instance("#!/bin/bash\necho hi\n", "job-1")
+
+        kwargs = ec2.run_instances.call_args.kwargs
+        # Plaintext: botocore base64-encodes UserData for RunInstances, so
+        # encoding it here as well would double-encode it.
+        assert kwargs["UserData"] == "#!/bin/bash\necho hi\n"
+        tags = kwargs["TagSpecifications"][0]["Tags"]
+        assert {"Key": "JobId", "Value": "job-1"} in tags
+
+    def test_fallback_path_sets_metadata_options_itself(self, ec2):
+        """No template means IMDSv2 has to be set per launch instead."""
+        mode = self._mode(ec2)
+        mode._launch_template_id = None
+
+        with patch("parsl_ephemeral_aws.modes.standard.wait_for_resource"):
+            mode._create_instance("#!/bin/bash\necho hi\n", "job-1")
+
+        kwargs = ec2.run_instances.call_args.kwargs
+        assert kwargs["MetadataOptions"]["HttpTokens"] == "required"
+        assert kwargs["InstanceInitiatedShutdownBehavior"] == "terminate"
+        assert kwargs["ImageId"] == "ami-12345678"
+
+    def test_spot_launch_goes_through_run_instances(self, ec2):
+        """``RequestSpotInstances`` can never carry IMDSv2.
+
+        It accepts no ``LaunchTemplate``, and its ``LaunchSpecification`` shape
+        has no ``MetadataOptions`` member -- so the only way to harden a spot
+        instance is ``RunInstances`` + ``InstanceMarketOptions``.
+        """
+        mode = self._mode(ec2, use_spot=True)
+
+        with patch("parsl_ephemeral_aws.modes.standard.wait_for_resource"):
+            mode._create_instance("#!/bin/bash\necho hi\n", "job-1")
+
+        ec2.request_spot_instances.assert_not_called()
+        kwargs = ec2.run_instances.call_args.kwargs
+        assert kwargs["InstanceMarketOptions"] == {"MarketType": "spot"}
+        assert kwargs["LaunchTemplate"]["LaunchTemplateId"] == "lt-1"
+
+    def test_spot_launch_keeps_terminate_shutdown_behavior(self, ec2):
+        """Verified against real EC2: a spot instance accepts ``terminate``.
+
+        The old ``RequestSpotInstances`` path had to drop the setting -- its
+        ``LaunchSpecification`` has no such member -- so a self-shutting-down
+        spot instance was left *stopped*, with a billed EBS volume that
+        ``EC2_STATUS_MAPPING`` then reported as COMPLETED, dropping the tracking
+        record. Forcing ``stop`` back on here would recreate that leak.
+        """
+        mode = self._mode(ec2, use_spot=True)
+
+        with patch("parsl_ephemeral_aws.modes.standard.wait_for_resource"):
+            mode._create_instance("#!/bin/bash\necho hi\n", "job-1")
+
+        kwargs = ec2.run_instances.call_args.kwargs
+        assert kwargs.get("InstanceInitiatedShutdownBehavior") != "stop"
+        data = ec2.create_launch_template.call_args.kwargs["LaunchTemplateData"]
+        assert data["InstanceInitiatedShutdownBehavior"] == "terminate"
+
+    def test_spot_max_price_becomes_spot_options(self, ec2):
+        mode = self._mode(ec2, use_spot=True, spot_max_price="0.05")
+
+        with patch("parsl_ephemeral_aws.modes.standard.wait_for_resource"):
+            mode._create_instance("#!/bin/bash\necho hi\n", "job-1")
+
+        kwargs = ec2.run_instances.call_args.kwargs
+        assert kwargs["InstanceMarketOptions"] == {
+            "MarketType": "spot",
+            "SpotOptions": {"MaxPrice": "0.05"},
+        }
+
+    def test_spot_falls_back_to_request_spot_instances_without_a_template(self, ec2):
+        mode = self._mode(ec2, use_spot=True)
+        mode._launch_template_id = None
+        ec2.request_spot_instances.return_value = {
+            "SpotInstanceRequests": [{"SpotInstanceRequestId": "sir-1"}]
+        }
+        ec2.describe_spot_instance_requests.return_value = {
+            "SpotInstanceRequests": [{"InstanceId": "i-1"}]
+        }
+
+        with patch("parsl_ephemeral_aws.modes.standard.wait_for_resource"):
+            mode._create_instance("#!/bin/bash\necho hi\n", "job-1")
+
+        ec2.request_spot_instances.assert_called_once()
+
+    def test_ami_builder_keeps_stop_and_avoids_the_template(self, ec2):
+        """The one launch that must not inherit ``terminate``.
+
+        UserData ends in ``shutdown -h now`` and ``create_image`` needs the
+        stopped instance to snapshot. The ``InstanceStopped`` waiter names
+        ``terminated`` as an explicit *failure* acceptor, so inheriting the
+        template's ``terminate`` would fail the bake outright.
+        """
+        mode = self._mode(ec2)
+
+        mode._launch_builder_instance()
+
+        kwargs = ec2.run_instances.call_args.kwargs
+        assert kwargs["InstanceInitiatedShutdownBehavior"] == "stop"
+        assert "LaunchTemplate" not in kwargs
+
+    def test_ami_builder_still_requires_imdsv2(self, ec2):
+        """A worker_init that works under IMDSv1 here would break every worker
+        launched from the resulting AMI."""
+        mode = self._mode(ec2)
+
+        mode._launch_builder_instance()
+
+        kwargs = ec2.run_instances.call_args.kwargs
+        assert kwargs["MetadataOptions"]["HttpTokens"] == "required"
+
+
+class TestSpotFleetLaunchTemplate:
+    """Spot Fleet reaches IMDSv2 only through a launch template."""
+
+    @pytest.fixture
+    def ec2(self):
+        client = MagicMock()
+        client.create_launch_template.return_value = {
+            "LaunchTemplate": {"LaunchTemplateId": "lt-fleet", "LatestVersionNumber": 1}
+        }
+        client.request_spot_fleet.return_value = {"SpotFleetRequestId": "sfr-1"}
+        return client
+
+    @pytest.fixture
+    def manager(self, ec2):
+        provider = type(
+            "SimpleProvider",
+            (),
+            {
+                "workflow_id": "wf-1",
+                "region": "us-east-1",
+                "aws_profile": None,
+                "vpc_id": "vpc-1",
+                "subnet_id": "subnet-1",
+                "security_group_id": "sg-1",
+                "image_id": "ami-1",
+                "instance_type": "t3.micro",
+                "instance_types": ["t3.micro", "t3.small"],
+                "key_name": None,
+                "use_public_ips": True,
+                "nodes_per_block": 1,
+                "spot_max_price_percentage": 100,
+                "worker_init": "echo hi",
+                "tags": {},
+                "iam_instance_profile_arn": "arn:aws:iam::1:instance-profile/p",
+            },
+        )()
+        session = MagicMock()
+        session.client.return_value = ec2
+        session.resource.return_value = MagicMock()
+        with patch(
+            "parsl_ephemeral_aws.compute.spot_fleet.CredentialManager"
+        ) as cred_cls:
+            cred_cls.return_value.create_boto3_session.return_value = session
+            return SpotFleetManager(provider)
+
+    def _request(self, manager):
+        manager._create_spot_fleet_request(
+            "block-1",
+            {
+                "vpc_id": "vpc-1",
+                "subnet_id": "subnet-1",
+                "security_group_id": "sg-1",
+            },
+            1,
+            "arn:aws:iam::1:role/fleet",
+        )
+        return manager.ec2_client.request_spot_fleet.call_args.kwargs[
+            "SpotFleetRequestConfig"
+        ]
+
+    def test_fleet_request_sends_only_the_template_form(self, manager):
+        """EC2 accepts both keys, then silently ignores the template.
+
+        DryRun against real EC2 returns ``DryRunOperation`` for a request
+        carrying ``LaunchSpecifications`` *and* ``LaunchTemplateConfigs`` -- and
+        the specifications win, taking IMDSv2 with them.
+        """
+        config = self._request(manager)
+
+        assert "LaunchTemplateConfigs" in config
+        assert "LaunchSpecifications" not in config
+
+    def test_fleet_template_requires_imdsv2(self, manager, ec2):
+        """The only route: ``SpotFleetLaunchSpecification`` has no
+        ``MetadataOptions`` member at all."""
+        self._request(manager)
+
+        data = ec2.create_launch_template.call_args.kwargs["LaunchTemplateData"]
+        assert data["MetadataOptions"]["HttpTokens"] == "required"
+
+    def test_fleet_template_carries_encoded_user_data(self, manager, ec2):
+        """``Overrides`` cannot carry ``UserData``, so it lives in the template.
+
+        And ``CreateLaunchTemplate`` does not base64-encode it, unlike
+        ``RunInstances`` -- plaintext here boots an instance that never runs the
+        worker, with nothing raising.
+        """
+        self._request(manager)
+
+        data = ec2.create_launch_template.call_args.kwargs["LaunchTemplateData"]
+        assert base64.b64decode(data["UserData"]).decode().startswith("#!/bin/bash")
+
+    def test_fleet_template_carries_the_iam_profile(self, manager, ec2):
+        self._request(manager)
+
+        data = ec2.create_launch_template.call_args.kwargs["LaunchTemplateData"]
+        assert data["IamInstanceProfile"] == {
+            "Arn": "arn:aws:iam::1:instance-profile/p"
+        }
+
+    def test_every_instance_type_becomes_an_override(self, manager):
+        """One template covers every pool the fleet may draw from."""
+        config = self._request(manager)
+
+        overrides = config["LaunchTemplateConfigs"][0]["Overrides"]
+        assert [o["InstanceType"] for o in overrides] == ["t3.micro", "t3.small"]
+        assert all(o["SubnetId"] == "subnet-1" for o in overrides)
+
+    def test_template_failure_falls_back_to_launch_specifications(self, manager, ec2):
+        """Unavoidably without IMDSv2, but a working fleet beats no fleet."""
+        ec2.create_launch_template.side_effect = _client_error(
+            "UnauthorizedOperation", "CreateLaunchTemplate"
+        )
+
+        config = self._request(manager)
+
+        assert "LaunchSpecifications" in config
+        assert "LaunchTemplateConfigs" not in config
+
+    def test_fallback_user_data_is_encoded(self, manager, ec2):
+        """``SpotFleetLaunchSpecification`` is not auto-encoded either."""
+        ec2.create_launch_template.side_effect = _client_error(
+            "UnauthorizedOperation", "CreateLaunchTemplate"
+        )
+
+        config = self._request(manager)
+
+        spec = config["LaunchSpecifications"][0]
+        assert base64.b64decode(spec["UserData"]).decode().startswith("#!/bin/bash")
+
+    def test_template_is_tracked_per_block(self, manager):
+        self._request(manager)
+
+        assert manager.launch_templates == {"block-1": "lt-fleet"}
+
+    def test_terminating_a_block_deletes_its_template(self, manager, ec2):
+        self._request(manager)
+        manager.blocks["block-1"] = {
+            "fleet_request_id": "sfr-1",
+            "instance_ids": [],
+            "status": "RUNNING",
+        }
+
+        manager.terminate_block("block-1")
+
+        ec2.delete_launch_template.assert_called_once_with(LaunchTemplateId="lt-fleet")
+        assert manager.launch_templates == {}
+
+    def test_a_block_with_no_fleet_request_still_drops_its_template(self, manager, ec2):
+        """The template belongs to the block, not to the fleet request.
+
+        ``terminate_block`` returns early when the request ID was never
+        recorded, which would otherwise leak the template until
+        ``cleanup_all_resources``.
+        """
+        self._request(manager)
+        manager.blocks["block-1"] = {"status": "RUNNING"}
+
+        manager.terminate_block("block-1")
+
+        ec2.delete_launch_template.assert_called_once_with(LaunchTemplateId="lt-fleet")
+
+    def test_cleanup_deletes_every_remaining_template(self, manager, ec2):
+        self._request(manager)
+
+        manager.cleanup_all_resources()
+
+        ec2.delete_launch_template.assert_any_call(LaunchTemplateId="lt-fleet")
+        assert manager.launch_templates == {}
+
+
+class TestBastionWorkerMetadataOptions:
+    """The bastion launches workers from a script it runs standalone.
+
+    It cannot import from the package, so the options are injected as a literal
+    at script generation time. ``str.replace`` finding nothing is not an error,
+    so the generated text is what has to be asserted on -- not the source.
+    """
+
+    def _script(self):
+        from parsl_ephemeral_aws.modes.detached import DetachedMode
+
+        mode = DetachedMode(
+            provider_id="test-provider",
+            session=MagicMock(),
+            state_store=MagicMock(),
+            workflow_id="test-workflow",
+            instance_type="t3.small",
+            image_id="ami-12345678",
+            region="us-east-1",
+            vpc_id="vpc-12345",
+            subnet_id="subnet-12345",
+            security_group_id="sg-12345",
+        )
+        return mode._get_bastion_manager_script()
+
+    def _injected_value(self, script):
+        for line in script.splitlines():
+            if line.startswith("METADATA_OPTIONS = "):
+                return ast.literal_eval(
+                    line.removeprefix("METADATA_OPTIONS = ").split("  #")[0]
+                )
+        raise AssertionError("script defines no METADATA_OPTIONS constant")
+
+    def test_injected_options_match_the_package_constant(self):
+        """A copy in the template would drift the next time the constant moves."""
+        assert self._injected_value(self._script()) == IMDSV2_METADATA_OPTIONS
+
+    def test_workers_launched_by_the_bastion_get_imdsv2(self):
+        assert self._injected_value(self._script())["HttpTokens"] == "required"
+
+    def test_generated_script_is_valid_python(self):
+        """The substitution must not break the script the bastion has to run."""
+        ast.parse(self._script())
+
+    def test_worker_launch_reads_the_constant(self):
+        script = self._script()
+
+        assert "'MetadataOptions': METADATA_OPTIONS," in script

--- a/tests/unit/test_spot_fleet.py
+++ b/tests/unit/test_spot_fleet.py
@@ -324,11 +324,17 @@ class TestSpotFleetManager(unittest.TestCase):
         config = mock_ec2_client.request_spot_fleet.call_args.kwargs[
             "SpotFleetRequestConfig"
         ]
-        tag_specs = config["TagSpecifications"] + [
-            spec
-            for launch_spec in config["LaunchSpecifications"]
-            for spec in launch_spec["TagSpecifications"]
-        ]
+        # Instance tags now travel in the launch *template* (#85), so gather them
+        # from CreateLaunchTemplate as well as from any LaunchSpecifications the
+        # fallback path would have emitted. Either form must be duplicate-free.
+        tag_specs = list(config["TagSpecifications"])
+        for launch_spec in config.get("LaunchSpecifications", []):
+            tag_specs.extend(launch_spec["TagSpecifications"])
+        for call in mock_ec2_client.create_launch_template.call_args_list:
+            tag_specs.extend(call.kwargs.get("TagSpecifications", []))
+            tag_specs.extend(
+                call.kwargs["LaunchTemplateData"].get("TagSpecifications", [])
+            )
         self.assertTrue(tag_specs)
         for spec in tag_specs:
             keys = [tag["Key"] for tag in spec["Tags"]]


### PR DESCRIPTION
Phase 5 of the v0.7.0 repair-and-modernize plan. Closes #85.

## What #85 asked for, and what changed

#85 asked for three things: move every raw `RunInstances` path onto a launch
template, fold in `MetadataOptions={"HttpTokens": "required"}`, and carry
`InstanceInitiatedShutdownBehavior` and the resolved IAM profile into the
template rather than per-call kwargs. All three are done. Four API asymmetries
reshaped *how*, each verified against the botocore service model and then real
EC2 — none is visible in a mock:

| Verified constraint | Consequence |
|---|---|
| `RequestSpotInstances` accepts no `LaunchTemplate`, and `LaunchSpecification` has no `MetadataOptions` **or** `InstanceInitiatedShutdownBehavior` member | Plain spot moved to `RunInstances` + `InstanceMarketOptions`; a one-time spot request *does* accept `terminate` (verified twice with real launches) |
| `SpotFleetLaunchSpecification` has no `MetadataOptions`, and `LaunchTemplateConfig.Overrides` carries no `UserData` | Per-block templates on the fleet path, with a logged fallback |
| `RequestSpotFleet` accepts **both** launch forms in one request (DryRun returns `DryRunOperation`) and the template loses to the specifications | Exactly one form is sent, or IMDSv2 would vanish silently |
| botocore base64-encodes `UserData` for `RunInstances` **only** — `CreateLaunchTemplate` is not among its handlers | `encode_user_data()`, applied to template data only. Plaintext there is base64-*decoded* by cloud-init and fails silently: the instance boots fine and never runs the worker |
| The `InstanceStopped` waiter lists `terminated` as an explicit **failure** acceptor | The AMI-baking builder keeps `"stop"` and deliberately does not use the template — inheriting `terminate` would *fail the bake*, not merely slow it |

## Defects fixed, and how each was verified

**A live cost leak on the spot path.** `InstanceInitiatedShutdownBehavior` is not
a member of the shape `RequestSpotInstances` accepts, so EC2's `stop` default
applied to the `shutdown -h now` that `_prepare_init_script` appends — while
`EC2_STATUS_MAPPING` maps `stopped` to COMPLETED, so `_cleanup_resources()`
dropped the tracking record and the volume was orphaned *and* untracked. This is
the same leak Phase 1.3a closed on the on-demand path, still open on spot.
*Verified:* real spot launch reports `InstanceLifecycle=spot` with a spot request
ID, shutdown behaviour `terminate`, `HttpTokens=required`; the instance reached
`terminated` and the request closed `instance-terminated-by-user` with no
`available` volume left behind. An earlier assumption that EC2 rejects
spot+`terminate` was wrong; acting on it would have recreated the leak.

**Fleet instances launched with no IAM instance profile.** The `SpotFleetManager`
provider stand-in that `StandardMode` builds never carried
`iam_instance_profile_arn`, so the manager's `getattr` fell through to `None` —
SSM never came online and dispatch silently fell back to UserData. The stand-in
is built in `__init__`, *before* `_resolve_instance_profile()` runs, so the
resolved ARN is now propagated to it once known. *Verified:* found by writing the
unit test; covered by `test_spot_fleet_template_carries_the_iam_profile` and
asserted on the real template.

**`terminate_block()` leaked the block's launch template** whenever no fleet
request ID had been recorded — it logged a warning and returned before the
delete. The template belongs to the block, not the request. *Verified:* found the
same way; two unit tests now pin both paths.

## IMDSv2

Nothing set `MetadataOptions` anywhere before, so every worker, bastion, spot,
and fleet instance accepted unauthenticated IMDSv1 — the shape that turns any
SSRF in submitted user code into instance-credential theft, and these workers run
arbitrary submitted commands. `HttpEndpoint` stays `enabled` (SSM reads the
identity document from IMDS). The hop limit is left at EC2's default of 2 rather
than tightened to 1: a request from inside a container spawned by `worker_init`
traverses the host network namespace and costs a hop. No IMDSv1 fetch exists
anywhere in the package, so nothing internal depended on the old default.

## Verification

| Gate | Before | After |
|---|---|---|
| `tests/unit tests/security` | 721 passed | **784 passed, 0 failed** |
| `ruff check parsl_ephemeral_aws tests` | clean | **clean** |
| `mypy parsl_ephemeral_aws` | 89 errors / 20 files | **87 errors / 20 files** |
| marked vs unmarked unit collection | 691 == 691 | **691 == 691** |
| `tests/integration` | 30F/37P/11S/11E | unchanged (pre-existing #92 debt) |

**Real AWS, us-east-1, all through the provider** — `tests/aws/test_launch_template_e2e.py`,
**7 passed in 2m18s**:

- template stored with `HttpTokens=required`, `HttpEndpoint=enabled`, hop limit
  unset, `InstanceInitiatedShutdownBehavior=terminate`, correct subnet/SG, IAM
  profile attached, `ProviderId` + `CreatedBy` + `additional_tags` present
- instance launched from it: `HttpTokens=required`, hop limit resolved to 2,
  shutdown behaviour `terminate` (read via `describe_instance_attribute` — it is
  not in the `describe_instances` response), profile attached
- spot instance: `InstanceLifecycle=spot` with a spot request ID, IMDSv2, and
  `terminate` intact
- `shutdown()` deletes the template and the mode forgets its ID

Orphan sweep after the run: no `parsl*` launch templates, no non-terminated
`CreatedBy=ParslEphemeralAWSProvider` instances, no `available` volumes, no
open/active spot requests.

## Notes

- The one-off `tools/verify_phase5_launch_templates.py` probe used during
  development was folded into the E2E suite and deleted — `tools/` is pruned by
  #93 in v0.8.0, so verification belongs in `tests/aws/`.
- Template creation failure is non-fatal: an account without
  `ec2:CreateLaunchTemplate` keeps working via the raw-kwargs fallback, just
  without IMDSv2 on the plain-spot path, and the fallback logs that.
- `create_launch_template()` is idempotent by adding a *new version* rather than
  reusing the existing one, so a resumed provider whose AMI or instance type has
  changed does not silently keep launching the previous definition.
