### PR TITLE
feat: migrate to EC2 Fleet, bound warm-pool cost, warn before reclaim (closes #86)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   live VPC and blackhole egress for unrelated workloads (closes #94).
 
 ### Fixed
+- `ServerlessMode`'s spot fleet path could never have launched an instance. Its
+  CloudFormation template declared a `RegionMap` of AMIs that no `FindInMap`
+  ever read, so the fleet's launch template carried no `ImageId` and EC2 refused
+  every request with `Parameter 'amiIdList' cannot be empty` — confirmed against
+  both fleet APIs. The template also padded a fixed set of `!Select` slots by
+  repeating an instance type, which EC2 rejects outright with
+  `InvalidFleetConfig: The fleet configuration contains duplicate instance
+  pools`; a `DryRun` does not catch that, having accepted the identical
+  duplicate-bearing request. The fleet is now created directly by
+  `_create_job_fleet()`, which resolves the AMI from SSM and deduplicates the
+  override list (closes #86).
+- The detached mode's default bastion path always failed. `_create_bastion_stack()`
+  sent `UseSpotFleet`, `InstanceTypes`, `NodesPerBlock`, and
+  `SpotMaxPricePercentage` to `bastion.yml`, which declares none of them, and
+  CloudFormation rejects an undeclared parameter outright:
+  `ValidationError: Parameters: [UseSpotFleet] do not exist in the template`.
+  Since `bastion_host_type` defaults to `"cloudformation"`, this was the default
+  path. All four describe a *worker fleet* and the bastion is a single host, so
+  they are dropped rather than added to the template; the fleet settings already
+  reach the workers through the bastion manager script (refs #86).
+- No spot fleet was ever registered with the interruption monitor.
+  `StandardMode` iterated a `"fleet_requests"` list on each block — at submit
+  time and again after a state load — but the manager records a single
+  `"fleet_request_id"` and nothing has ever written `"fleet_requests"`. The loop
+  body was therefore unreachable, so every fleet ran unmonitored while
+  `spot_interruption_handling=True` reported otherwise (refs #86).
+- The orphan sweep missed both kinds of fleet resource it was meant to find.
+  `cleanup_all_spot_fleet_resources()` looked for IAM roles named
+  `parsl-aws-spot-fleet-role-*` only, but the bastion manager script created
+  them as `parsl-ephemeral-spot-fleet-role-*`, so every role that path made was
+  leaked. It also enumerated fleets with `describe_spot_fleet_requests`, which
+  cannot see an EC2 Fleet at all. Both prefixes are now swept, and fleets are
+  found through the `aws:ec2:fleet-id` tag on their instances (refs #86).
+- The synthesised "similar instance types" in the bastion manager script
+  produced invalid type names for most families. Slicing off the first
+  character assumes a single-character family, so `m5a.large` became
+  `mm5a.large`/`rm5a.large` and `c6i.large` became `c7i.large` via a
+  generation bump that ignored the suffix. Each bad name was a pool the fleet
+  could not draw from. The script now uses the configured instance types, or
+  the job's single type (refs #86).
 - A spot instance that shut itself down was left `stopped` with a billed EBS
   volume that the provider had already forgotten about. `InstanceInitiatedShutdownBehavior`
   is not a member of the `LaunchSpecification` shape `RequestSpotInstances`
@@ -426,6 +466,75 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a first run can proceed with no saved state (closes #122).
 
 ### Added
+- **Spot interruption warnings now arrive before the instance dies.** An
+  EventBridge rule matching `EC2 Spot Instance Interruption Warning` delivers to
+  an SQS queue that the driver long-polls, giving roughly two minutes of notice
+  while the instance is still `running` — the only window in which checkpointing
+  can succeed. `SpotInterruptionMonitor` creates the rule and queue in
+  `start_monitoring()` and deletes them in `stop_monitoring()`, including when no
+  thread was running, since nothing else in the package would reclaim them.
+  This **requires new IAM permissions**: `events:PutRule`, `events:PutTargets`,
+  `events:RemoveTargets`, `events:DeleteRule`, `events:TagResource`,
+  `sqs:CreateQueue`, `sqs:GetQueueAttributes`, `sqs:SetQueueAttributes`,
+  `sqs:ReceiveMessage`, `sqs:DeleteMessage`, and `sqs:DeleteQueue`. Failing to
+  create the notifier is logged and does **not** fail the workflow: detection
+  degrades to the pre-existing EC2-state poll, which still works but can only
+  report an interruption post-facto. Set `use_event_bridge=False` on the monitor
+  to skip creation deliberately. Verified end to end against real AWS with a
+  Fault Injection Simulator experiment
+  (`aws:ec2:send-spot-instance-interruptions`): the warning reached the queue
+  15.2s after the experiment started, with the instance still `running`, and a
+  handler registered through the provider's own monitor fired with
+  `Source: "eventbridge"` (closes #86).
+  - **No IAM role is created for the target, and none is needed.** Delivery to
+    SQS is authorised by the *queue's* resource policy, unlike most target
+    types; `put_targets` with an SQS ARN and no `RoleArn` returns
+    `FailedEntryCount=0`. The queue policy grants `events.amazonaws.com`
+    `sqs:SendMessage` conditioned on `aws:SourceArn` being this rule, so no
+    other rule in any account can post to it.
+  - **The rule cannot be scoped to this provider's instances.** The event's
+    `detail` carries only `instance-id` and `instance-action`, and instance IDs
+    are not known until the fleet launches, so the rule necessarily matches
+    every spot interruption in the account and region. Each monitor discards
+    warnings for instances it does not track; two providers in one account each
+    see the other's warnings and ignore them.
+  - `EC2 Instance Rebalance Recommendation` is deliberately **not** matched. It
+    signals elevated interruption risk rather than an impending reclaim, so
+    treating it as an interruption would checkpoint and tear down workers that
+    were never going away.
+  - A fake warning cannot be used to test this. `put_events` refuses any
+    `aws.`-prefixed source with `NotAuthorizedForSourceException`, which is why
+    the E2E test drives a real interruption through FIS. Set
+    `AWS_TEST_FIS_ROLE_ARN` to run those two tests; the other nine in
+    `tests/aws/test_spot_warning_e2e.py` need only the standard E2E network.
+- `create_ec2_fleet()`, `describe_ec2_fleet()`, `get_ec2_fleet_instance_ids()`,
+  `delete_ec2_fleet()`, `build_fleet_launch_template_configs()`,
+  `normalize_ec2_fleet_allocation_strategy()`,
+  `create_spot_interruption_notifier()`, and
+  `delete_spot_interruption_notifier()` in `utils/aws.py`, plus
+  `find_fleet_ids_for_workflow()` and `find_legacy_spot_fleet_request_ids()` in
+  `compute/spot_fleet_cleanup.py` (refs #86).
+- `tests/unit/test_spot_warning_notifier.py` — 43 tests. The notifier had none.
+  Four claims a live probe proves once and that then rot silently are pinned
+  here: the queue policy is set *before* the target is added (a warning arriving
+  in that window is dropped as unauthorised and never retried, so the two
+  minutes elapse and the instance is gone — and a live probe cannot catch this,
+  since it creates the rule long before any interruption fires); `put_targets`
+  reports refusal in `FailedEntryCount` rather than by raising, so an unchecked
+  call wires nothing and the absence of warnings is indistinguishable from the
+  absence of interruptions; every message is deleted *before* it is parsed,
+  because the rule matches the whole account and an unparseable body would
+  otherwise be redelivered on every poll, crowding out usable warnings via
+  `MaxNumberOfMessages`; and the notifier is torn down even when no thread was
+  running. Ordering assertions span two clients, so both are attached to a
+  shared parent mock whose `mock_calls` interleaves them (refs #86).
+- `tests/aws/test_spot_warning_e2e.py` — 11 tests against real AWS. Reads back
+  what AWS actually stored rather than what was sent: the target has no
+  `RoleArn`, the rule is `ENABLED` with the exact pattern, the queue policy's
+  `aws:SourceArn` matches the ARN AWS assigned, and the retention period is
+  whatever SQS clamped it to (SQS clamps rather than rejects, so reading it back
+  is the only way to know). Deletion is asserted inside the tests, not only in
+  teardown, so a silent teardown failure cannot hide a leaked rule (refs #86).
 - **Launch templates.** `StandardMode.initialize()` now builds one launch template
   that every launch path shares — on-demand, spot, and spot fleet — carrying the
   AMI, instance type, network interface, key pair, IMDSv2 settings,
@@ -604,6 +713,91 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   template is caught (refs #112, #113).
 
 ### Changed
+- **Spot Fleet is replaced by EC2 Fleet.** AWS: "Spot Fleet … uses a legacy API
+  with no planned investment." Every `request_spot_fleet` call is now
+  `create_fleet` — in `SpotFleetManager`, `ServerlessMode`, and the detached
+  mode's bastion manager script — backed by the launch template #85 introduced.
+  The migration was only possible after that, because `CreateFleet` has no
+  `LaunchSpecifications` member at all: a template is mandatory, not preferred.
+  Requires `ec2:CreateFleet`, `ec2:DescribeFleets`, and `ec2:DeleteFleets` in
+  place of `ec2:RequestSpotFleet`, `ec2:DescribeSpotFleetRequests`, and
+  `ec2:CancelSpotFleetRequests`; the legacy permissions are still used by the
+  orphan sweep, which cancels pre-upgrade requests. The `use_spot_fleet` kwarg,
+  the `SpotFleetManager` class name, and the `fleet_request_id` state key are all
+  unchanged, so existing configuration and state documents keep working.
+  Consequences worth knowing:
+  - **No IAM service role is created any more.** `CreateFleet` has no
+    `IamFleetRole` member, so `_get_iam_fleet_role()` and its
+    `AmazonEC2SpotFleetTaggingRole` attachment are gone from both the manager and
+    the bastion script, along with the 10-second IAM propagation sleep. The
+    orphan sweep still deletes roles left by a pre-upgrade workflow.
+  - **Fleet type is `instant`.** It returns the launched instance IDs
+    synchronously in the `CreateFleet` response, which is what preserves the
+    block → instance-ID mapping the rest of the package is built on; the
+    alternatives are asynchronous and would need polling before a block could
+    report its instances. The 300-second `_wait_for_fleet_instances()` poll is
+    gone with it, and `StandardMode` now fails a block immediately when the fleet
+    launched nothing, instead of waiting out a timeout that conflated "no spot
+    capacity" with "slow to boot".
+  - **An `instant` fleet gets no Capacity Rebalance.** `ReplaceUnhealthyInstances`,
+    `TerminateInstancesWithExpiration`, and `SpotOptions.MaintenanceStrategies`
+    are not merely ignored for this fleet type — EC2 rejects each with
+    `InvalidParameter` ("only compatible with fleet type maintain"), verified
+    against real EC2. The two-minute interruption warning is delivered through
+    the EventBridge route above instead.
+  - **An unfilled fleet is a successful API call.** An `instant` fleet reports
+    pools it could not fill in the response body rather than failing, and makes
+    no further attempts, so both `StandardMode` and `ServerlessMode` now treat an
+    empty fleet as a submission failure and delete it rather than leaving an
+    empty fleet behind.
+  - **`aws:ec2:fleet-id` is the only way to find an instant fleet's instances.**
+    `describe_fleets` with no `FleetIds` returns an empty list for instant fleets
+    (AWS: "you must specify the fleet ID in the request, otherwise the fleet does
+    not appear in the response"), a tag filter on `describe_fleets` does not find
+    them either, and `describe_fleet_instances` refuses them with `Unsupported`.
+    The orphan sweep therefore goes through `describe_instances` filtered on that
+    reserved tag. moto 5.1.21 supports `create_fleet(Type="instant")` but does
+    not apply the tag, so this path is asserted against real AWS only.
+  - **`MaxTotalPrice` replaces `SpotPrice`, and is fleet-wide.** The legacy value
+    was per instance-hour, so `spot_max_price_percentage` is now multiplied by
+    the node count. AWS advises against setting it at all ("can lead to increased
+    interruptions"), so it is sent only when configured.
+  - **The fleet is no longer built by CloudFormation on any path.** The
+    `Overrides` list is variable-length, one entry per instance type, and CFN
+    cannot build one: `Fn::ForEach` (`AWS::LanguageExtensions`) expands to a
+    *map*, confirmed by reading the processed template off a change set; a fixed
+    set of `!Select` slots cannot be left partly filled, because an out-of-range
+    `!Select` fails validation even inside the untaken branch of an `!If`; and
+    padding the slots by repeating a type is rejected by EC2 as duplicate
+    instance pools. `ServerlessMode` calls `CreateFleet` directly, which also
+    stops it deploying an ECS cluster, task definition, two IAM roles, and a log
+    group that an EC2 fleet never touches — and makes the fleet ID available
+    immediately instead of after up to three minutes of polling stack outputs,
+    during which an interruption would have gone unhandled.
+  - The spot bastion is now an `AWS::EC2::Instance` referencing a launch template
+    with `InstanceMarketOptions`, replacing the `AWS::EC2::SpotFleet` resource
+    `bastion.yml` used to carry for that case. `AWS::EC2::Instance` does not
+    accept `InstanceMarketOptions` directly, but a launch template does, and an
+    instance referencing that template launches as spot. One template now serves
+    both bastion variants, and the spot bastion gains IMDSv2 with it.
+  - Failing to build a fleet's launch template now fails the block. The old
+    `LaunchSpecifications` fallback silently launched without IMDSv2 —
+    `SpotFleetLaunchSpecification` has no `MetadataOptions` member — and there is
+    nothing to fall back to under `CreateFleet` anyway.
+- **`warm_pool_ttl` now defaults to 120 seconds, down from 600.** A warm instance
+  is left *Running*, not Stopped, so it bills at the full instance rate for the
+  whole window whether or not another job arrives. AWS is blunt about this shape
+  — keeping warm instances running is "highly discouraged to avoid incurring
+  unnecessary charges" — and the native ASG warm pool it recommends instead holds
+  them Stopped or Hibernated. This package cannot use the native pool yet:
+  dispatch is SSM `SendCommand`, and a Stopped instance runs no SSM agent, so it
+  cannot receive one. Moving to a pull model is tracked as #130 for v0.8.0. Until
+  then the cost is bounded rather than eliminated — an idle pool costs a fifth of
+  what it did, `warm_pool_size` is capped at `MAX_WARM_POOL_SIZE` (20) with a
+  `ValueError` above it, and enabling a pool logs a warning stating the instance
+  count, the window, and the resulting idle instance-seconds. The docstring says
+  so too; the kwarg name alone does not convey that it costs money while doing
+  nothing (refs #86).
 - Plain spot instances are requested with `RunInstances` +
   `InstanceMarketOptions` instead of `RequestSpotInstances`. The old API cannot
   express either IMDSv2 or the shutdown behaviour, as above. `RequestSpotInstances`
@@ -811,6 +1005,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   from the environment; tests are skipped (not failed) when these are unset.
 
 ### Removed
+- `SpotFleetManager._get_iam_fleet_role()` and `_create_spot_fleet_request()`,
+  `_wait_for_fleet_instances()`, and the bastion manager script's
+  `get_spot_fleet_role()` and `wait_for_fleet_instances()`. `CreateFleet` needs no
+  service role and reports its instances synchronously, so all five became
+  unreachable (refs #86).
+- `SpotFleetRole` and `SpotFleetRequest` from `ecs_worker.yml`, `SpotBastionHost`
+  from `bastion.yml`, and the `UseSpotFleet`/`InstanceTypes`/`NodesPerBlock`/
+  `SpotMaxPricePercentage` parameters both templates carried. The
+  `SpotFleetLaunchTemplate` in `ecs_worker.yml` goes with them; the fleet is
+  created by `CreateFleet` directly. `ecs_worker.yml` also loses a `RegionMap` of
+  15 Python-3.9-era AMIs that no `FindInMap` referenced (refs #86).
 - `parsl_ephemeral_aws/utils/localstack.py` (422 LOC). Test-only scaffolding that
   shipped in every wheel; no package code has ever imported it. Its replacement,
   `tests/substrate_support.py`, is not distributed (closes #125).

--- a/parsl_ephemeral_aws/compute/spot_fleet.py
+++ b/parsl_ephemeral_aws/compute/spot_fleet.py
@@ -1,7 +1,19 @@
-"""Spot Fleet compute resource implementation for Parsl Ephemeral AWS Provider.
+"""Fleet-based compute resource implementation for Parsl Ephemeral AWS Provider.
 
-This module provides enhanced spot instance management using AWS EC2 Spot Fleet,
-offering better reliability and flexibility than individual spot requests.
+Provides multi-pool spot instance management, which is more reliable than
+individual spot requests: a fleet draws from several instance types at once, so
+a single exhausted capacity pool does not fail the request.
+
+Built on EC2 Fleet (``CreateFleet``) since #86. It previously used Spot Fleet
+(``RequestSpotFleet``), which AWS describes as "a legacy API with no planned
+investment", recommending EC2 Fleet or EC2 Auto Scaling instead. The class name
+is unchanged to keep the ``use_spot_fleet`` provider kwarg and the persisted
+state documents working across the upgrade.
+
+Fleet type ``instant`` is used throughout: it returns the launched instance IDs
+synchronously, so a block knows its instances without polling. See
+:func:`parsl_ephemeral_aws.utils.aws.create_ec2_fleet` for the parameters this
+fleet type rejects, and why capacity rebalancing is not among the options.
 
 SPDX-License-Identifier: Apache-2.0
 SPDX-FileCopyrightText: 2025 Scott Friedman and Project Contributors
@@ -10,14 +22,14 @@ SPDX-FileCopyrightText: 2025 Scott Friedman and Project Contributors
 import logging
 import uuid
 import time
-import json
-from typing import Dict, List, Optional, Any
+from typing import Dict, List, Optional, Any, Tuple
 
 from botocore.exceptions import ClientError, NoCredentialsError
 
 from ..exceptions import (
     ResourceCreationError,
     ResourceCleanupError,
+    ResourceDeletionError,
     SpotFleetError,
     SpotFleetRequestError,
     SpotFleetThrottlingError,
@@ -40,11 +52,14 @@ from ..constants import (
 )
 from ..config import SecurityConfig
 from ..utils.aws import (
+    build_fleet_launch_template_configs,
     build_launch_template_data,
+    create_ec2_fleet,
     create_launch_template,
+    delete_ec2_fleet,
     delete_launch_template,
-    encode_user_data,
-    normalize_spot_fleet_allocation_strategy,
+    describe_ec2_fleet,
+    get_ec2_fleet_instance_ids,
     resolve_manager_session,
 )
 from ..security import (
@@ -66,17 +81,19 @@ logger = logging.getLogger(__name__)
 
 
 class SpotFleetManager:
-    """Manager for AWS EC2 Spot Fleet compute resources.
+    """Manager for AWS EC2 Fleet compute resources.
 
-    This manager provides enhanced spot instance management using EC2 Spot Fleet,
-    which offers better reliability and cost optimization compared to individual
-    spot requests. Spot Fleet can automatically request instances from multiple
-    instance types, availability zones, and purchase options to meet capacity
-    requirements at the lowest possible cost.
+    Requests instances from several instance types at once, so an exhausted
+    capacity pool degrades the fleet rather than failing it, and the allocation
+    strategy can pick the pools least likely to be interrupted.
+
+    Named for the legacy Spot Fleet API it was originally built on. It now calls
+    ``CreateFleet`` (#86); the name is retained because it is reachable through
+    the public ``use_spot_fleet`` provider kwarg and appears in persisted state.
     """
 
     def __init__(self, provider: Any) -> None:
-        """Initialize the Spot Fleet manager.
+        """Initialize the fleet manager.
 
         Parameters
         ----------
@@ -173,7 +190,14 @@ class SpotFleetManager:
         self.vpc_id = None
         self.subnet_id = None
         self.security_group_id = None
+        # Retained for state compatibility only. CreateFleet needs no service
+        # role -- there is no IamFleetRole member on the request at all -- so
+        # nothing sets this any more (#86). A resumed pre-#86 state document may
+        # still carry a role ARN, and cleanup_all_resources() will delete the
+        # role it names.
         self.iam_fleet_role_arn = None
+        # fleet ID -> fleet record. Keyed by EC2 Fleet ID since #86; the
+        # attribute name is unchanged because it is persisted in state.
         self.fleet_requests: Dict[str, Any] = {}
         self.instances: Dict[str, Any] = {}
         self.blocks: Dict[str, Any] = {}
@@ -286,7 +310,7 @@ class SpotFleetManager:
         ]
         if missing:
             raise ResourceCreationError(
-                "Spot Fleet requires pre-provisioned network resources; "
+                "EC2 Fleet requires pre-provisioned network resources; "
                 f"missing: {', '.join(missing)}"
             )
 
@@ -300,107 +324,6 @@ class SpotFleetManager:
             "subnet_id": self.subnet_id,
             "security_group_id": self.security_group_id,
         }
-
-    def _get_iam_fleet_role(self) -> str:
-        """Get or create an IAM role for the Spot Fleet.
-
-        Returns
-        -------
-        str
-            ARN of the IAM role
-        """
-        # Check if we already have a fleet role
-        if self.iam_fleet_role_arn:
-            return self.iam_fleet_role_arn
-
-        iam_client = self.aws_session.client("iam")
-        role_name = f"{TAG_PREFIX}-spot-fleet-role-{self.provider.workflow_id[:8]}"
-
-        try:
-            # Check if the role already exists
-            try:
-                response = iam_client.get_role(RoleName=role_name)
-                self.iam_fleet_role_arn = response["Role"]["Arn"]
-                logger.info(f"Using existing IAM role for Spot Fleet: {role_name}")
-                return self.iam_fleet_role_arn
-            except ClientError as e:
-                if e.response["Error"]["Code"] != "NoSuchEntity":
-                    raise
-
-                # Role doesn't exist, create it
-                trust_policy = {
-                    "Version": "2012-10-17",
-                    "Statement": [
-                        {
-                            "Effect": "Allow",
-                            "Principal": {"Service": "spotfleet.amazonaws.com"},
-                            "Action": "sts:AssumeRole",
-                        }
-                    ],
-                }
-
-                response = iam_client.create_role(
-                    RoleName=role_name,
-                    AssumeRolePolicyDocument=json.dumps(trust_policy),
-                    Description=f"Role for Parsl Spot Fleet ({self.provider.workflow_id})",
-                )
-
-                # Attach the required policy
-                iam_client.attach_role_policy(
-                    RoleName=role_name,
-                    PolicyArn="arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole",
-                )
-
-                # Get the role ARN
-                self.iam_fleet_role_arn = response["Role"]["Arn"]
-                logger.info(f"Created IAM role for Spot Fleet: {role_name}")
-
-                # Wait for role to be ready (IAM changes can take time to propagate)
-                time.sleep(10)
-
-                return self.iam_fleet_role_arn
-
-        except ClientError as e:
-            error_code = e.response["Error"]["Code"]
-            error_msg = e.response["Error"]["Message"]
-            logger.error(
-                f"Error getting or creating IAM role for Spot Fleet: {error_code} - {error_msg}"
-            )
-
-            if error_code == "AccessDenied":
-                raise SpotFleetError(
-                    f"Access denied when creating IAM role for Spot Fleet. Ensure your AWS credentials "
-                    f"have IAM permissions: {error_msg}"
-                )
-            elif error_code == "EntityAlreadyExists":
-                # Role already exists but we failed to get it
-                logger.warning(
-                    f"IAM role {role_name} already exists but could not be retrieved"
-                )
-                try:
-                    # Try to get the role again
-                    response = iam_client.get_role(RoleName=role_name)
-                    self.iam_fleet_role_arn = response["Role"]["Arn"]
-                    logger.info(
-                        f"Retrieved existing IAM role for Spot Fleet: {role_name}"
-                    )
-                    return self.iam_fleet_role_arn
-                except Exception as retry_e:
-                    logger.error(
-                        f"Failed to retrieve existing IAM role {role_name}: {retry_e}"
-                    )
-                    raise SpotFleetError(
-                        f"Failed to work with existing IAM role for Spot Fleet: {retry_e}"
-                    )
-            else:
-                raise SpotFleetError(
-                    f"Failed to create IAM role for Spot Fleet: {error_code} - {error_msg}"
-                )
-        except Exception as e:
-            logger.error(f"Error getting or creating IAM role for Spot Fleet: {e}")
-            raise SpotFleetError(
-                f"Failed to get or create IAM role for Spot Fleet: {e}"
-            )
 
     def _generate_user_data(self) -> str:
         """Generate user data script for instance initialization.
@@ -424,55 +347,71 @@ class SpotFleetManager:
 
         return user_data
 
-    def _create_spot_fleet_with_retry(
-        self, fleet_config: Dict[str, Any], context: ErrorContext
-    ) -> Dict[str, Any]:
-        """Create spot fleet request with error handling and retry logic.
+    def _translate_fleet_error(
+        self, exc: ClientError, context: ErrorContext
+    ) -> Exception:
+        """Map a ``CreateFleet`` ``ClientError`` onto this package's exceptions.
+
+        Returned rather than raised so the caller keeps its ``raise ... from``
+        chain, which is what preserves the original botocore traceback.
 
         Parameters
         ----------
-        fleet_config : Dict[str, Any]
-            Spot fleet configuration
+        exc : ClientError
+            The error EC2 returned.
         context : ErrorContext
-            Error context for tracking
+            Error context, recorded for anything unrecognised.
 
         Returns
         -------
-        Dict[str, Any]
-            Spot fleet request response
+        Exception
+            The exception the caller should raise.
         """
-        try:
-            response = self.ec2_client.request_spot_fleet(**fleet_config)
-            return response
-        except ClientError as e:
-            error_code = e.response["Error"]["Code"]
+        error_code = exc.response["Error"]["Code"]
 
-            # Handle specific spot fleet errors
-            if error_code in [
-                "SpotFleetLaunchTemplateConfig.NotFound",
-                "InvalidLaunchTemplateName.NotFound",
-            ]:
-                raise SpotFleetRequestError(f"Launch template configuration error: {e}")
-            elif error_code in [
-                "InsufficientInstanceCapacity",
-                "InsufficientReservedInstanceCapacity",
-            ]:
-                raise SpotFleetError(f"Insufficient instance capacity: {e}")
-            elif error_code in ["SpotFleetRequestConfig.InvalidLaunchSpecification"]:
-                raise SpotFleetRequestError(f"Invalid launch specification: {e}")
-            elif error_code in ["Throttling", "RequestLimitExceeded"]:
-                raise SpotFleetThrottlingError(f"API throttling error: {e}")
-            else:
-                # Record error for analysis
-                error_record = self.error_handler.handle_error(e, context)
-                raise SpotFleetError(f"Failed to create spot fleet request: {e}")
-        except Exception as e:
-            error_record = self.error_handler.handle_error(e, context)
-            raise SpotFleetError(f"Failed to create spot fleet request: {e}")
+        if error_code in (
+            "InvalidLaunchTemplateId.NotFound",
+            "InvalidLaunchTemplateName.NotFoundException",
+            "InvalidLaunchTemplateId.VersionNotFound",
+        ):
+            return SpotFleetRequestError(f"Launch template configuration error: {exc}")
+        if error_code in (
+            "InsufficientInstanceCapacity",
+            "InsufficientReservedInstanceCapacity",
+        ):
+            return SpotFleetError(f"Insufficient instance capacity: {exc}")
+        if error_code in (
+            "InvalidParameter",
+            "InvalidParameterValue",
+            # CreateFleet's own configuration rejection, e.g. duplicate instance
+            # pools in Overrides. The legacy API called this
+            # InvalidSpotFleetRequestConfig, a code CreateFleet never returns.
+            "InvalidFleetConfig",
+        ):
+            # Where a rejected allocation strategy, or a parameter the instant
+            # fleet type does not accept, lands.
+            return SpotFleetRequestError(f"Invalid fleet configuration: {exc}")
+        if error_code in ("MaxSpotInstanceCountExceeded", "VcpuLimitExceeded"):
+            # An account quota, not a transient shortage: retrying cannot help,
+            # and the distinction from InsufficientInstanceCapacity is what tells
+            # a caller to request a limit increase rather than back off. These are
+            # the codes CreateFleet actually returns; the legacy
+            # InstanceLimitExceeded belonged to RunInstances.
+            return SpotFleetRequestError(f"Spot quota exceeded: {exc}")
+        if error_code in ("Throttling", "RequestLimitExceeded"):
+            retry_after = exc.response.get("ResponseMetadata", {}).get("RetryAfter", 60)
+            return SpotFleetThrottlingError(
+                message=f"AWS throttled the fleet request: {exc}",
+                operation="create_fleet",
+                retry_after=retry_after,
+            )
+
+        self.error_handler.handle_error(exc, context)
+        return SpotFleetError(f"Failed to create EC2 Fleet: {exc}")
 
     @retry_with_backoff()
     def create_blocks(self, count: int) -> Dict[str, Dict[str, Any]]:
-        """Create compute blocks using Spot Fleet.
+        """Create compute blocks, one EC2 Fleet each.
 
         Parameters
         ----------
@@ -490,30 +429,28 @@ class SpotFleetManager:
             # Ensure network resources exist
             network = self._setup_network_resources()
 
-            # Get IAM fleet role
-            fleet_role_arn = self._get_iam_fleet_role()
-
-            # Create blocks
+            # Create blocks. No IAM service role is fetched first: CreateFleet
+            # has no IamFleetRole member, so the role the legacy API required is
+            # simply not part of this path any more (#86).
             for _ in range(count):
                 block_id = str(uuid.uuid4())
 
-                # Create a Spot Fleet request for the block
-                fleet_request_id = self._create_spot_fleet_request(
-                    block_id, network, self.provider.nodes_per_block, fleet_role_arn
+                # Create an EC2 Fleet for the block. Type "instant" returns its
+                # instance IDs synchronously, so there is nothing to wait for.
+                fleet_id, instance_ids = self._create_fleet(
+                    block_id, network, self.provider.nodes_per_block
                 )
 
                 # Record block information
                 self.blocks[block_id] = {
                     "id": block_id,
-                    "fleet_request_id": fleet_request_id,
-                    "status": STATUS_PENDING,
+                    "fleet_request_id": fleet_id,
+                    "status": STATUS_RUNNING if instance_ids else STATUS_PENDING,
+                    "instance_ids": instance_ids,
                     "created_at": time.time(),
                 }
 
                 blocks[block_id] = self.blocks[block_id]
-
-                # Wait for instances to be created
-                self._wait_for_fleet_instances(fleet_request_id, block_id)
 
             return blocks
 
@@ -535,19 +472,18 @@ class SpotFleetManager:
         network: Dict[str, str],
         instance_types: List[str],
         instance_tags: List[Dict[str, str]],
-    ) -> Optional[Dict[str, Any]]:
-        """Build a ``LaunchTemplateConfig`` for this block, or None on failure.
+    ) -> List[Dict[str, Any]]:
+        """Build the ``LaunchTemplateConfigs`` for this block's fleet.
 
         One template per block, because the user data is per-block and the
-        ``Overrides`` shape cannot carry it -- it accepts only
-        ``InstanceType``/``SubnetId``/price/priority. The instance types become
-        overrides so a single template still covers every pool the fleet may
-        draw from.
+        ``Overrides`` shape cannot carry it. The instance types become overrides
+        so a single template still covers every pool the fleet may draw from.
 
-        Returns None if the template cannot be created, in which case the caller
-        falls back to ``LaunchSpecifications``. That fallback launches without
-        IMDSv2, which is unavoidable: ``SpotFleetLaunchSpecification`` has no
-        ``MetadataOptions`` member.
+        A template is mandatory rather than preferred: ``CreateFleet`` has no
+        ``LaunchSpecifications`` member at all, so unlike the legacy
+        ``RequestSpotFleet`` path there is nothing to fall back to (#86). That
+        removes the old fallback's silent IMDSv2 downgrade -- failing to build
+        the template now fails the block, which is the correct outcome.
 
         Parameters
         ----------
@@ -562,67 +498,54 @@ class SpotFleetManager:
 
         Returns
         -------
-        Optional[Dict[str, Any]]
-            A ``LaunchTemplateConfig``, or None to use the legacy form.
+        List[Dict[str, Any]]
+            A single-element ``LaunchTemplateConfigs`` list.
+
+        Raises
+        ------
+        ResourceCreationError
+            If the launch template cannot be created.
         """
         name = f"{LAUNCH_TEMPLATE_NAME_PREFIX}-fleet-{block_id}"
-        try:
-            template_data = build_launch_template_data(
-                image_id=self.provider.image_id,
-                instance_type=instance_types[0],
-                subnet_id=network["subnet_id"],
-                security_group_id=network["security_group_id"],
-                associate_public_ip=getattr(self.provider, "use_public_ips", True),
-                key_name=getattr(self.provider, "key_name", None),
-                iam_instance_profile_arn=getattr(
-                    self.provider, "iam_instance_profile_arn", None
-                ),
-                # Fleet instances are reclaimed by cancelling the fleet request
-                # with TerminateInstances=True, so an instance that shuts itself
-                # down should terminate rather than linger as a billed volume.
-                shutdown_behavior="terminate",
-                user_data=self._generate_user_data(),
-            )
-            # Instances launched from the template carry the block tags; the
-            # template resource itself carries them too, so a leaked template is
-            # traceable to the workflow that made it.
-            template_data["TagSpecifications"] = [
-                {"ResourceType": "instance", "Tags": list(instance_tags)}
-            ]
+        template_data = build_launch_template_data(
+            image_id=self.provider.image_id,
+            instance_type=instance_types[0],
+            subnet_id=network["subnet_id"],
+            security_group_id=network["security_group_id"],
+            associate_public_ip=getattr(self.provider, "use_public_ips", True),
+            key_name=getattr(self.provider, "key_name", None),
+            iam_instance_profile_arn=getattr(
+                self.provider, "iam_instance_profile_arn", None
+            ),
+            # Fleet instances are reclaimed by deleting the fleet, which always
+            # terminates them, so an instance that shuts itself down should
+            # terminate too rather than linger as a billed volume.
+            shutdown_behavior="terminate",
+            user_data=self._generate_user_data(),
+        )
+        # Instances launched from the template carry the block tags; the
+        # template resource itself carries them too, so a leaked template is
+        # traceable to the workflow that made it.
+        template_data["TagSpecifications"] = [
+            {"ResourceType": "instance", "Tags": list(instance_tags)}
+        ]
 
-            template_id, version = create_launch_template(
-                self.ec2_client, name, template_data, list(instance_tags)
-            )
-            self.launch_templates[block_id] = template_id
-            logger.debug(
-                f"Created launch template {template_id} for fleet block {block_id}"
-            )
-            return {
-                "LaunchTemplateSpecification": {
-                    "LaunchTemplateId": template_id,
-                    "Version": version,
-                },
-                "Overrides": [
-                    {
-                        "InstanceType": instance_type,
-                        "SubnetId": network["subnet_id"],
-                    }
-                    for instance_type in instance_types
-                ],
-            }
-        except Exception as e:
-            logger.warning(
-                f"Could not create launch template for block {block_id}: {e}. "
-                "Falling back to LaunchSpecifications; IMDSv2 will not be "
-                "enforced on these instances."
-            )
-            return None
+        template_id, version = create_launch_template(
+            self.ec2_client, name, template_data, list(instance_tags)
+        )
+        self.launch_templates[block_id] = template_id
+        logger.debug(
+            f"Created launch template {template_id} for fleet block {block_id}"
+        )
+        return build_fleet_launch_template_configs(
+            template_id, version, instance_types, network["subnet_id"]
+        )
 
     def _delete_launch_template_for_block(self, block_id: str) -> None:
         """Delete the launch template created for *block_id*, if any.
 
         Deleting a template does not affect instances already launched from it,
-        so this is safe as soon as the fleet request is cancelled.
+        so this is safe as soon as the fleet is deleted.
         """
         template_id = self.launch_templates.pop(block_id, None)
         if not template_id:
@@ -635,34 +558,85 @@ class SpotFleetManager:
                 f"{block_id}: {e}"
             )
 
-    def _create_spot_fleet_request(
+    def _resolve_max_total_price(self, target_capacity: int) -> Optional[str]:
+        """Translate ``spot_max_price_percentage`` into a fleet ``MaxTotalPrice``.
+
+        Returns None when the provider sets no cap, which is the recommended
+        configuration -- AWS: "We do not recommend using this parameter because
+        it can lead to increased interruptions." A fleet with no maximum simply
+        pays the prevailing spot price, which is already far below on-demand.
+
+        The percentage is of on-demand, matching what the setting has always
+        documented. There is no cheap API for an on-demand price, so the legacy
+        3x-current-spot proxy is kept rather than adding a Pricing API call to
+        the launch path. Unlike the legacy ``SpotPrice``, which was per instance
+        hour, ``MaxTotalPrice`` covers the whole fleet, so it is multiplied by
+        the capacity being requested.
+
+        Parameters
+        ----------
+        target_capacity : int
+            Instances this fleet will request.
+
+        Returns
+        -------
+        Optional[str]
+            The fleet-wide hourly maximum, or None for no cap.
+        """
+        percentage = getattr(self.provider, "spot_max_price_percentage", None)
+        if not percentage:
+            return None
+
+        try:
+            history = self.ec2_client.describe_spot_price_history(
+                InstanceTypes=[self.provider.instance_type],
+                ProductDescriptions=["Linux/UNIX"],
+                MaxResults=1,
+            ).get("SpotPriceHistory", [])
+            current_spot = float(history[0]["SpotPrice"]) if history else 1.0
+            # Use 3x current spot as a conservative on-demand proxy
+            on_demand_price = current_spot * 3
+        except Exception:
+            on_demand_price = 1.0  # safe fallback
+
+        per_instance = on_demand_price * (percentage / 100.0)
+        return str(per_instance * target_capacity)
+
+    def _create_fleet(
         self,
         block_id: str,
         network: Dict[str, str],
         target_capacity: int,
-        fleet_role_arn: str,
-    ) -> str:
-        """Create a Spot Fleet request.
+    ) -> Tuple[str, List[str]]:
+        """Create an EC2 Fleet for *block_id* and return its ID and instances.
+
+        Replaces the legacy ``RequestSpotFleet`` builder (#86). The differences
+        that matter to callers: there is no IAM service role to supply, the
+        launch template is mandatory rather than preferred, and the instance IDs
+        come back from the create call itself instead of from a polling loop.
 
         Parameters
         ----------
         block_id : str
-            ID of the block
+            ID of the block this fleet backs.
         network : Dict[str, str]
-            Network configuration
+            Resolved ``subnet_id`` and ``security_group_id``.
         target_capacity : int
-            Number of instances to request
+            Number of instances to request.
 
         Returns
         -------
-        str
-            Spot Fleet request ID
-        """
-        # Generate a unique client token
-        client_token = f"{self.provider.workflow_id}-{block_id}"
+        Tuple[str, List[str]]
+            The fleet ID, and the instances it launched. The list can be short
+            or empty if EC2 could not fill the request.
 
-        # Prepare launch specifications for multiple instance types
-        launch_specifications = []
+        Raises
+        ------
+        SpotFleetError
+            Or a subclass, for any failure to create the fleet.
+        """
+        # Idempotency token, so a retried create does not double-launch.
+        client_token = f"{self.provider.workflow_id}-{block_id}"
 
         # Use instance types from provider, falling back to the single primary type.
         # Do not attempt to synthesize alternatives from the instance type string
@@ -686,167 +660,51 @@ class SpotFleetManager:
         for key, value in self.provider.tags.items():
             instance_tags.append({"Key": key, "Value": value})
 
-        # Prefer a launch template (#85). This is the only way to get IMDSv2 onto
-        # Spot Fleet instances at all: SpotFleetLaunchSpecification has no
-        # MetadataOptions member, and the LaunchTemplateConfig Overrides shape
-        # carries only InstanceType/SubnetId/price/priority -- no UserData or
-        # TagSpecifications -- so the per-block user data has to live in a
-        # per-block template rather than in the overrides.
-        launch_template_config = self._build_launch_template_config(
+        # The launch template is the only launch form CreateFleet accepts, and
+        # the only way the per-block user data and IMDSv2 reach the instances:
+        # the Overrides shape carries just InstanceType/SubnetId/price/priority.
+        launch_template_configs = self._build_launch_template_config(
             block_id, network, instance_types, instance_tags
         )
 
-        # Generate specs for each instance type
-        for instance_type in instance_types:
-            try:
-                launch_spec = {
-                    "ImageId": self.provider.image_id,
-                    "InstanceType": instance_type,
-                    "SubnetId": network["subnet_id"],
-                    "SecurityGroups": [{"GroupId": network["security_group_id"]}],
-                    "UserData": encode_user_data(self._generate_user_data()),
-                    "TagSpecifications": [
-                        {
-                            "ResourceType": "instance",
-                            "Tags": list(instance_tags),
-                        }
-                    ],
-                }
-
-                # Add key name if provided
-                if self.provider.key_name:
-                    launch_spec["KeyName"] = self.provider.key_name
-
-                launch_specifications.append(launch_spec)
-            except Exception as e:
-                logger.warning(
-                    f"Skipping instance type {instance_type} due to error: {e}"
-                )
-
-        # Prepare Spot Fleet request parameters
-        request_params = {
-            "SpotFleetRequestConfig": {
-                "ClientToken": client_token,
-                "TargetCapacity": target_capacity,
-                "OnDemandTargetCapacity": 0,  # Use only spot instances
-                "IamFleetRole": fleet_role_arn,
-                "TerminateInstancesWithExpiration": True,
-                "Type": "maintain",  # Maintain target capacity
-                # Honour the provider's spot_allocation_strategy instead of
-                # hardcoding lowestPrice, which ignored the documented setting
-                # and chose the most interruption-prone pools (#84). Normalised
-                # because RequestSpotFleet takes only the camelCase spelling.
-                "AllocationStrategy": normalize_spot_fleet_allocation_strategy(
-                    getattr(
-                        self.provider,
-                        "spot_allocation_strategy",
-                        DEFAULT_SPOT_ALLOCATION_STRATEGY,
-                    )
-                ),
-                "ReplaceUnhealthyInstances": True,
-                "TagSpecifications": [
-                    {
-                        "ResourceType": "spot-fleet-request",
-                        "Tags": [
-                            {
-                                "Key": "Name",
-                                "Value": f"{TAG_PREFIX}-fleet-{block_id[:8]}",
-                            },
-                            {"Key": TAG_MANAGED, "Value": "true"},
-                            {
-                                "Key": TAG_WORKFLOW_ID,
-                                "Value": self.provider.workflow_id,
-                            },
-                            {"Key": TAG_BLOCK_ID, "Value": block_id},
-                        ],
-                    }
-                ],
-            }
-        }
-
-        # Exactly one of the two launch forms. EC2 tolerates both keys being
-        # present, but then the template silently loses to the specifications --
-        # and with it IMDSv2 -- so only the preferred one is sent (#85).
-        if launch_template_config:
-            request_params["SpotFleetRequestConfig"]["LaunchTemplateConfigs"] = [
-                launch_template_config
-            ]
-        else:
-            request_params["SpotFleetRequestConfig"]["LaunchSpecifications"] = (
-                launch_specifications
-            )
-
-        # Add provider tags to fleet request
+        # The fleet resource carries its own Name so it is distinguishable from
+        # the instances in the console, but shares the marker and workflow tags
+        # so one sweep finds both.
+        fleet_tags = [
+            {"Key": "Name", "Value": f"{TAG_PREFIX}-fleet-{block_id[:8]}"},
+            {"Key": TAG_MANAGED, "Value": "true"},
+            {"Key": TAG_WORKFLOW_ID, "Value": self.provider.workflow_id},
+            {"Key": TAG_BLOCK_ID, "Value": block_id},
+        ]
         for key, value in self.provider.tags.items():
-            request_params["SpotFleetRequestConfig"]["TagSpecifications"][0][
-                "Tags"
-            ].append({"Key": key, "Value": value})
+            fleet_tags.append({"Key": key, "Value": value})
 
-        # Configure fleet to terminate instances when the request is cancelled
-        request_params["SpotFleetRequestConfig"]["TerminateInstancesWithExpiration"] = (
-            True
+        context = ErrorContext(
+            operation="create_ec2_fleet",
+            resource_type="ec2_fleet",
+            resource_id=block_id,
+            metadata={"instance_types": instance_types},
         )
 
-        # Set a max price if specified
-        if self.provider.spot_max_price_percentage:
-            try:
-                history = self.ec2_client.describe_spot_price_history(
-                    InstanceTypes=[self.provider.instance_type],
-                    ProductDescriptions=["Linux/UNIX"],
-                    MaxResults=1,
-                ).get("SpotPriceHistory", [])
-                current_spot = float(history[0]["SpotPrice"]) if history else 1.0
-                # Use 3× current spot as a conservative on-demand proxy
-                on_demand_price = current_spot * 3
-            except Exception:
-                on_demand_price = 1.0  # safe fallback
-            max_price = str(
-                on_demand_price * (self.provider.spot_max_price_percentage / 100.0)
-            )
-            request_params["SpotFleetRequestConfig"]["SpotPrice"] = max_price
-
         try:
-            # Create the Spot Fleet request
-            response = self.ec2_client.request_spot_fleet(**request_params)
-
-            fleet_request_id = response["SpotFleetRequestId"]
-            logger.info(
-                f"Created Spot Fleet request: {fleet_request_id} for block {block_id}"
+            fleet_id, instance_ids = create_ec2_fleet(
+                self.ec2_client,
+                launch_template_configs=launch_template_configs,
+                target_capacity=target_capacity,
+                allocation_strategy=getattr(
+                    self.provider,
+                    "spot_allocation_strategy",
+                    DEFAULT_SPOT_ALLOCATION_STRATEGY,
+                ),
+                client_token=client_token,
+                tags=fleet_tags,
+                max_total_price=self._resolve_max_total_price(target_capacity),
             )
-
-            # Record the request
-            self.fleet_requests[fleet_request_id] = {
-                "id": fleet_request_id,
-                "block_id": block_id,
-                "target_capacity": target_capacity,
-                "status": "submitted",
-                "instance_ids": [],
-                "created_at": time.time(),
-            }
-
-            # Log successful spot fleet creation
-            if self.audit_logger:
-                self.audit_logger.log_resource_operation(
-                    operation="create",
-                    resource_type="spot_fleet",
-                    resource_id=fleet_request_id,
-                    success=True,
-                    workflow_id=self.provider.workflow_id,
-                    block_id=block_id,
-                    target_capacity=target_capacity,
-                    instance_types=instance_types,
-                )
-
-            return fleet_request_id
-
         except ClientError as e:
             error_code = e.response["Error"]["Code"]
             error_msg = e.response["Error"]["Message"]
-            logger.error(
-                f"Error creating Spot Fleet request: {error_code} - {error_msg}"
-            )
+            logger.error(f"Error creating EC2 Fleet: {error_code} - {error_msg}")
 
-            # Log failed spot fleet creation
             if self.audit_logger:
                 self.audit_logger.log_resource_operation(
                     operation="create",
@@ -858,170 +716,51 @@ class SpotFleetManager:
                     error=f"{error_code}: {error_msg}",
                 )
 
-            # Handle specific error cases
-            if error_code == "RequestLimitExceeded":
-                # AWS is throttling our requests
-                retry_after = e.response.get("ResponseMetadata", {}).get(
-                    "RetryAfter", 60
-                )
-                raise SpotFleetThrottlingError(
-                    message=f"AWS throttled Spot Fleet request: {error_msg}",
-                    operation="request_spot_fleet",
-                    retry_after=retry_after,
-                )
-            elif error_code == "InvalidIamInstanceProfileArn":
-                # IAM role issue
-                raise SpotFleetRequestError(
-                    f"Invalid IAM role configuration: {error_msg}"
-                )
-            elif error_code == "InstanceLimitExceeded":
-                # Instance limit reached
-                raise SpotFleetRequestError(f"AWS instance limit exceeded: {error_msg}")
-            elif "capacity-not-available" in error_msg.lower():
-                # Not enough capacity for the request
-                raise SpotFleetRequestError(
-                    f"Insufficient capacity for Spot Fleet request: {error_msg}"
-                )
-            else:
-                # General Spot Fleet error
-                raise SpotFleetError(
-                    f"Failed to create Spot Fleet request: {error_code} - {error_msg}"
-                )
+            # The template is useless without the fleet it was built for, and
+            # nothing else will reclaim it once this block is abandoned.
+            self._delete_launch_template_for_block(block_id)
+            raise self._translate_fleet_error(e, context) from e
 
-    def _wait_for_fleet_instances(
-        self, fleet_request_id: str, block_id: str, max_wait: int = 300
-    ) -> List[str]:
-        """Wait for Spot Fleet instances to be created.
+        self.fleet_requests[fleet_id] = {
+            "id": fleet_id,
+            "block_id": block_id,
+            "target_capacity": target_capacity,
+            "status": STATUS_RUNNING if instance_ids else STATUS_PENDING,
+            "instance_ids": instance_ids,
+            "created_at": time.time(),
+        }
 
-        Parameters
-        ----------
-        fleet_request_id : str
-            Spot Fleet request ID
-        block_id : str
-            ID of the block
-        max_wait : int, optional
-            Maximum wait time in seconds, by default 300
+        for instance_id in instance_ids:
+            self.instances[instance_id] = {
+                "id": instance_id,
+                "block_id": block_id,
+                "fleet_request_id": fleet_id,
+                "type": RESOURCE_TYPE_SPOT_FLEET,
+                "status": "running",
+            }
 
-        Returns
-        -------
-        List[str]
-            List of instance IDs
-        """
-        start_time = time.time()
-        instance_ids = []
-
-        logger.info(f"Waiting for Spot Fleet instances for fleet {fleet_request_id}")
-
-        while time.time() - start_time < max_wait:
-            try:
-                # Check fleet status
-                response = self.ec2_client.describe_spot_fleet_requests(
-                    SpotFleetRequestIds=[fleet_request_id]
-                )
-
-                if not response["SpotFleetRequestConfigs"]:
-                    logger.warning(
-                        f"No Spot Fleet request found with ID {fleet_request_id}"
-                    )
-                    break
-
-                config = response["SpotFleetRequestConfigs"][0]
-                status = config["SpotFleetRequestState"]
-                activity_status = config.get("ActivityStatus")
-
-                # Update fleet request info
-                self.fleet_requests[fleet_request_id]["status"] = status
-
-                if status == "active":
-                    # Get instances in the fleet
-                    instances_response = self.ec2_client.describe_spot_fleet_instances(
-                        SpotFleetRequestId=fleet_request_id
-                    )
-
-                    # Extract instance IDs
-                    instance_ids = [
-                        instance["InstanceId"]
-                        for instance in instances_response.get("ActiveInstances", [])
-                    ]
-
-                    # Update fleet request with instance IDs
-                    self.fleet_requests[fleet_request_id]["instance_ids"] = instance_ids
-
-                    # Update block status
-                    self.blocks[block_id]["status"] = STATUS_RUNNING
-                    self.blocks[block_id]["instance_ids"] = instance_ids
-
-                    # Track instances
-                    for instance_id in instance_ids:
-                        if instance_id not in self.instances:
-                            self.instances[instance_id] = {
-                                "id": instance_id,
-                                "block_id": block_id,
-                                "fleet_request_id": fleet_request_id,
-                                "type": RESOURCE_TYPE_SPOT_FLEET,
-                                "status": "running",
-                            }
-
-                    logger.info(
-                        f"Spot Fleet {fleet_request_id} is active with {len(instance_ids)} instances"
-                    )
-                    break
-
-                elif status in [
-                    "cancelled",
-                    "cancelled_running",
-                    "cancelled_terminating",
-                    "error",
-                ]:
-                    logger.error(
-                        f"Spot Fleet request {fleet_request_id} failed with status {status}"
-                    )
-
-                    # Update block status
-                    self.blocks[block_id]["status"] = STATUS_FAILED
-
-                    raise ResourceCreationError(
-                        f"Spot Fleet request failed with status {status}"
-                    )
-
-                # Wait before checking again
-                time.sleep(10)
-
-            except ClientError as e:
-                error_code = e.response["Error"]["Code"]
-                error_msg = e.response["Error"]["Message"]
-                logger.error(
-                    f"Error checking Spot Fleet status: {error_code} - {error_msg}"
-                )
-
-                if error_code == "RequestLimitExceeded":
-                    # AWS is throttling our requests, back off and retry
-                    retry_after = e.response.get("ResponseMetadata", {}).get(
-                        "RetryAfter", 10
-                    )
-                    logger.warning(
-                        f"AWS throttled request, backing off for {retry_after} seconds"
-                    )
-                    time.sleep(retry_after)
-                else:
-                    # Other errors, wait a shorter time
-                    time.sleep(10)
-
-        # If we've waited too long without success
-        if time.time() - start_time >= max_wait and not instance_ids:
-            logger.error(
-                f"Timeout waiting for Spot Fleet instances for fleet {fleet_request_id}"
+        if self.audit_logger:
+            self.audit_logger.log_resource_operation(
+                operation="create",
+                resource_type="spot_fleet",
+                resource_id=fleet_id,
+                success=True,
+                workflow_id=self.provider.workflow_id,
+                block_id=block_id,
+                target_capacity=target_capacity,
+                instance_types=instance_types,
+                instance_ids=instance_ids,
             )
 
-            # Update block status
-            self.blocks[block_id]["status"] = STATUS_FAILED
-
-            raise ResourceCreationError("Timeout waiting for Spot Fleet instances")
-
-        return instance_ids
+        return fleet_id, instance_ids
 
     def get_block_status(self, block_id: str) -> str:
         """Get the status of a block.
+
+        An instant fleet does not maintain capacity, so its ``FleetState`` stays
+        ``active`` for the life of the fleet regardless of what happened to the
+        instances. The block's status therefore comes from the instances, with
+        the fleet state consulted only for the terminal cases.
 
         Parameters
         ----------
@@ -1036,102 +775,91 @@ class SpotFleetManager:
         if block_id not in self.blocks:
             return STATUS_UNKNOWN
 
-        # Get fleet request ID for this block
-        fleet_request_id = self.blocks[block_id].get("fleet_request_id")
-        if not fleet_request_id:
+        fleet_id = self.blocks[block_id].get("fleet_request_id")
+        if not fleet_id:
             return self.blocks[block_id].get("status", STATUS_UNKNOWN)
 
         try:
-            # Check fleet status
-            response = self.ec2_client.describe_spot_fleet_requests(
-                SpotFleetRequestIds=[fleet_request_id]
-            )
+            fleet = describe_ec2_fleet(self.ec2_client, fleet_id)
 
-            if not response["SpotFleetRequestConfigs"]:
-                # Fleet request not found
+            if fleet is None:
+                # EC2 forgets a deleted fleet after roughly an hour, so an
+                # unknown ID means the block is long gone rather than broken.
                 self.blocks[block_id]["status"] = STATUS_COMPLETED
                 return STATUS_COMPLETED
 
-            config = response["SpotFleetRequestConfigs"][0]
-            status = config["SpotFleetRequestState"]
+            fleet_state = fleet.get("FleetState")
 
-            # Map EC2 status to our status
-            if status == "active":
-                # Check instance status
-                instance_ids = self.blocks[block_id].get("instance_ids", [])
-
-                if not instance_ids:
-                    # No instances yet, check if any are associated with the fleet
-                    try:
-                        instances_response = (
-                            self.ec2_client.describe_spot_fleet_instances(
-                                SpotFleetRequestId=fleet_request_id
-                            )
-                        )
-
-                        instance_ids = [
-                            instance["InstanceId"]
-                            for instance in instances_response.get(
-                                "ActiveInstances", []
-                            )
-                        ]
-
-                        # Update block with instance IDs
-                        self.blocks[block_id]["instance_ids"] = instance_ids
-                    except Exception as e:
-                        logger.error(
-                            f"Error getting instances for fleet {fleet_request_id}: {e}"
-                        )
-
-                if instance_ids:
-                    # Check status of instances
-                    try:
-                        response = self.ec2_client.describe_instances(
-                            InstanceIds=instance_ids
-                        )
-
-                        # Count instances by state
-                        states = {}
-                        for reservation in response.get("Reservations", []):
-                            for instance in reservation.get("Instances", []):
-                                state = instance["State"]["Name"]
-                                states[state] = states.get(state, 0) + 1
-
-                        # Determine overall status based on instance states
-                        if states.get("running", 0) == len(instance_ids):
-                            block_status = STATUS_RUNNING
-                        elif states.get("terminated", 0) == len(instance_ids):
-                            block_status = STATUS_COMPLETED
-                        elif "running" in states:
-                            block_status = STATUS_RUNNING
-                        else:
-                            block_status = STATUS_PENDING
-                    except Exception as e:
-                        logger.error(
-                            f"Error checking instance status for block {block_id}: {e}"
-                        )
-                        block_status = (
-                            STATUS_RUNNING  # Assume running if we can't check
-                        )
-                else:
-                    block_status = STATUS_PENDING  # No instances yet
-            elif status in ["submitted", "modifying"]:
-                block_status = STATUS_PENDING
-            elif status in ["cancelled", "cancelled_running", "cancelled_terminating"]:
+            if fleet_state in ("deleted", "deleted_running", "deleted_terminating"):
                 block_status = STATUS_CANCELLED
-            elif status == "error":
+            elif fleet_state == "failed":
                 block_status = STATUS_FAILED
+            elif fleet_state in ("submitted", "modifying"):
+                block_status = STATUS_PENDING
             else:
-                block_status = STATUS_UNKNOWN
+                block_status = self._status_from_instances(block_id, fleet_id)
 
-            # Update block status
             self.blocks[block_id]["status"] = block_status
-
             return block_status
 
         except Exception as e:
             logger.error(f"Error getting block status for {block_id}: {e}")
             return self.blocks[block_id].get("status", STATUS_UNKNOWN)
+
+    def _status_from_instances(self, block_id: str, fleet_id: str) -> str:
+        """Derive a block's status from the states of its instances.
+
+        Parameters
+        ----------
+        block_id : str
+            Block being examined; its ``instance_ids`` are refreshed.
+        fleet_id : str
+            Fleet backing the block, queried when the block has no instances
+            recorded yet.
+
+        Returns
+        -------
+        str
+            One of the ``STATUS_*`` constants.
+        """
+        instance_ids = self.blocks[block_id].get("instance_ids", [])
+
+        if not instance_ids:
+            # A block restored from state, or one whose create call came back
+            # unfilled, has nothing recorded; ask EC2 via the fleet-id tag.
+            instance_ids = get_ec2_fleet_instance_ids(self.ec2_client, fleet_id)
+            self.blocks[block_id]["instance_ids"] = instance_ids
+
+        if not instance_ids:
+            return STATUS_PENDING
+
+        try:
+            response = self.ec2_client.describe_instances(InstanceIds=instance_ids)
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "InvalidInstanceID.NotFound":
+                # EC2 drops terminated instances entirely after about an hour.
+                return STATUS_COMPLETED
+            logger.error(f"Error checking instance status for block {block_id}: {e}")
+            return STATUS_RUNNING  # Assume running if we cannot check
+        except Exception as e:
+            logger.error(f"Error checking instance status for block {block_id}: {e}")
+            return STATUS_RUNNING
+
+        states: Dict[str, int] = {}
+        for reservation in response.get("Reservations", []):
+            for instance in reservation.get("Instances", []):
+                state = instance["State"]["Name"]
+                states[state] = states.get(state, 0) + 1
+
+        if states.get("running", 0) == len(instance_ids):
+            return STATUS_RUNNING
+        if states.get("terminated", 0) + states.get("shutting-down", 0) == len(
+            instance_ids
+        ):
+            return STATUS_COMPLETED
+        if "running" in states:
+            return STATUS_RUNNING
+        return STATUS_PENDING
 
     def terminate_block(self, block_id: str) -> None:
         """Terminate a compute block.
@@ -1140,131 +868,111 @@ class SpotFleetManager:
         ----------
         block_id : str
             ID of the block to terminate
+
+        Raises
+        ------
+        SpotFleetThrottlingError
+            If AWS throttled the deletion. Carries ``retry_after``, so a caller
+            can wait the interval AWS named rather than retry blind.
+        SpotFleetError
+            If EC2 refused the deletion for any other reason.
+        ResourceCleanupError
+            For a failure that is not EC2 refusing the deletion.
         """
         if block_id not in self.blocks:
             logger.warning(f"Block {block_id} not found")
             return
 
-        # Get fleet request ID for this block
-        fleet_request_id = self.blocks[block_id].get("fleet_request_id")
-        if not fleet_request_id:
-            logger.warning(f"No fleet request ID found for block {block_id}")
-            # Still drop the template: it belongs to the block, not to the fleet
-            # request, and a block whose request never got recorded would
-            # otherwise leak it until cleanup_all_resources runs (#85).
+        fleet_id = self.blocks[block_id].get("fleet_request_id")
+        if not fleet_id:
+            logger.warning(f"No fleet ID found for block {block_id}")
+            # Still drop the template: it belongs to the block, not to the
+            # fleet, and a block whose fleet never got recorded would otherwise
+            # leak it until cleanup_all_resources runs (#85).
             self._delete_launch_template_for_block(block_id)
             return
 
         try:
-            # Cancel the Spot Fleet request
-            self.ec2_client.cancel_spot_fleet_requests(
-                SpotFleetRequestIds=[fleet_request_id],
-                TerminateInstances=True,  # Terminate the instances as well
-            )
+            # Deleting the fleet terminates its instances; that is not optional
+            # for an instant fleet (#86).
+            delete_ec2_fleet(self.ec2_client, fleet_id)
 
-            logger.info(
-                f"Cancelled Spot Fleet request {fleet_request_id} for block {block_id}"
-            )
+            logger.info(f"Deleted EC2 Fleet {fleet_id} for block {block_id}")
 
-            # Update fleet request status
-            if fleet_request_id in self.fleet_requests:
-                self.fleet_requests[fleet_request_id]["status"] = "cancelled"
+            if fleet_id in self.fleet_requests:
+                self.fleet_requests[fleet_id]["status"] = STATUS_CANCELLED
 
-            # Update block status
             self.blocks[block_id]["status"] = STATUS_CANCELLED
 
-            # Update instance status
-            instance_ids = self.blocks[block_id].get("instance_ids", [])
-            for instance_id in instance_ids:
+            for instance_id in self.blocks[block_id].get("instance_ids", []):
                 if instance_id in self.instances:
                     self.instances[instance_id]["status"] = "terminated"
 
-            # The block's launch template has no further use once the request is
-            # cancelled, and deleting it does not disturb instances still
-            # shutting down (#85).
+            # The block's launch template has no further use once the fleet is
+            # deleted, and deleting it does not disturb instances still shutting
+            # down (#85).
             self._delete_launch_template_for_block(block_id)
 
-        except ClientError as e:
-            error_code = e.response["Error"]["Code"]
-            error_msg = e.response["Error"]["Message"]
+        except ResourceDeletionError as e:
+            # ``delete_ec2_fleet`` wraps the ClientError, so the original is
+            # reached through __cause__ rather than by catching ClientError here.
+            # Catching ClientError instead left this whole branch dead: the
+            # wrapper fell through to the ``except Exception`` below and every
+            # refused deletion -- throttling included -- reported as a generic
+            # ResourceCleanupError, discarding the retry_after AWS supplied.
+            cause = e.__cause__
+            error_code = ""
+            error_msg = str(e)
+            response: Dict[str, Any] = {}
+            if isinstance(cause, ClientError):
+                response = cause.response
+                error_code = response["Error"]["Code"]
+                error_msg = response["Error"]["Message"]
+
             logger.error(
                 f"Error terminating block {block_id}: {error_code} - {error_msg}"
             )
 
-            if error_code == "RequestLimitExceeded":
-                # AWS is throttling our requests
-                retry_after = e.response.get("ResponseMetadata", {}).get(
-                    "RetryAfter", 60
-                )
+            if error_code in ("Throttling", "RequestLimitExceeded"):
+                retry_after = response.get("ResponseMetadata", {}).get("RetryAfter", 60)
                 raise SpotFleetThrottlingError(
-                    message=f"AWS throttled Spot Fleet termination request: {error_msg}",
-                    operation="cancel_spot_fleet_requests",
+                    message=f"AWS throttled the fleet deletion: {error_msg}",
+                    operation="delete_fleets",
                     retry_after=retry_after,
-                )
-            elif error_code == "InvalidSpotFleetRequestId.NotFound":
-                # Fleet request ID not found, likely already terminated
-                logger.warning(
-                    f"Spot Fleet {fleet_request_id} not found, may already be terminated"
-                )
-                # Update our records anyway
-                self.blocks[block_id]["status"] = STATUS_CANCELLED
-                if fleet_request_id in self.fleet_requests:
-                    self.fleet_requests[fleet_request_id]["status"] = "cancelled"
-            else:
-                # General error with termination
-                raise SpotFleetError(
-                    f"Failed to terminate Spot Fleet {fleet_request_id}: {error_code} - {error_msg}"
-                )
+                ) from e
+            raise SpotFleetError(
+                f"Failed to terminate EC2 Fleet {fleet_id}: {error_code} - {error_msg}"
+            ) from e
         except Exception as e:
             logger.error(f"Error terminating block {block_id}: {e}")
-            raise ResourceCleanupError(f"Failed to terminate block {block_id}: {e}")
+            raise ResourceCleanupError(
+                f"Failed to terminate block {block_id}: {e}"
+            ) from e
 
     def cleanup_all_resources(self) -> None:
         """Clean up all AWS resources created by this manager."""
         try:
-            # Cancel all Spot Fleet requests
-            fleet_request_ids = list(self.fleet_requests.keys())
-            if fleet_request_ids:
+            # Delete each fleet individually. ``delete_fleets`` accepts a list,
+            # but reports per-fleet failures in UnsuccessfulFleetDeletions rather
+            # than failing the call, so one loop iteration per fleet keeps a
+            # single stuck fleet from hiding the others.
+            for fleet_id in list(self.fleet_requests):
                 try:
-                    self.ec2_client.cancel_spot_fleet_requests(
-                        SpotFleetRequestIds=fleet_request_ids, TerminateInstances=True
-                    )
-                    logger.info(
-                        f"Cancelled {len(fleet_request_ids)} Spot Fleet requests"
-                    )
-                except ClientError as e:
-                    error_code = e.response["Error"]["Code"]
-                    error_msg = e.response["Error"]["Message"]
-                    logger.error(
-                        f"Error cancelling Spot Fleet requests: {error_code} - {error_msg}"
-                    )
-
-                    # If some fleet requests were not found, try to cancel the valid ones individually
-                    if error_code == "InvalidSpotFleetRequestId.NotFound":
-                        logger.warning(
-                            "Some Spot Fleet requests not found, trying to cancel individually"
-                        )
-                        for fleet_id in fleet_request_ids:
-                            try:
-                                self.ec2_client.cancel_spot_fleet_requests(
-                                    SpotFleetRequestIds=[fleet_id],
-                                    TerminateInstances=True,
-                                )
-                                logger.info(f"Cancelled Spot Fleet request {fleet_id}")
-                            except ClientError as individual_e:
-                                ind_error_code = individual_e.response["Error"]["Code"]
-                                logger.warning(
-                                    f"Could not cancel Spot Fleet {fleet_id}: {ind_error_code}"
-                                )
+                    delete_ec2_fleet(self.ec2_client, fleet_id)
+                    self.fleet_requests[fleet_id]["status"] = STATUS_CANCELLED
+                    logger.info(f"Deleted EC2 Fleet {fleet_id}")
                 except Exception as e:
-                    logger.error(f"Error cancelling Spot Fleet requests: {e}")
+                    logger.error(f"Error deleting EC2 Fleet {fleet_id}: {e}")
 
             # Delete every per-block launch template (#85). Iterated over a copy
             # of the keys because the helper pops from the dict as it goes.
             for block_id in list(self.launch_templates):
                 self._delete_launch_template_for_block(block_id)
 
-            # Clean up IAM role if we created one
+            # Clean up the legacy Spot Fleet service role, which only a state
+            # document written before #86 can still name. CreateFleet has no
+            # IamFleetRole, so nothing creates this any more -- but a workflow
+            # resumed across the upgrade would otherwise leak the role.
             if self.iam_fleet_role_arn:
                 role_name = self.iam_fleet_role_arn.split("/")[-1]
                 try:

--- a/parsl_ephemeral_aws/compute/spot_fleet_cleanup.py
+++ b/parsl_ephemeral_aws/compute/spot_fleet_cleanup.py
@@ -1,4 +1,4 @@
-"""Utilities for cleaning up Spot Fleet resources.
+"""Utilities for cleaning up fleet resources left behind by a workflow.
 
 SPDX-License-Identifier: Apache-2.0
 SPDX-FileCopyrightText: 2025 Scott Friedman and Project Contributors
@@ -6,13 +6,41 @@ SPDX-FileCopyrightText: 2025 Scott Friedman and Project Contributors
 
 import logging
 import time
-from typing import Dict, Any
+from typing import Dict, List, Any, Set
 
 import boto3
 from botocore.exceptions import ClientError
 
+from parsl_ephemeral_aws.constants import (
+    TAG_AWS_FLEET_ID,
+    TAG_PREFIX,
+    TAG_WORKFLOW_ID,
+)
+from parsl_ephemeral_aws.utils.aws import delete_ec2_fleet
+
 
 logger = logging.getLogger(__name__)
+
+# Tag keys that have been used to stamp a workflow ID onto a fleet's instances.
+# TAG_WORKFLOW_ID is what this package writes; "ParslWorkflowId" is what the
+# detached mode's bastion manager script writes (detached.py:1005).
+WORKFLOW_ID_TAG_KEYS = (TAG_WORKFLOW_ID, "ParslWorkflowId")
+
+# Name prefixes under which a Spot Fleet service role may have been created.
+#
+# Two producers used two different prefixes, and the sweep only ever knew about
+# the first, so roles made by the second were never reclaimed:
+#
+#   parsl-aws-spot-fleet-role-  ecs_worker.yml:233 (CloudFormation)
+#   parsl-ephemeral-spot-fleet-role-  detached.py:884 (bastion manager script)
+#
+# ``CreateFleet`` has no ``IamFleetRole``, so nothing this package runs creates
+# either any more (#86). They are swept for the sake of a workflow that was
+# started before the upgrade.
+SPOT_FLEET_ROLE_PREFIXES = (
+    "parsl-aws-spot-fleet-role-",
+    f"{TAG_PREFIX}-spot-fleet-role-",
+)
 
 
 def cleanup_spot_fleet_role(
@@ -52,7 +80,7 @@ def cleanup_spot_fleet_role(
         try:
             # Get the role to ensure it exists
             try:
-                role = iam.get_role(RoleName=role_name)
+                iam.get_role(RoleName=role_name)
             except ClientError as e:
                 if e.response["Error"]["Code"] == "NoSuchEntity":
                     logger.debug(f"Role {role_name} not found, nothing to clean up")
@@ -108,18 +136,124 @@ def cleanup_spot_fleet_role(
     return False
 
 
+def find_fleet_ids_for_workflow(ec2_client: Any, workflow_id: str) -> List[str]:
+    """Find the EC2 Fleets belonging to *workflow_id*, via their instances.
+
+    The sweep has to go through ``describe_instances`` rather than
+    ``describe_fleets`` (#86). An ``instant`` fleet is invisible to a
+    fleet-level listing -- AWS: "if a fleet is of type instant, you must specify
+    the fleet ID in the request, otherwise the fleet does not appear in the
+    response" -- and a tag filter on ``describe_fleets`` does not find one
+    either. Both verified against real EC2. Since the point of a sweep is to
+    find fleets whose IDs are *not* known, the only workable route is the
+    ``aws:ec2:fleet-id`` tag EC2 stamps on every fleet-launched instance.
+
+    No instance-state filter is applied. A fleet all of whose instances have
+    terminated should still be deleted, and deleting an already-empty fleet is
+    harmless.
+
+    Parameters
+    ----------
+    ec2_client : Any
+        A boto3 EC2 client.
+    workflow_id : str
+        Workflow whose fleets to find.
+
+    Returns
+    -------
+    List[str]
+        Fleet IDs, deduplicated. Empty if the workflow launched no fleets, or
+        EC2 has already forgotten their instances.
+    """
+    fleet_ids: Set[str] = set()
+
+    # One pass per workflow tag key: describe_instances ANDs its filters, so
+    # the two keys cannot be expressed in a single call.
+    for tag_key in WORKFLOW_ID_TAG_KEYS:
+        try:
+            paginator = ec2_client.get_paginator("describe_instances")
+            pages = paginator.paginate(
+                Filters=[
+                    {"Name": f"tag:{tag_key}", "Values": [workflow_id]},
+                    {"Name": "tag-key", "Values": [TAG_AWS_FLEET_ID]},
+                ]
+            )
+            for page in pages:
+                for reservation in page.get("Reservations", []):
+                    for instance in reservation.get("Instances", []):
+                        for tag in instance.get("Tags", []):
+                            if tag["Key"] == TAG_AWS_FLEET_ID:
+                                fleet_ids.add(tag["Value"])
+        except ClientError as e:
+            logger.warning(
+                f"Error searching for fleet instances tagged {tag_key}="
+                f"{workflow_id}: {e}"
+            )
+
+    return sorted(fleet_ids)
+
+
+def find_legacy_spot_fleet_request_ids(ec2_client: Any, workflow_id: str) -> List[str]:
+    """Find legacy Spot Fleet requests belonging to *workflow_id*.
+
+    Retained only for a workflow that was started before #86 replaced
+    ``RequestSpotFleet`` with ``CreateFleet``. Nothing in this package creates a
+    Spot Fleet request any more, so on a workflow started after the upgrade this
+    returns an empty list -- at the cost of one ``describe_spot_fleet_requests``
+    pagination.
+
+    Parameters
+    ----------
+    ec2_client : Any
+        A boto3 EC2 client.
+    workflow_id : str
+        Workflow whose requests to find.
+
+    Returns
+    -------
+    List[str]
+        Spot Fleet request IDs.
+    """
+    request_ids: List[str] = []
+
+    paginator = ec2_client.get_paginator("describe_spot_fleet_requests")
+    for page in paginator.paginate():
+        for config in page.get("SpotFleetRequestConfigs", []):
+            request_id = config["SpotFleetRequestId"]
+
+            # A Spot Fleet request's own tags are not in the describe response,
+            # so they have to be read separately.
+            try:
+                tags_response = ec2_client.describe_tags(
+                    Filters=[{"Name": "resource-id", "Values": [request_id]}]
+                )
+            except ClientError as e:
+                logger.warning(
+                    f"Error checking tags for Spot Fleet request {request_id}: {e}"
+                )
+                continue
+
+            for tag in tags_response.get("Tags", []):
+                if tag["Key"] in WORKFLOW_ID_TAG_KEYS and tag["Value"] == workflow_id:
+                    request_ids.append(request_id)
+                    break
+
+    return request_ids
+
+
 def cleanup_all_spot_fleet_resources(
     session: boto3.Session,
     workflow_id: str,
     cancel_active_requests: bool = True,
     cleanup_iam_roles: bool = True,
 ) -> Dict[str, Any]:
-    """Clean up all Spot Fleet resources associated with a workflow.
+    """Clean up all fleet resources associated with a workflow.
 
     This function handles cleaning up:
-    1. Active Spot Fleet requests
-    2. Running instances from these requests
-    3. IAM roles created for the Spot Fleet requests
+
+    1. EC2 Fleets, and the instances they launched
+    2. Legacy Spot Fleet requests, for a workflow that predates #86
+    3. IAM service roles created for those legacy requests
 
     Parameters
     ----------
@@ -128,7 +262,7 @@ def cleanup_all_spot_fleet_resources(
     workflow_id : str
         Workflow ID used to identify resources to clean up
     cancel_active_requests : bool, optional
-        Whether to cancel active Spot Fleet requests, by default True
+        Whether to delete fleets and cancel Spot Fleet requests, by default True
     cleanup_iam_roles : bool, optional
         Whether to clean up IAM roles, by default True
 
@@ -136,88 +270,95 @@ def cleanup_all_spot_fleet_resources(
     -------
     Dict[str, Any]
         Dictionary with cleanup results:
-        - cancelled_requests: List of cancelled requests
-        - cleaned_roles: List of cleaned IAM roles
-        - errors: List of errors encountered
+
+        - deleted_fleets: IDs of EC2 Fleets deleted
+        - cancelled_requests: IDs of legacy Spot Fleet requests cancelled
+        - cleaned_roles: names of IAM roles deleted
+        - errors: errors encountered, one dict per failure
     """
-    result = {"cancelled_requests": [], "cleaned_roles": [], "errors": []}
+    result: Dict[str, Any] = {
+        "deleted_fleets": [],
+        "cancelled_requests": [],
+        "cleaned_roles": [],
+        "errors": [],
+    }
 
     ec2 = session.client("ec2")
     iam = session.client("iam")
 
-    # Find Spot Fleet requests for this workflow
-    try:
-        # Get all Spot Fleet requests
-        fleet_requests = []
-        paginator = ec2.get_paginator("describe_spot_fleet_requests")
+    # Delete EC2 Fleets.
+    if cancel_active_requests:
+        fleet_ids = find_fleet_ids_for_workflow(ec2, workflow_id)
+        if fleet_ids:
+            logger.info(f"Deleting {len(fleet_ids)} EC2 Fleets")
 
-        for page in paginator.paginate():
-            for config in page.get("SpotFleetRequestConfigs", []):
-                # Check tags for workflow ID
-                request_id = config["SpotFleetRequestId"]
+        # One fleet per call. delete_fleets takes a list, but reports per-fleet
+        # failures in UnsuccessfulFleetDeletions rather than failing the call,
+        # so batching would let one stuck fleet hide the others.
+        for fleet_id in fleet_ids:
+            try:
+                delete_ec2_fleet(ec2, fleet_id)
+                result["deleted_fleets"].append(fleet_id)
+            except Exception as e:
+                logger.error(f"Error deleting EC2 Fleet {fleet_id}: {e}")
+                result["errors"].append(
+                    {
+                        "resource_id": fleet_id,
+                        "operation": "delete_fleets",
+                        "error": str(e),
+                    }
+                )
 
-                # Get request tags
-                try:
-                    tags_response = ec2.describe_tags(
-                        Filters=[{"Name": "resource-id", "Values": [request_id]}]
-                    )
+    # Cancel legacy Spot Fleet requests, if any survive from before #86.
+    if cancel_active_requests:
+        try:
+            request_ids = find_legacy_spot_fleet_request_ids(ec2, workflow_id)
+        except Exception as e:
+            logger.error(f"Error finding Spot Fleet requests: {e}")
+            result["errors"].append(
+                {"operation": "find_spot_fleet_requests", "error": str(e)}
+            )
+            request_ids = []
 
-                    # Check if this request belongs to our workflow
-                    for tag in tags_response.get("Tags", []):
-                        if (
-                            tag["Key"] == "WorkflowId"
-                            or tag["Key"] == "ParslWorkflowId"
-                        ) and tag["Value"] == workflow_id:
-                            fleet_requests.append(request_id)
-                            break
-                except ClientError as e:
-                    logger.warning(
-                        f"Error checking tags for Spot Fleet request {request_id}: {e}"
-                    )
-
-        # Cancel active requests
-        if cancel_active_requests and fleet_requests:
-            logger.info(f"Cancelling {len(fleet_requests)} Spot Fleet requests")
+        if request_ids:
+            logger.info(f"Cancelling {len(request_ids)} legacy Spot Fleet requests")
             try:
                 response = ec2.cancel_spot_fleet_requests(
-                    SpotFleetRequestIds=fleet_requests, TerminateInstances=True
+                    SpotFleetRequestIds=request_ids, TerminateInstances=True
                 )
 
                 for success in response.get("SuccessfulFleetRequests", []):
                     result["cancelled_requests"].append(success["SpotFleetRequestId"])
 
                 for failure in response.get("UnsuccessfulFleetRequests", []):
-                    error = {
-                        "resource_id": failure["SpotFleetRequestId"],
-                        "error": failure.get("Error", {}).get(
-                            "Message", "Unknown error"
-                        ),
-                    }
-                    result["errors"].append(error)
-
+                    result["errors"].append(
+                        {
+                            "resource_id": failure["SpotFleetRequestId"],
+                            "operation": "cancel_spot_fleet_requests",
+                            "error": failure.get("Error", {}).get(
+                                "Message", "Unknown error"
+                            ),
+                        }
+                    )
             except Exception as e:
                 logger.error(f"Error cancelling Spot Fleet requests: {e}")
                 result["errors"].append(
                     {"operation": "cancel_spot_fleet_requests", "error": str(e)}
                 )
-    except Exception as e:
-        logger.error(f"Error finding Spot Fleet requests: {e}")
-        result["errors"].append(
-            {"operation": "find_spot_fleet_requests", "error": str(e)}
-        )
 
     # Clean up IAM roles
     if cleanup_iam_roles:
         try:
-            # Get roles with name pattern for this workflow
-            role_prefix = f"parsl-aws-spot-fleet-role-{workflow_id[:8]}"
+            role_prefixes = tuple(
+                f"{prefix}{workflow_id[:8]}" for prefix in SPOT_FLEET_ROLE_PREFIXES
+            )
 
             roles_to_clean = []
             paginator = iam.get_paginator("list_roles")
 
             for page in paginator.paginate():
                 for role in page["Roles"]:
-                    if role["RoleName"].startswith(role_prefix):
+                    if role["RoleName"].startswith(role_prefixes):
                         roles_to_clean.append(role["RoleName"])
 
             # Clean up each role

--- a/parsl_ephemeral_aws/compute/spot_interruption.py
+++ b/parsl_ephemeral_aws/compute/spot_interruption.py
@@ -12,6 +12,7 @@ import logging
 import time
 import threading
 import queue
+import uuid
 import boto3
 from typing import Dict, List, Optional, Callable, Any
 from botocore.exceptions import ClientError
@@ -20,6 +21,14 @@ from parsl_ephemeral_aws.exceptions import SpotInstanceError
 from parsl_ephemeral_aws.constants import (
     DEFAULT_SPOT_INTERRUPTION_CHECK_INTERVAL,
     DEFAULT_SPOT_INTERRUPTION_LEAD_TIME,
+    SPOT_INTERRUPTION_QUEUE_WAIT_SECONDS,
+    SPOT_INTERRUPTION_RULE_NAME_PREFIX,
+    TAG_MANAGED,
+)
+from parsl_ephemeral_aws.utils.aws import (
+    create_spot_interruption_notifier,
+    delete_spot_interruption_notifier,
+    get_ec2_fleet_instance_ids,
 )
 
 logger = logging.getLogger(__name__)
@@ -31,6 +40,14 @@ class SpotInterruptionMonitor:
     The SpotInterruptionMonitor checks for spot instance interruption notices and
     executes recovery actions when interruptions are detected. It can monitor both
     individual spot instances and spot fleet requests.
+
+    Detection runs on two tracks. The EventBridge warning is the one that
+    matters: it arrives roughly two minutes *before* the reclaim, with the
+    instance still running, which is the only point at which checkpointing can
+    succeed. The EC2-state poll is kept as a fallback for when the notifier
+    could not be created (missing ``events``/``sqs`` permissions, say), but it
+    can only ever report an interruption post-facto, once the instance has
+    already reached ``shutting-down``.
 
     Attributes
     ----------
@@ -48,6 +65,10 @@ class SpotInterruptionMonitor:
         Thread for background monitoring
     stop_event : threading.Event
         Event to signal thread termination
+    warning_rule_name : Optional[str]
+        EventBridge rule delivering interruption warnings, once created.
+    warning_queue_url : Optional[str]
+        SQS queue the rule delivers to, once created.
     """
 
     def __init__(
@@ -55,6 +76,8 @@ class SpotInterruptionMonitor:
         session: boto3.Session,
         check_interval: int = DEFAULT_SPOT_INTERRUPTION_CHECK_INTERVAL,
         lead_time: int = DEFAULT_SPOT_INTERRUPTION_LEAD_TIME,
+        provider_id: Optional[str] = None,
+        use_event_bridge: bool = True,
     ) -> None:
         """Initialize the SpotInterruptionMonitor.
 
@@ -66,6 +89,14 @@ class SpotInterruptionMonitor:
             Interval in seconds between checks for interruption notices
         lead_time : int, optional
             Minimum time in seconds we want for recovery before instance termination
+        provider_id : Optional[str], optional
+            Names the EventBridge rule and SQS queue, keeping them unique per
+            provider. Falls back to a random suffix when omitted.
+        use_event_bridge : bool, optional
+            Whether to create the EventBridge notifier that supplies the
+            two-minute advance warning. Set False to rely solely on the
+            post-facto EC2-state poll -- useful when the caller's IAM policy
+            grants no ``events``/``sqs`` access.
         """
         self.session = session
         self.check_interval = check_interval
@@ -77,7 +108,18 @@ class SpotInterruptionMonitor:
         # Background monitoring
         self.monitoring_thread = None
         self.stop_event = threading.Event()
-        self.event_queue = queue.Queue()
+        self.event_queue: queue.Queue = queue.Queue()
+
+        # EventBridge notifier (#86). Created lazily by start_monitoring() rather
+        # than here, so constructing a monitor makes no AWS calls and cannot
+        # fail -- every mode builds one during __init__.
+        self.use_event_bridge = use_event_bridge
+        self._notifier_name = (
+            f"{SPOT_INTERRUPTION_RULE_NAME_PREFIX}-"
+            f"{(provider_id or uuid.uuid4().hex)[:8]}"
+        )
+        self.warning_rule_name: Optional[str] = None
+        self.warning_queue_url: Optional[str] = None
 
     def register_instance(
         self, instance_id: str, handler: Callable[[str, Dict[str, Any]], None]
@@ -149,10 +191,18 @@ class SpotInterruptionMonitor:
         )
 
     def start_monitoring(self) -> None:
-        """Start background monitoring for spot interruption notices."""
+        """Start background monitoring for spot interruption notices.
+
+        Creates the EventBridge notifier first, when enabled. A failure there is
+        logged and not raised: losing the advance warning degrades this to the
+        post-facto EC2-state poll, which is worse but still functional, and is
+        not a reason to fail the workflow that was about to run.
+        """
         if self.monitoring_thread is not None and self.monitoring_thread.is_alive():
             logger.warning("Monitoring thread is already running")
             return
+
+        self._ensure_warning_notifier()
 
         self.stop_event.clear()
         self.monitoring_thread = threading.Thread(
@@ -162,9 +212,15 @@ class SpotInterruptionMonitor:
         logger.info("Started spot interruption monitoring")
 
     def stop_monitoring(self) -> None:
-        """Stop background monitoring for spot interruption notices."""
+        """Stop background monitoring, and delete the EventBridge notifier.
+
+        The notifier is torn down even when no thread was running, so a monitor
+        that was stopped twice -- or whose thread died -- still cleans up the rule
+        and queue it created rather than leaking them.
+        """
         if self.monitoring_thread is None or not self.monitoring_thread.is_alive():
             logger.warning("No monitoring thread is running")
+            self._delete_warning_notifier()
             return
 
         self.stop_event.set()
@@ -173,15 +229,62 @@ class SpotInterruptionMonitor:
             logger.warning("Monitoring thread did not terminate gracefully")
 
         self.monitoring_thread = None
+        self._delete_warning_notifier()
         logger.info("Stopped spot interruption monitoring")
+
+    def _ensure_warning_notifier(self) -> None:
+        """Create the EventBridge rule and SQS queue, if not already present."""
+        if not self.use_event_bridge or self.warning_queue_url:
+            return
+
+        try:
+            rule_name, queue_url, _ = create_spot_interruption_notifier(
+                self.session.client("events"),
+                self.session.client("sqs"),
+                self._notifier_name,
+                tags=[{"Key": TAG_MANAGED, "Value": "true"}],
+            )
+        except Exception as e:
+            # Degrade to the EC2-state poll rather than failing the workflow.
+            # The poll cannot see a warning in advance, so log loudly enough that
+            # the loss of checkpointing lead time is visible.
+            logger.warning(
+                "Could not create the spot interruption notifier, falling back "
+                "to post-facto EC2 state polling -- interruptions will be "
+                f"detected only once an instance is already shutting down: {e}"
+            )
+            return
+
+        self.warning_rule_name = rule_name
+        self.warning_queue_url = queue_url
+
+    def _delete_warning_notifier(self) -> None:
+        """Delete the EventBridge rule and SQS queue, if this monitor made them."""
+        if not (self.warning_rule_name or self.warning_queue_url):
+            return
+
+        delete_spot_interruption_notifier(
+            self.session.client("events"),
+            self.session.client("sqs"),
+            self.warning_rule_name,
+            self.warning_queue_url,
+        )
+        self.warning_rule_name = None
+        self.warning_queue_url = None
 
     def _monitoring_loop(self) -> None:
         """Main loop for checking spot interruption notices."""
         ec2_client = self.session.client("ec2")
         cloudwatch_client = self.session.client("cloudwatch")
+        sqs_client = self.session.client("sqs") if self.warning_queue_url else None
 
         while not self.stop_event.is_set():
             try:
+                # The advance warning first: it is the only source that fires
+                # while the instance is still running.
+                if sqs_client is not None:
+                    self._poll_warning_queue(sqs_client, ec2_client)
+
                 # Check instance interruption notices
                 self._check_instance_interruptions(ec2_client, cloudwatch_client)
 
@@ -194,11 +297,114 @@ class SpotInterruptionMonitor:
             except Exception as e:
                 logger.error(f"Error in spot interruption monitoring: {e}")
 
-            # Wait for next check interval or until stop is requested
+            # Wait for next check interval or until stop is requested.
+            # _poll_warning_queue already long-polls SQS, so when the notifier is
+            # active most of the interval is spent blocked on a warning arriving
+            # rather than idling.
             self.stop_event.wait(self.check_interval)
 
+    def _poll_warning_queue(self, sqs_client: Any, ec2_client: Any) -> None:
+        """Drain interruption warnings from the notifier queue (#86).
+
+        Each message is an EventBridge envelope whose ``detail`` carries
+        ``instance-id`` and ``instance-action``. Confirmed against a real
+        FIS-driven interruption; the arriving instance was still ``running``,
+        which is what makes this usable for checkpointing where the EC2-state
+        poll is not.
+
+        The rule cannot be scoped to specific instances -- their IDs are not
+        known until the fleet launches -- so it matches every spot interruption
+        in the account and region. Warnings for instances this monitor does not
+        track are therefore expected, and are dropped rather than logged as
+        errors.
+        """
+        try:
+            response = sqs_client.receive_message(
+                QueueUrl=self.warning_queue_url,
+                MaxNumberOfMessages=10,
+                WaitTimeSeconds=min(
+                    SPOT_INTERRUPTION_QUEUE_WAIT_SECONDS, self.check_interval
+                ),
+            )
+        except ClientError as e:
+            logger.error(f"Error polling spot interruption warning queue: {e}")
+            return
+
+        for message in response.get("Messages", []):
+            # Delete first, unconditionally. A message that cannot be parsed, or
+            # that names an instance this monitor does not own, would otherwise
+            # be redelivered on every poll for the whole retention period.
+            try:
+                sqs_client.delete_message(
+                    QueueUrl=self.warning_queue_url,
+                    ReceiptHandle=message["ReceiptHandle"],
+                )
+            except ClientError as e:
+                logger.warning(f"Could not delete warning message: {e}")
+
+            try:
+                body = json.loads(message["Body"])
+            except (ValueError, KeyError) as e:
+                logger.warning(f"Unparseable spot interruption warning: {e}")
+                continue
+
+            detail = body.get("detail", {})
+            instance_id = detail.get("instance-id")
+            if not instance_id:
+                continue
+
+            event_details = {
+                "InstanceId": instance_id,
+                "InstanceAction": detail.get("instance-action", "terminate"),
+                "NoticeTime": time.time(),
+                # Distinguishes an advance warning from the post-facto poll, so a
+                # handler can tell whether it has time to checkpoint.
+                "Source": "eventbridge",
+            }
+            self._queue_warning(instance_id, event_details, ec2_client)
+
+    def _queue_warning(
+        self, instance_id: str, event_details: Dict[str, Any], ec2_client: Any
+    ) -> None:
+        """Route a warning for *instance_id* to whichever handler owns it.
+
+        An instance may be registered directly, or belong to a registered fleet,
+        or be neither -- the rule matches the whole account, so unowned instances
+        are the common case and are silently ignored.
+        """
+        with self._lock:
+            if instance_id in self.instance_handlers:
+                self.event_queue.put(("instance", instance_id, event_details))
+                logger.info(
+                    f"Spot interruption warning for instance {instance_id}: "
+                    f"{event_details['InstanceAction']}"
+                )
+                return
+            fleet_ids = list(self.fleet_handlers.keys())
+
+        for fleet_id in fleet_ids:
+            if instance_id in get_ec2_fleet_instance_ids(ec2_client, fleet_id):
+                fleet_details = dict(event_details, FleetRequestId=fleet_id)
+                self.event_queue.put(("fleet", fleet_id, [instance_id], fleet_details))
+                logger.info(
+                    f"Spot interruption warning for instance {instance_id} "
+                    f"in fleet {fleet_id}"
+                )
+                return
+
+        logger.debug(
+            f"Ignoring spot interruption warning for unmonitored instance {instance_id}"
+        )
+
     def _check_instance_interruptions(self, ec2_client, cloudwatch_client) -> None:
-        """Check for interruption notices on individual spot instances."""
+        """Detect already-interrupted instances from their EC2 state.
+
+        The fallback track. It reports an interruption only once the instance has
+        reached ``shutting-down`` or ``stopping`` -- after the reclaim, too late
+        to checkpoint -- so it exists to catch what the EventBridge notifier
+        misses, or to cover the case where the notifier could not be created at
+        all. :meth:`_poll_warning_queue` is the one that gives advance notice.
+        """
         if not self.instance_handlers:
             return
 
@@ -207,12 +413,6 @@ class SpotInterruptionMonitor:
 
         try:
             # Detect termination using real, observable EC2 states.
-            # NOTE: The authoritative 2-minute advance warning requires either
-            # EventBridge rules or worker-side IMDSv2 polling of
-            # 169.254.169.254/latest/meta-data/spot/termination-time — that
-            # is tracked as a future enhancement.  For now we detect
-            # interruption post-facto: spot instances entering "shutting-down"
-            # or "stopping" are treated as interrupted.
             instances = ec2_client.describe_instances(InstanceIds=instance_ids)
             for reservation in instances.get("Reservations", []):
                 for instance in reservation.get("Instances", []):
@@ -228,6 +428,10 @@ class SpotInterruptionMonitor:
                                 "InstanceId": instance_id,
                                 "InstanceAction": "terminate",
                                 "NoticeTime": time.time(),
+                                # No lead time left on this track; a handler can
+                                # skip checkpointing rather than attempt it
+                                # against an instance that is already going.
+                                "Source": "ec2-state",
                             }
                             self.event_queue.put(
                                 ("instance", instance_id, event_details)
@@ -237,7 +441,11 @@ class SpotInterruptionMonitor:
             logger.error(f"Error checking spot instance interruptions: {e}")
 
     def _check_fleet_interruptions(self, ec2_client) -> None:
-        """Check for interruptions in spot fleet instances."""
+        """Detect already-interrupted fleet instances from their EC2 state.
+
+        The fleet counterpart of :meth:`_check_instance_interruptions`, and
+        equally post-facto. See that method for why this is the fallback track.
+        """
         if not self.fleet_handlers:
             return
 
@@ -245,16 +453,11 @@ class SpotInterruptionMonitor:
             fleet_request_ids = list(self.fleet_handlers.keys())
 
         try:
-            # Get the instances in each fleet
+            # Get the instances in each fleet. Goes through the fleet-id tag
+            # rather than describe_spot_fleet_instances, which rejects an EC2
+            # Fleet of type instant outright (#86).
             for fleet_id in fleet_request_ids:
-                fleet_instances = ec2_client.describe_spot_fleet_instances(
-                    SpotFleetRequestId=fleet_id
-                )
-
-                instance_ids = [
-                    instance["InstanceId"]
-                    for instance in fleet_instances.get("ActiveInstances", [])
-                ]
+                instance_ids = get_ec2_fleet_instance_ids(ec2_client, fleet_id)
 
                 if not instance_ids:
                     continue
@@ -282,6 +485,7 @@ class SpotInterruptionMonitor:
                             "FleetRequestId": fleet_id,
                             "InstanceAction": "terminate",
                             "NoticeTime": time.time(),
+                            "Source": "ec2-state",
                         }
                         self.event_queue.put(
                             ("fleet", fleet_id, interrupted_instances, event_details)

--- a/parsl_ephemeral_aws/constants.py
+++ b/parsl_ephemeral_aws/constants.py
@@ -146,6 +146,10 @@ RESOURCE_TYPE_CLOUDFORMATION = "cloudformation"
 RESOURCE_TYPE_LAMBDA_FUNCTION = "lambda_function"
 RESOURCE_TYPE_ECS_TASK = "ecs_task"
 RESOURCE_TYPE_LAUNCH_TEMPLATE = "launch-template"
+# EC2's tag resource type for an EC2 Fleet (#86). Distinct from
+# RESOURCE_TYPE_SPOT_FLEET above, which is this package's own internal label for
+# a fleet-backed resource record and is persisted in state documents.
+RESOURCE_TYPE_FLEET = "fleet"
 
 # Instance metadata service options applied to every launch (#85).
 #
@@ -172,6 +176,67 @@ IMDSV2_METADATA_OPTIONS = {
 SPOT_FLEET_TARGET_CAPACITY_TYPE = "TargetCapacity"
 SPOT_FLEET_FULFILLED_CAPACITY_TYPE = "FulfilledCapacity"
 
+# EC2 Fleet constants (#86).
+#
+# AWS's guidance on the API this package used to call: "Spot Fleet ... uses a
+# legacy API with no planned investment." CreateFleet replaces it. The migration
+# was only possible once #85 put a launch template in place, because CreateFleet
+# has no LaunchSpecifications member at all -- a template is mandatory.
+#
+# Fleet type ``instant`` is what this package uses. It places a *synchronous*
+# one-time request and returns the launched instance IDs in the CreateFleet
+# response, which preserves the block -> instance-ID mapping the rest of the
+# package is built on. The alternatives are asynchronous and would require
+# polling before a block could report its instances.
+#
+# Verified against real EC2 in us-east-1, and these are not merely ignored --
+# CreateFleet rejects them outright with InvalidParameter:
+#
+#   ReplaceUnhealthyInstances        -> "not supported for given fleet type"
+#   TerminateInstancesWithExpiration -> "not supported for given fleet type"
+#   SpotOptions.MaintenanceStrategies (Capacity Rebalance)
+#                                    -> "only compatible with fleet type maintain"
+#
+# So an instant fleet gets no capacity rebalancing; the two-minute interruption
+# warning is delivered instead through the EventBridge route below.
+EC2_FLEET_TYPE_INSTANT = "instant"
+
+# Deleting an instant fleet always terminates its instances -- AWS: "A deleted
+# instant fleet with running instances is not supported." NoTerminateInstances is
+# rejected for this fleet type, so the flag is always True.
+EC2_FLEET_TERMINATE_INSTANCES = True
+
+# Why no fleet is built by CloudFormation (#86).
+#
+# Every fleet in this package is created by calling CreateFleet directly. The
+# override list is variable-length -- one entry per instance type -- and
+# CloudFormation cannot build one. Three routes were tried against real AWS:
+#
+#   ``Fn::ForEach`` (Transform: AWS::LanguageExtensions) expands to a *map*, not
+#   a list -- reading the processed template off a change set returned
+#   ``{"InstanceTypeOverridet3.small": {...}, ...}`` where a list was needed.
+#
+#   A fixed number of ``!Select`` slots cannot be left partly filled: an
+#   out-of-range ``!Select`` fails validation even inside the untaken branch of
+#   an ``!If`` -- "Fn::Select cannot select nonexistent value at index 2".
+#
+#   Padding those slots by repeating a type is rejected by EC2 --
+#   "InvalidFleetConfig: The fleet configuration contains duplicate instance
+#   pools". Note a DryRun does *not* catch this: EC2 accepted the identical
+#   duplicate-bearing request with DryRun=True and rejected it without.
+#
+# Tag EC2 applies to every instance a fleet launches, without being asked.
+#
+# This is the only way to find an instant fleet's instances after the fact.
+# Verified against real EC2: ``describe_fleets()`` with no FleetIds returns an
+# *empty* list for instant fleets (AWS: "If a fleet is of type instant, you must
+# specify the fleet ID in the request, otherwise the fleet does not appear in
+# the response"), a tag filter on describe_fleets does not find them either, and
+# ``describe_fleet_instances`` refuses them with ``Unsupported``. Filtering
+# describe_instances on this tag does work, so the orphan sweep goes through the
+# instances rather than the fleets.
+TAG_AWS_FLEET_ID = "aws:ec2:fleet-id"
+
 # Allocation strategy (#84). ``price-capacity-optimized`` is AWS's current
 # recommendation: it picks from the pools with the deepest spare capacity and
 # then the lowest price among those, so it interrupts far less often than
@@ -185,9 +250,15 @@ SPOT_FLEET_FULFILLED_CAPACITY_TYPE = "FulfilledCapacity"
 #   CreateFleet       SpotOptions.AllocationStrategy            -> kebab-case
 #       "priceCapacityOptimized"   => InvalidParameter
 #
-# So there cannot be one constant for both. SPOT_FLEET_* is the camelCase form
-# for the legacy RequestSpotFleet path this package uses today; EC2_FLEET_* is
-# the kebab-case form for the CreateFleet migration in #86.
+# So there cannot be one constant for both. EC2_FLEET_* is the kebab-case form
+# CreateFleet takes, which is what this package now uses (#86). SPOT_FLEET_* is
+# the camelCase form for the legacy RequestSpotFleet API, still needed by the
+# CloudFormation templates and the detached mode's bastion manager, which drive
+# AWS::EC2::SpotFleet resources.
+#
+# Note that neither DryRun nor TotalTargetCapacity=0 validates these enums --
+# both accepted the wrong spelling in probes, and describe_fleets showed EC2 had
+# stored it verbatim. Only a real launch rejects it.
 SPOT_FLEET_DEFAULT_ALLOCATION_STRATEGY = "priceCapacityOptimized"
 EC2_FLEET_DEFAULT_ALLOCATION_STRATEGY = "price-capacity-optimized"
 
@@ -211,6 +282,35 @@ EC2_FLEET_ALLOCATION_STRATEGIES = frozenset(
         "price-capacity-optimized",
     }
 )
+
+# Spot interruption warning delivery (#86).
+#
+# An ``instant`` fleet gets no Capacity Rebalance, so the two-minute warning is
+# taken from EventBridge instead: a rule matching the interruption event, with an
+# SQS queue as its target, which the driver polls. Verified end to end against
+# real EC2 with a Fault Injection Simulator experiment
+# (``aws:ec2:send-spot-instance-interruptions``) -- the warning reached the queue
+# 15.2s after the experiment started, with the instance still ``running``. That
+# is the whole point: the EC2-state poll this supplements cannot see anything
+# until ``shutting-down``, by which time checkpointing is already too late.
+#
+# ``EC2 Instance Rebalance Recommendation`` is deliberately *not* matched. It is
+# a separate detail-type that signals elevated interruption risk, not an
+# impending reclaim, and confirmed via ``test_event_pattern`` not to match this
+# pattern. Treating it as an interruption would checkpoint and tear down workers
+# that were never going away.
+SPOT_INTERRUPTION_EVENT_SOURCE = "aws.ec2"
+SPOT_INTERRUPTION_EVENT_DETAIL_TYPE = "EC2 Spot Instance Interruption Warning"
+
+# Retention is short on purpose: a warning is worthless once its two minutes are
+# up, so an undelivered message should expire rather than be replayed against a
+# long-dead instance on the next run.
+SPOT_INTERRUPTION_QUEUE_RETENTION_SECONDS = 300
+
+# SQS long-poll ceiling. 20s is the maximum ReceiveMessage accepts, and long
+# polling is what keeps warning latency near-zero without spending an API call
+# per second.
+SPOT_INTERRUPTION_QUEUE_WAIT_SECONDS = 20
 
 # Cleanup constants
 CLEANUP_BATCH_SIZE = 10
@@ -238,6 +338,16 @@ TAG_NAME = "Name"
 # Launch template naming (#85). The provider ID is appended, keeping the whole
 # name unique per provider instance and well inside EC2's 128-character limit.
 LAUNCH_TEMPLATE_NAME_PREFIX = f"{DEFAULT_TAG_PREFIX}-lt"
+# Names both the EventBridge rule and the SQS queue carrying spot interruption
+# warnings (#86); the provider ID is appended, keeping them unique per provider.
+#
+# The warning cannot be filtered any more narrowly than by detail-type. The
+# event's ``detail`` carries only ``instance-id`` and ``instance-action``, and
+# instance IDs are not known until the fleet launches, so the rule necessarily
+# matches every spot interruption in the account and region. Each monitor
+# therefore discards warnings for instances it does not track, and two providers
+# in one account each see the other's warnings and ignore them.
+SPOT_INTERRUPTION_RULE_NAME_PREFIX = f"{DEFAULT_TAG_PREFIX}-spot-warning"
 # Marker tag identifying a resource as created by this provider (#109).
 #
 # This used to be TAG_NAME, which is the EC2-reserved "Name" key. Every tag list
@@ -278,9 +388,33 @@ STATUS_UNKNOWN = "UNKNOWN"
 STATUS_SUCCEEDED = "COMPLETED"  # Alias for compatibility
 STATUS_WARM = "WARM"  # instance running, job done, ready for reuse
 
-# Warm pool defaults
+# Warm pool defaults.
+#
+# A warm instance is *Running*, not Stopped, and so bills at the full on-demand
+# or spot rate for every second it waits. AWS is blunt about this shape --
+# keeping warm instances running is "highly discouraged to avoid incurring
+# unnecessary charges" -- and the native ASG warm pool it recommends instead
+# holds them Stopped or Hibernated.
+#
+# This package cannot use the native pool: dispatch is SSM SendCommand, and a
+# Stopped instance runs no SSM agent, so it cannot receive one. Moving to a pull
+# model would let the pool be Stopped and is tracked as #130 for v0.8.0.
+#
+# Until then the cost is bounded rather than eliminated: the TTL default is cut
+# to 120s from the 600s it shipped with in v0.6.0, so an idle pool costs at most
+# a fifth of what it did, and MAX_WARM_POOL_SIZE caps the blast radius of a
+# mistyped size.
 DEFAULT_WARM_POOL_SIZE = 0  # 0 = disabled
-DEFAULT_WARM_POOL_TTL = 600  # seconds a warm idle instance stays alive
+DEFAULT_WARM_POOL_TTL = 120  # seconds a warm *running* instance stays alive
+
+# Hard ceiling on warm_pool_size.
+#
+# Every warm instance is a running instance, so an accidental warm_pool_size=200
+# is a bill, not an error -- nothing in EC2 refuses it and no quota is
+# necessarily hit. The limit is deliberately low: a warm pool is a latency
+# optimisation for a handful of instances, and wanting dozens of idle machines
+# means wanting a different mechanism.
+MAX_WARM_POOL_SIZE = 20
 
 # AMI baking defaults
 DEFAULT_BAKE_AMI = False  # bake worker_init into a custom AMI during initialize()

--- a/parsl_ephemeral_aws/modes/detached.py
+++ b/parsl_ephemeral_aws/modes/detached.py
@@ -38,8 +38,9 @@ from parsl_ephemeral_aws.modes.base import OperatingMode
 from parsl_ephemeral_aws.state.base import STATE_KEY_MODE, StateStore
 from parsl_ephemeral_aws.utils.aws import (
     architecture_for_instance_type,
+    delete_ec2_fleet,
     get_default_ami,
-    normalize_spot_fleet_allocation_strategy,
+    normalize_ec2_fleet_allocation_strategy,
     wait_for_resource,
     get_cf_template,
 )
@@ -158,7 +159,9 @@ class DetachedMode(OperatingMode):
                 logger.debug(
                     "Initializing SpotInterruptionMonitor and Handler for DetachedMode"
                 )
-                self.spot_interruption_monitor = SpotInterruptionMonitor(self.session)
+                self.spot_interruption_monitor = SpotInterruptionMonitor(
+                    self.session, provider_id=self.provider_id
+                )
                 self.spot_interruption_handler = ParslSpotInterruptionHandler(
                     session=self.session,
                     checkpoint_bucket=self.checkpoint_bucket,
@@ -504,26 +507,18 @@ class DetachedMode(OperatingMode):
                         "ParameterKey": "Tags",
                         "ParameterValue": json.dumps(self.additional_tags),
                     },
-                    {
-                        "ParameterKey": "UseSpotFleet",
-                        "ParameterValue": "true" if self.use_spot_fleet else "false",
-                    },
-                    {
-                        "ParameterKey": "InstanceTypes",
-                        "ParameterValue": json.dumps(self.instance_types)
-                        if self.instance_types
-                        else "[]",
-                    },
-                    {
-                        "ParameterKey": "NodesPerBlock",
-                        "ParameterValue": str(self.nodes_per_block),
-                    },
-                    {
-                        "ParameterKey": "SpotMaxPricePercentage",
-                        "ParameterValue": str(self.spot_max_price_percentage)
-                        if self.spot_max_price_percentage
-                        else "",
-                    },
+                    # UseSpotFleet/InstanceTypes/NodesPerBlock/
+                    # SpotMaxPricePercentage used to be sent here. bastion.yml
+                    # declares none of them, and CloudFormation rejects an
+                    # undeclared parameter outright -- verified:
+                    # "ValidationError: Parameters: [UseSpotFleet] do not exist
+                    # in the template". Since bastion_host_type defaults to
+                    # "cloudformation", the default bastion path always failed.
+                    #
+                    # They are dropped rather than added to the template: all
+                    # four describe a *worker fleet*, and the bastion is a
+                    # single host. The fleet settings reach the workers through
+                    # the bastion manager script's environment instead.
                 ],
                 Capabilities=["CAPABILITY_IAM"],
                 OnFailure="DELETE",
@@ -744,10 +739,13 @@ JOB_COMMAND_PREFIX = f'{SSM_PARAMETER_PREFIX}/jobs'
 JOB_STATUS_PREFIX = f'{SSM_PARAMETER_PREFIX}/status'
 TAG_PREFIX = "parsl-ephemeral"
 RESOURCE_TYPE_SPOT_FLEET = "spot_fleet"
-# Spot Fleet allocation strategy, overwritten at script generation time with the
-# mode's spot_allocation_strategy (#84). RequestSpotFleet accepts only the
-# camelCase spelling, so the value substituted here is already normalised.
-ALLOCATION_STRATEGY = 'priceCapacityOptimized'
+# Fleet allocation strategy, overwritten at script generation time with the
+# mode's spot_allocation_strategy (#84). CreateFleet accepts only the kebab-case
+# spelling, so the value substituted here is already normalised.
+ALLOCATION_STRATEGY = 'price-capacity-optimized'
+# Tag EC2 applies to every fleet-launched instance. The only way to enumerate an
+# instant fleet's instances -- describe_fleet_instances rejects that fleet type.
+TAG_AWS_FLEET_ID = 'aws:ec2:fleet-id'
 # IMDSv2 options for workers this bastion launches, overwritten at script
 # generation time from the package constant (#85). Defined as a literal because
 # the bastion runs this script standalone and cannot import from the package.
@@ -760,7 +758,6 @@ EC2_STATUS_MAPPING = {
     'stopping': 'CANCELED',
     'stopped': 'CANCELED',
 }
-SPOT_FLEET_IAM_ROLE_ARN = None  # Will be populated dynamically
 
 def get_session():
     """Get AWS session."""
@@ -864,74 +861,15 @@ def update_job_status(job_id, status, instance_id=None, error=None, fleet_reques
         logger.error(f"Error updating job status: {e}")
         traceback.print_exc()
 
-def get_spot_fleet_role():
-    """Get or create the IAM role for Spot Fleet requests.
-
-    Returns
-    -------
-    str
-        ARN of the IAM role for Spot Fleet
-    """
-    global SPOT_FLEET_IAM_ROLE_ARN
-
-    # Return cached value if available
-    if SPOT_FLEET_IAM_ROLE_ARN:
-        return SPOT_FLEET_IAM_ROLE_ARN
-
-    # Create a new role
-    session = get_session()
-    iam = session.client('iam')
-    role_name = f"{TAG_PREFIX}-spot-fleet-role-{WORKFLOW_ID[:8]}"
-
-    try:
-        # Check if the role already exists
-        try:
-            response = iam.get_role(RoleName=role_name)
-            SPOT_FLEET_IAM_ROLE_ARN = response['Role']['Arn']
-            logger.info(f"Using existing IAM role for Spot Fleet: {role_name}")
-            return SPOT_FLEET_IAM_ROLE_ARN
-        except ClientError as e:
-            if e.response['Error']['Code'] != 'NoSuchEntity':
-                raise
-
-            # Role doesn't exist, create it
-            trust_policy = {
-                "Version": "2012-10-17",
-                "Statement": [
-                    {
-                        "Effect": "Allow",
-                        "Principal": {"Service": "spotfleet.amazonaws.com"},
-                        "Action": "sts:AssumeRole"
-                    }
-                ]
-            }
-
-            response = iam.create_role(
-                RoleName=role_name,
-                AssumeRolePolicyDocument=json.dumps(trust_policy),
-                Description=f"Role for Parsl Spot Fleet ({WORKFLOW_ID})"
-            )
-
-            # Attach the required policy
-            iam.attach_role_policy(
-                RoleName=role_name,
-                PolicyArn="arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole"
-            )
-
-            # Get the role ARN
-            SPOT_FLEET_IAM_ROLE_ARN = response['Role']['Arn']
-            logger.info(f"Created IAM role for Spot Fleet: {role_name}")
-
-            # Wait for role to be ready (IAM changes can take time to propagate)
-            time.sleep(10)
-
-            return SPOT_FLEET_IAM_ROLE_ARN
-    except Exception as e:
-        logger.error(f"Error getting or creating IAM role for Spot Fleet: {e}")
-        raise
-
 def launch_spot_fleet(job_data):
-    """Launch a Spot Fleet for the job.
+    """Launch an EC2 Fleet for the job.
+
+    Uses CreateFleet with type 'instant', replacing RequestSpotFleet -- an API
+    AWS describes as legacy with no planned investment (#86). Three consequences
+    for this function: there is no IAM service role to create (CreateFleet has no
+    IamFleetRole member), the launch template is mandatory rather than optional
+    (there is no LaunchSpecifications member either), and the instance IDs come
+    back from the create call itself, so the old 300-second polling loop is gone.
 
     Parameters
     ----------
@@ -941,11 +879,12 @@ def launch_spot_fleet(job_data):
     Returns
     -------
     str
-        Instance ID or Spot Fleet request ID
+        Primary instance ID, or None if the fleet launched nothing
     """
     session = get_session()
     ec2 = session.client('ec2')
     job_id = job_data['id']
+    template_id = None
 
     try:
         # Prepare user data script
@@ -963,40 +902,16 @@ export PARSL_WORKER_ID=$(hostname)
 {f"shutdown -h now" if job_data.get('auto_shutdown', True) else "# Auto-shutdown disabled"}
 """
 
-        # Get IAM fleet role
-        fleet_role_arn = get_spot_fleet_role()
-
         # Generate a unique client token
         client_token = f"{WORKFLOW_ID}-{job_id}"
 
-        # Prepare launch specifications for multiple instance types
-        launch_specifications = []
-
-        # Use instance types from job data or default to a set of common types
+        # Use instance types from job data, or the job's single instance type.
+        # Alternatives are not synthesized from the type string: that only works
+        # for single-character families, and produces invalid names like
+        # "mm5a.large" or "c6h.large" for anything else.
         instance_types = job_data.get('instance_types', [])
         if not instance_types:
-            # If no instance types specified, use the job's instance type
             instance_types = [job_data['instance_type']]
-
-            # Add similar instance types for better availability
-            instance_type = job_data['instance_type']
-            if instance_type.startswith(('c', 'm', 'r', 't')) and len(instance_type) > 3:
-                family = instance_type[0]
-                size = instance_type.split('.')[1]
-
-                # Add similar types
-                if family == 'c':
-                    instance_types.extend([f"m{instance_type[1:]}", f"r{instance_type[1:]}"])
-                elif family == 'm':
-                    instance_types.extend([f"c{instance_type[1:]}", f"r{instance_type[1:]}"])
-                elif family == 'r':
-                    instance_types.extend([f"m{instance_type[1:]}", f"c{instance_type[1:]}"])
-
-                # Try to add a newer generation if possible
-                gen = instance_type[1]
-                if gen.isdigit() and int(gen) < 9:
-                    next_gen = str(int(gen) + 1)
-                    instance_types.append(f"{family}{next_gen}.{size}")
 
         # Common tags for all instances
         tags = [
@@ -1007,86 +922,104 @@ export PARSL_WORKER_ID=$(hostname)
             {'Key': 'ParslJobId', 'Value': job_id},
         ]
 
-        # Generate specs for each instance type
-        for instance_type in instance_types:
-            try:
-                launch_spec = {
-                    'ImageId': job_data['image_id'],
-                    'InstanceType': instance_type,
-                    'SubnetId': job_data['subnet_id'],
-                    'SecurityGroups': [
-                        {'GroupId': job_data['security_group_id']}
-                    ],
-                    'UserData': base64.b64encode(user_data.encode()).decode(),
-                    'TagSpecifications': [
-                        {
-                            'ResourceType': 'instance',
-                            'Tags': tags
-                        }
-                    ],
-                    'Monitoring': {'Enabled': True},
-                    'InstanceInitiatedShutdownBehavior': 'terminate',
-                }
-
-                # Add key name if provided
-                if job_data.get('key_name'):
-                    launch_spec['KeyName'] = job_data['key_name']
-
-                launch_specifications.append(launch_spec)
-            except Exception as e:
-                logger.warning(f"Skipping instance type {instance_type} due to error: {e}")
-
-        if not launch_specifications:
-            raise Exception("No valid launch specifications could be created")
-
-        # Prepare Spot Fleet request parameters
-        nodes_per_block = job_data.get('nodes_per_block', 1)
-        request_params = {
-            'SpotFleetRequestConfig': {
-                'ClientToken': client_token,
-                'TargetCapacity': nodes_per_block,
-                'OnDemandTargetCapacity': 0,  # Use only spot instances
-                'IamFleetRole': fleet_role_arn,
-                'LaunchSpecifications': launch_specifications,
-                'TerminateInstancesWithExpiration': True,
-                'Type': 'maintain',  # Maintain target capacity
-                'AllocationStrategy': ALLOCATION_STRATEGY,
-                'ReplaceUnhealthyInstances': True,
-                'TagSpecifications': [
-                    {
-                        'ResourceType': 'spot-fleet-request',
-                        'Tags': tags
-                    }
-                ]
-            }
+        # The launch template is the only launch form CreateFleet accepts, and
+        # the only place the per-job user data can live: an Overrides entry
+        # carries just InstanceType/SubnetId/price/priority.
+        template_data = {
+            'ImageId': job_data['image_id'],
+            'UserData': base64.b64encode(user_data.encode()).decode(),
+            'Monitoring': {'Enabled': True},
+            'InstanceInitiatedShutdownBehavior': 'terminate',
+            'MetadataOptions': METADATA_OPTIONS,
+            'NetworkInterfaces': [{
+                'DeviceIndex': 0,
+                'Groups': [job_data['security_group_id']],
+                'SubnetId': job_data['subnet_id'],
+            }],
+            'TagSpecifications': [{'ResourceType': 'instance', 'Tags': tags}],
         }
+        if job_data.get('key_name'):
+            template_data['KeyName'] = job_data['key_name']
 
-        # Set a max price if specified
+        template_response = ec2.create_launch_template(
+            LaunchTemplateName=f"{TAG_PREFIX}-lt-{job_id[:8]}",
+            LaunchTemplateData=template_data,
+            TagSpecifications=[{'ResourceType': 'launch-template', 'Tags': tags}],
+        )
+        template_id = template_response['LaunchTemplate']['LaunchTemplateId']
+        # Pin the version rather than using $Latest, so the fleet launches the
+        # definition built here even if something else adds a version.
+        template_version = str(
+            template_response['LaunchTemplate']['LatestVersionNumber']
+        )
+
+        spot_options = {
+            'AllocationStrategy': ALLOCATION_STRATEGY,
+            'InstanceInterruptionBehavior': 'terminate',
+        }
+        # MaxTotalPrice is fleet-wide, unlike the legacy per-instance-hour
+        # SpotPrice. AWS advises against setting it at all ("can lead to
+        # increased interruptions"), so it is only sent when asked for.
+        nodes_per_block = job_data.get('nodes_per_block', 1)
         if job_data.get('spot_max_price'):
-            request_params['SpotFleetRequestConfig']['SpotPrice'] = job_data['spot_max_price']
+            spot_options['MaxTotalPrice'] = str(
+                float(job_data['spot_max_price']) * nodes_per_block
+            )
         elif job_data.get('spot_max_price_percentage'):
-            # Convert percentage to actual price (rough approximation)
-            # In practice, you would query the price API for accurate pricing
             percent = float(job_data['spot_max_price_percentage']) / 100.0
-            request_params['SpotFleetRequestConfig']['SpotPrice'] = str(percent)
+            spot_options['MaxTotalPrice'] = str(percent * nodes_per_block)
 
-        # Create the Spot Fleet request
-        response = ec2.request_spot_fleet(**request_params)
-        fleet_request_id = response['SpotFleetRequestId']
-        logger.info(f"Created Spot Fleet request: {fleet_request_id} for job {job_id}")
+        # ReplaceUnhealthyInstances, TerminateInstancesWithExpiration, and
+        # SpotOptions.MaintenanceStrategies are all rejected outright for fleet
+        # type 'instant' -- verified against real EC2 -- so none are sent.
+        response = ec2.create_fleet(
+            Type='instant',
+            ClientToken=client_token,
+            LaunchTemplateConfigs=[{
+                'LaunchTemplateSpecification': {
+                    'LaunchTemplateId': template_id,
+                    'Version': template_version,
+                },
+                'Overrides': [
+                    {'InstanceType': instance_type, 'SubnetId': job_data['subnet_id']}
+                    for instance_type in instance_types
+                ],
+            }],
+            TargetCapacitySpecification={
+                'TotalTargetCapacity': nodes_per_block,
+                'DefaultTargetCapacityType': 'spot',
+            },
+            SpotOptions=spot_options,
+            TagSpecifications=[{'ResourceType': 'fleet', 'Tags': tags}],
+        )
+        fleet_request_id = response['FleetId']
+        logger.info(f"Created EC2 Fleet: {fleet_request_id} for job {job_id}")
 
-        # Wait for Spot Fleet instances to be created
-        logger.info(f"Waiting for Spot Fleet instances for fleet {fleet_request_id}")
-        instance_ids = wait_for_fleet_instances(fleet_request_id)
+        # An instant fleet reports per-instance failures inline rather than
+        # failing the call, so a partly-filled or empty fleet looks like success.
+        for error in response.get('Errors', []):
+            logger.warning(
+                f"EC2 Fleet {fleet_request_id} could not launch an instance: "
+                f"{error.get('ErrorCode')} - {error.get('ErrorMessage')}"
+            )
+
+        instance_ids = [
+            instance_id
+            for entry in response.get('Instances', [])
+            for instance_id in entry.get('InstanceIds', [])
+        ]
 
         if not instance_ids:
             update_job_status(
                 job_id,
                 'FAILED',
                 None,
-                error=f"No instances were created in the Spot Fleet {fleet_request_id}",
+                error=f"No instances were created in EC2 Fleet {fleet_request_id}",
                 fleet_request_id=fleet_request_id
             )
+            # The template is useless without the fleet it was built for, and
+            # nothing else will reclaim it.
+            delete_launch_template(template_id)
             return None
 
         # Update job status with the first instance ID and the fleet request ID
@@ -1102,76 +1035,55 @@ export PARSL_WORKER_ID=$(hostname)
 
         return primary_instance_id
     except Exception as e:
-        logger.error(f"Error creating Spot Fleet for job {job_id}: {e}")
+        logger.error(f"Error creating EC2 Fleet for job {job_id}: {e}")
         traceback.print_exc()
         update_job_status(job_id, 'FAILED', None, error=str(e))
+        if template_id:
+            delete_launch_template(template_id)
         return None
 
-def wait_for_fleet_instances(fleet_request_id, max_wait=300):
-    """Wait for Spot Fleet instances to be created.
+def delete_launch_template(template_id):
+    """Delete a launch template, tolerating one that is already gone."""
+    session = get_session()
+    ec2 = session.client('ec2')
+    try:
+        ec2.delete_launch_template(LaunchTemplateId=template_id)
+        logger.debug(f"Deleted launch template {template_id}")
+    except Exception as e:
+        logger.warning(f"Could not delete launch template {template_id}: {e}")
+
+def get_fleet_instance_ids(fleet_id):
+    """Return the non-terminated instances belonging to an EC2 Fleet.
+
+    Goes through the aws:ec2:fleet-id tag rather than describe_fleet_instances,
+    which refuses a fleet of type 'instant' outright with 'Unsupported'.
 
     Parameters
     ----------
-    fleet_request_id : str
-        Spot Fleet request ID
-    max_wait : int, optional
-        Maximum wait time in seconds, by default 300
+    fleet_id : str
+        Fleet ID
 
     Returns
     -------
     list
-        List of instance IDs
+        Instance IDs
     """
-    start_time = time.time()
-    instance_ids = []
-
     session = get_session()
     ec2 = session.client('ec2')
+    instance_ids = []
 
-    logger.info(f"Waiting for Spot Fleet instances for fleet {fleet_request_id}")
-
-    while time.time() - start_time < max_wait:
-        try:
-            # Check fleet status
-            response = ec2.describe_spot_fleet_requests(
-                SpotFleetRequestIds=[fleet_request_id]
-            )
-
-            if not response['SpotFleetRequestConfigs']:
-                logger.warning(f"No Spot Fleet request found with ID {fleet_request_id}")
-                break
-
-            config = response['SpotFleetRequestConfigs'][0]
-            status = config['SpotFleetRequestState']
-
-            if status == 'active':
-                # Get instances in the fleet
-                instances_response = ec2.describe_spot_fleet_instances(
-                    SpotFleetRequestId=fleet_request_id
-                )
-
-                # Extract instance IDs
-                instance_ids = [instance['InstanceId'] for instance in instances_response.get('ActiveInstances', [])]
-
-                if instance_ids:
-                    logger.info(f"Spot Fleet {fleet_request_id} is active with {len(instance_ids)} instances")
-                    break
-
-            elif status in ['cancelled', 'cancelled_running', 'cancelled_terminating', 'error']:
-                logger.error(f"Spot Fleet request {fleet_request_id} failed with status {status}")
-                break
-
-            # Wait before checking again
-            time.sleep(10)
-
-        except Exception as e:
-            logger.error(f"Error checking Spot Fleet status: {e}")
-            # Continue waiting, might be temporary
-            time.sleep(10)
-
-    # If we've waited too long without success
-    if time.time() - start_time >= max_wait and not instance_ids:
-        logger.error(f"Timeout waiting for Spot Fleet instances for fleet {fleet_request_id}")
+    try:
+        paginator = ec2.get_paginator('describe_instances')
+        for page in paginator.paginate(Filters=[
+            {'Name': f'tag:{TAG_AWS_FLEET_ID}', 'Values': [fleet_id]},
+            {'Name': 'instance-state-name',
+             'Values': ['pending', 'running', 'stopping', 'stopped']},
+        ]):
+            for reservation in page.get('Reservations', []):
+                for instance in reservation.get('Instances', []):
+                    instance_ids.append(instance['InstanceId'])
+    except Exception as e:
+        logger.warning(f"Could not list instances for EC2 Fleet {fleet_id}: {e}")
 
     return instance_ids
 
@@ -1309,39 +1221,44 @@ def update_running_job_status():
                 else:
                     raise
 
-        # Check Spot Fleet statuses if there are any
+        # Check EC2 Fleet statuses if there are any
         fleet_statuses = {}
-        if spot_fleet_jobs:
-            # Get all fleet request IDs
-            fleet_request_ids = list(spot_fleet_jobs.values())
+        for fleet_id in set(spot_fleet_jobs.values()):
+            # One fleet per call. describe_fleets accepts a list, but AWS
+            # documents that "if a fleet is of type instant, you must specify the
+            # fleet ID in the request, otherwise the fleet does not appear in the
+            # response" -- so a partial response cannot be distinguished from a
+            # deleted fleet when several IDs are batched.
+            try:
+                fleets = ec2.describe_fleets(FleetIds=[fleet_id]).get('Fleets', [])
+            except ClientError as e:
+                if 'InvalidFleetId.NotFound' in str(e):
+                    fleet_statuses[fleet_id] = 'COMPLETED'
+                    continue
+                raise
 
-            # Process in batches of 100 (AWS API limit)
-            for i in range(0, len(fleet_request_ids), 100):
-                batch = fleet_request_ids[i:i+100]
-                try:
-                    response = ec2.describe_spot_fleet_requests(SpotFleetRequestIds=batch)
+            if not fleets:
+                fleet_statuses[fleet_id] = 'COMPLETED'
+                continue
 
-                    for config in response.get('SpotFleetRequestConfigs', []):
-                        fleet_id = config['SpotFleetRequestId']
-                        state = config['SpotFleetRequestState']
-
-                        # Map fleet state to job status
-                        if state == 'active':
-                            fleet_statuses[fleet_id] = 'RUNNING'
-                        elif state in ['cancelled', 'cancelled_running', 'cancelled_terminating']:
-                            fleet_statuses[fleet_id] = 'CANCELED'
-                        elif state == 'error':
-                            fleet_statuses[fleet_id] = 'FAILED'
-                        else:
-                            fleet_statuses[fleet_id] = 'UNKNOWN'
-                except ClientError as e:
-                    if 'InvalidSpotFleetRequestId.NotFound' in str(e):
-                        # Mark fleets not found as completed
-                        for fleet_id in batch:
-                            if fleet_id not in fleet_statuses:
-                                fleet_statuses[fleet_id] = 'COMPLETED'
-                    else:
-                        raise
+            state = fleets[0]['FleetState']
+            if state in ['deleted', 'deleted_running', 'deleted_terminating']:
+                fleet_statuses[fleet_id] = 'CANCELED'
+            elif state == 'failed':
+                fleet_statuses[fleet_id] = 'FAILED'
+            elif state in ['submitted', 'modifying']:
+                fleet_statuses[fleet_id] = 'PENDING'
+            elif state == 'active':
+                # An instant fleet does not maintain capacity, so FleetState
+                # stays 'active' for the fleet's whole life no matter what
+                # happened to its instances. Only the instances can say whether
+                # the job is still running.
+                if get_fleet_instance_ids(fleet_id):
+                    fleet_statuses[fleet_id] = 'RUNNING'
+                else:
+                    fleet_statuses[fleet_id] = 'COMPLETED'
+            else:
+                fleet_statuses[fleet_id] = 'UNKNOWN'
 
         # Update job statuses
         for job_id, status_data in running_jobs_data:
@@ -1453,21 +1370,18 @@ def handle_cancel_requests():
                     if e.response['Error']['Code'] != 'ParameterNotFound':
                         raise
 
-            # First cancel Spot Fleet requests
-            if fleet_request_ids:
+            # First delete the EC2 Fleets. Instance termination is not optional
+            # for type 'instant': NoTerminateInstances is rejected, and AWS
+            # states "a deleted instant fleet with running instances is not
+            # supported".
+            for fleet_id in fleet_request_ids:
                 try:
-                    ec2.cancel_spot_fleet_requests(
-                        SpotFleetRequestIds=fleet_request_ids,
-                        TerminateInstances=True
-                    )
-                    logger.info(f"Canceled Spot Fleet requests: {fleet_request_ids}")
+                    ec2.delete_fleets(FleetIds=[fleet_id], TerminateInstances=True)
+                    logger.info(f"Deleted EC2 Fleet: {fleet_id}")
                 except Exception as fleet_error:
-                    logger.error(f"Error canceling Spot Fleet requests: {fleet_error}")
-                    # Continue to terminate any instances we know about
-
-                    # If we have the all_instance_ids, add them to our list
+                    logger.error(f"Error deleting EC2 Fleet {fleet_id}: {fleet_error}")
+                    # Fall back to terminating the instances directly.
                     if all_fleet_instance_ids:
-                        # Remove duplicates
                         unique_ids = set(all_fleet_instance_ids) - set(instance_ids)
                         instance_ids.extend(list(unique_ids))
 
@@ -1535,11 +1449,12 @@ if __name__ == '__main__':
         # package -- the strategy has to be substituted in as a literal. The
         # fleet request used to hardcode 'lowestPrice' here, ignoring the
         # configured spot_allocation_strategy entirely and choosing the pools
-        # with the least spare capacity (#84).
+        # with the least spare capacity (#84). Kebab-case since the script now
+        # calls CreateFleet, which rejects the camelCase spelling (#86).
         script = script.replace(
-            "ALLOCATION_STRATEGY = 'priceCapacityOptimized'",
+            "ALLOCATION_STRATEGY = 'price-capacity-optimized'",
             "ALLOCATION_STRATEGY = "
-            f"'{normalize_spot_fleet_allocation_strategy(self.spot_allocation_strategy)}'"
+            f"'{normalize_ec2_fleet_allocation_strategy(self.spot_allocation_strategy)}'"
             "  # injected at script generation time",
         )
         # Same reason as above: injected as a literal so the workers the bastion
@@ -1859,22 +1774,20 @@ if __name__ == '__main__':
         if active_resources:
             self.cancel_jobs(active_resources)
 
-        # Ensure all Spot Fleet requests are cancelled explicitly
+        # Ensure all fleets are deleted explicitly
         for resource_id in spot_fleet_resources:
             resource = self.resources.get(resource_id)
-            if resource and resource.get("fleet_request_id"):
-                fleet_request_id = resource.get("fleet_request_id")
+            if resource and (fleet_request_id := resource.get("fleet_request_id")):
                 try:
-                    # Cancel the Spot Fleet request and terminate instances
-                    ec2.cancel_spot_fleet_requests(
-                        SpotFleetRequestIds=[fleet_request_id], TerminateInstances=True
-                    )
+                    # Deleting the fleet terminates its instances; that is not
+                    # optional for an instant fleet (#86).
+                    delete_ec2_fleet(ec2, fleet_request_id)
                     logger.info(
-                        f"Explicitly cancelled Spot Fleet request {fleet_request_id} during cleanup"
+                        f"Explicitly deleted EC2 Fleet {fleet_request_id} during cleanup"
                     )
                 except Exception as e:
                     logger.error(
-                        f"Error cancelling Spot Fleet request {fleet_request_id} during cleanup: {e}"
+                        f"Error deleting EC2 Fleet {fleet_request_id} during cleanup: {e}"
                     )
 
         # Now clean up tracking in SSM
@@ -2171,7 +2084,8 @@ if __name__ == '__main__':
                                 "Initializing SpotInterruptionMonitor and Handler after state load"
                             )
                             self.spot_interruption_monitor = SpotInterruptionMonitor(
-                                self.session
+                                self.session,
+                                provider_id=self.provider_id,
                             )
                             self.spot_interruption_handler = (
                                 ParslSpotInterruptionHandler(

--- a/parsl_ephemeral_aws/modes/serverless.py
+++ b/parsl_ephemeral_aws/modes/serverless.py
@@ -9,15 +9,18 @@ SPDX-FileCopyrightText: 2025 Scott Friedman and Project Contributors
 
 import logging
 import time
-import json
 from typing import Any, Dict, List, Optional
 
 import boto3
 from botocore.exceptions import ClientError
 
 from parsl_ephemeral_aws.constants import (
+    DEFAULT_INSTANCE_TYPE,
+    DEFAULT_REGION,
+    LAUNCH_TEMPLATE_NAME_PREFIX,
     RESOURCE_TYPE_LAMBDA_FUNCTION,
     RESOURCE_TYPE_ECS_TASK,
+    RESOURCE_TYPE_SPOT_FLEET,
     WORKER_TYPE_LAMBDA,
     WORKER_TYPE_ECS,
     WORKER_TYPE_AUTO,
@@ -50,7 +53,19 @@ from parsl_ephemeral_aws.compute.spot_interruption import (
     SpotInterruptionMonitor,
     ParslSpotInterruptionHandler,
 )
-from parsl_ephemeral_aws.utils.aws import get_cf_template
+from parsl_ephemeral_aws.utils.aws import (
+    architecture_for_instance_type,
+    build_fleet_launch_template_configs,
+    build_launch_template_data,
+    create_ec2_fleet,
+    create_launch_template,
+    delete_ec2_fleet,
+    delete_launch_template,
+    describe_ec2_fleet,
+    get_cf_template,
+    get_default_ami,
+    get_ec2_fleet_instance_ids,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -288,7 +303,9 @@ class ServerlessMode(OperatingMode):
                 logger.debug(
                     "Initializing SpotInterruptionMonitor and Handler for ServerlessMode"
                 )
-                self.spot_interruption_monitor = SpotInterruptionMonitor(self.session)
+                self.spot_interruption_monitor = SpotInterruptionMonitor(
+                    self.session, provider_id=self.provider_id
+                )
                 self.spot_interruption_handler = ParslSpotInterruptionHandler(
                     session=self.session,
                     checkpoint_bucket=self.checkpoint_bucket,
@@ -687,6 +704,17 @@ class ServerlessMode(OperatingMode):
         """
         logger.debug(f"Submitting job {job_id} to ECS")
 
+        # An EC2 Fleet is created directly rather than through CloudFormation.
+        # CloudFormation cannot express this resource: the override list is
+        # variable-length, and CFN has no way to build one -- Fn::ForEach expands
+        # to a map, and padding a fixed set of !Select slots is rejected by EC2
+        # ("duplicate instance pools"). CreateFleet takes the list natively.
+        # Deploying the stack also created an ECS cluster, task definition, two
+        # IAM roles, and a log group that an EC2 fleet never uses.
+        if self.use_spot_fleet:
+            self._create_job_fleet(job_id, command, resource_id)
+            return
+
         try:
             # Deploy ECS task using CloudFormation
             stack_name = f"parsl-ecs-{job_id[:8]}"
@@ -741,31 +769,7 @@ class ServerlessMode(OperatingMode):
                     },
                     {
                         "ParameterKey": "UseSpot",
-                        "ParameterValue": "true"
-                        if self.use_spot and not self.use_spot_fleet
-                        else "false",
-                    },
-                    {
-                        "ParameterKey": "UseSpotFleet",
-                        "ParameterValue": "true" if self.use_spot_fleet else "false",
-                    },
-                    {
-                        "ParameterKey": "InstanceTypes",
-                        "ParameterValue": json.dumps(self.instance_types)
-                        if self.use_spot_fleet
-                        else "[]",
-                    },
-                    {
-                        "ParameterKey": "NodesPerBlock",
-                        "ParameterValue": str(self.nodes_per_block)
-                        if self.use_spot_fleet
-                        else "1",
-                    },
-                    {
-                        "ParameterKey": "SpotMaxPricePercentage",
-                        "ParameterValue": str(self.spot_max_price_percentage)
-                        if self.spot_max_price_percentage
-                        else "",
+                        "ParameterValue": "true" if self.use_spot else "false",
                     },
                 ],
                 Tags=[
@@ -777,80 +781,13 @@ class ServerlessMode(OperatingMode):
             )
 
             # Store reference to stack in resource data
-            resource_type = RESOURCE_TYPE_ECS_TASK
-            if self.use_spot_fleet:
-                from parsl_ephemeral_aws.constants import RESOURCE_TYPE_SPOT_FLEET
-
-                resource_type = RESOURCE_TYPE_SPOT_FLEET
-
             self.resources[resource_id].update(
                 {
                     "stack_name": stack_name,
-                    "resource_type": resource_type,
-                    "use_spot_fleet": self.use_spot_fleet,
+                    "resource_type": RESOURCE_TYPE_ECS_TASK,
+                    "use_spot_fleet": False,
                 }
             )
-
-            # Register with spot interruption monitor if needed
-            if (
-                self.use_spot_fleet
-                and self.spot_interruption_handling
-                and self.spot_interruption_monitor
-                and self.spot_interruption_handler
-            ):
-                # We need to wait for and fetch the fleet request ID from the outputs
-                start_time = time.time()
-                fleet_request_id = None
-
-                # Wait for up to 3 minutes for stack to create resources
-                while time.time() - start_time < 180 and not fleet_request_id:
-                    try:
-                        # Check if the stack has output values yet
-                        stack_response = self.cf_client.describe_stacks(
-                            StackName=stack_name
-                        )
-                        stack_status = stack_response["Stacks"][0]["StackStatus"]
-
-                        # Only check outputs if stack is complete
-                        if stack_status == "CREATE_COMPLETE":
-                            outputs = stack_response["Stacks"][0].get("Outputs", [])
-
-                            for output in outputs:
-                                if output["OutputKey"] == "SpotFleetRequestId":
-                                    fleet_request_id = output["OutputValue"]
-                                    break
-
-                            if fleet_request_id:
-                                # Save fleet ID in resource data
-                                self.resources[resource_id]["fleet_request_id"] = (
-                                    fleet_request_id
-                                )
-
-                                # Register with interruption monitor
-                                self.spot_interruption_monitor.register_fleet(
-                                    fleet_request_id,
-                                    self.spot_interruption_handler.handle_fleet_interruption,
-                                )
-                                logger.info(
-                                    f"Registered spot fleet {fleet_request_id} for interruption handling"
-                                )
-                                break
-
-                        # If stack is still being created, wait and check again
-                        if "CREATE_IN_PROGRESS" in stack_status:
-                            time.sleep(10)
-                        else:
-                            # If stack has failed or is in any other state, log and break
-                            if stack_status != "CREATE_COMPLETE":
-                                logger.warning(
-                                    f"Stack {stack_name} is in state {stack_status}, not waiting for fleet ID"
-                                )
-                            break
-                    except Exception as e:
-                        logger.error(
-                            f"Error getting spot fleet ID from stack {stack_name}: {e}"
-                        )
-                        break
 
             logger.debug(
                 f"Created CloudFormation stack {stack_name} for ECS job {job_id}"
@@ -882,6 +819,15 @@ class ServerlessMode(OperatingMode):
             resource = self.resources.get(resource_id)
             if not resource:
                 status_map[resource_id] = STATUS_UNKNOWN
+                continue
+
+            # A fleet-backed job has no stack: the fleet is created directly, so
+            # its status comes from the fleet rather than from CloudFormation.
+            fleet_request_id = resource.get("fleet_request_id")
+            if resource.get("use_spot_fleet") and fleet_request_id:
+                status = self._get_spot_fleet_status(fleet_request_id)
+                self.resources[resource_id]["status"] = status
+                status_map[resource_id] = status
                 continue
 
             # Get stack status
@@ -923,36 +869,9 @@ class ServerlessMode(OperatingMode):
                                 status = STATUS_RUNNING
 
                     elif worker_type == WORKER_TYPE_ECS:
-                        # Check if this is a SpotFleet resource
-                        if resource.get("use_spot_fleet"):
-                            # For SpotFleet resources, we need to check the fleet status
-                            outputs = response["Stacks"][0].get("Outputs", [])
-                            fleet_request_id = None
-
-                            for output in outputs:
-                                if output["OutputKey"] == "SpotFleetRequestId":
-                                    fleet_request_id = output["OutputValue"]
-                                    break
-
-                            if fleet_request_id:
-                                # If we haven't stored the fleet_request_id yet, do so
-                                if "fleet_request_id" not in resource:
-                                    self.resources[resource_id]["fleet_request_id"] = (
-                                        fleet_request_id
-                                    )
-                                    from parsl_ephemeral_aws.constants import (
-                                        RESOURCE_TYPE_SPOT_FLEET,
-                                    )
-
-                                    self.resources[resource_id]["resource_type"] = (
-                                        RESOURCE_TYPE_SPOT_FLEET
-                                    )
-
-                                # Check SpotFleet status
-                                status = self._get_spot_fleet_status(fleet_request_id)
-                            else:
-                                status = STATUS_RUNNING
-                        elif self.ecs_manager:
+                        # No fleet branch here: a fleet-backed job never reaches
+                        # this point, having been answered from the fleet above.
+                        if self.ecs_manager:
                             # For standard ECS, we get the cluster and service name from stack outputs
                             outputs = response["Stacks"][0].get("Outputs", [])
                             cluster_name = None
@@ -1044,13 +963,326 @@ class ServerlessMode(OperatingMode):
             # After timeout, assume success (in a real impl, we'd check CloudWatch)
             return STATUS_SUCCEEDED
 
+    def _create_job_fleet(self, job_id: str, command: str, resource_id: str) -> None:
+        """Launch this job's workers as an ``instant`` EC2 Fleet.
+
+        Bypasses CloudFormation, which the fleet used to go through. Two reasons,
+        both established against real AWS:
+
+        * The ``Overrides`` list is variable-length -- one entry per instance type
+          -- and CloudFormation cannot build one. ``Fn::ForEach`` expands to a map
+          rather than a list, and a fixed set of ``!Select`` slots cannot be left
+          partly unfilled because an out-of-range ``!Select`` fails validation even
+          in an untaken ``!If`` branch. Padding the slots by repeating a type is
+          what the previous revision did, and EC2 rejects it outright:
+          ``InvalidFleetConfig: The fleet configuration contains duplicate
+          instance pools``.
+        * The stack's other resources -- an ECS cluster, a task definition, two
+          IAM roles, a log group -- are Fargate machinery that an EC2 fleet never
+          touches, so deploying it to get one fleet created five resources to
+          leak and made the fleet ID reachable only by polling stack outputs.
+
+        The launch template is mandatory: ``CreateFleet`` has no
+        ``LaunchSpecifications`` member, and the per-job user data has nowhere
+        else to live -- ``Overrides`` cannot carry ``UserData``.
+
+        Parameters
+        ----------
+        job_id : str
+            Job this fleet serves; names the launch template.
+        command : str
+            Command the instances run, via user data.
+        resource_id : str
+            Resource record to annotate with the fleet and template IDs.
+
+        Raises
+        ------
+        JobSubmissionError
+            If the template or the fleet cannot be created, or if EC2 filled none
+            of the requested capacity.
+        """
+        ec2_client = self.session.client("ec2")
+        instance_types = self._fleet_instance_types()
+        tags = self._build_fleet_tags(job_id)
+
+        # Restated here rather than relied upon from the ECS guard in
+        # submit_job. Every fleet override names the subnet, so an unset one
+        # reaches CreateFleet as a null and is refused there -- after the launch
+        # template has already been created, leaving it to be cleaned up.
+        if not self.subnet_id:
+            raise JobSubmissionError(
+                "subnet_id is required to launch an EC2 Fleet; every launch "
+                "template override names the subnet to launch into."
+            )
+
+        template_name = f"{LAUNCH_TEMPLATE_NAME_PREFIX}-ecs-{job_id[:8]}"
+        template_id = None
+
+        try:
+            template_data = build_launch_template_data(
+                image_id=self._resolve_fleet_image_id(),
+                instance_type=instance_types[0],
+                subnet_id=self.subnet_id,
+                security_group_id=self.security_group_id,
+                associate_public_ip=self.use_public_ips,
+                # Fleet instances are reclaimed by deleting the fleet, which
+                # always terminates them, so one that shuts itself down should
+                # terminate too rather than linger as a billed volume.
+                shutdown_behavior="terminate",
+                user_data=self._build_fleet_user_data(command),
+            )
+            template_data["TagSpecifications"] = [
+                {"ResourceType": "instance", "Tags": list(tags)}
+            ]
+            template_id, version = create_launch_template(
+                ec2_client, template_name, template_data, list(tags)
+            )
+
+            max_total_price = self._resolve_max_total_price()
+            fleet_id, instance_ids = create_ec2_fleet(
+                ec2_client,
+                build_fleet_launch_template_configs(
+                    template_id, version, instance_types, self.subnet_id
+                ),
+                target_capacity=max(1, self.nodes_per_block),
+                allocation_strategy=self.spot_allocation_strategy,
+                tags=tags,
+                max_total_price=max_total_price or None,
+            )
+        except Exception as e:
+            # The template outlives a failed CreateFleet, so drop it here rather
+            # than leaving a per-job resource behind for the orphan sweep.
+            if template_id:
+                try:
+                    delete_launch_template(ec2_client, template_id)
+                except Exception as cleanup_error:
+                    logger.warning(
+                        f"Failed to delete launch template {template_id} after a "
+                        f"failed fleet submit: {cleanup_error}"
+                    )
+            logger.error(f"Failed to submit fleet job {job_id}: {e}")
+            raise JobSubmissionError(f"Failed to submit fleet job: {e}") from e
+
+        self.resources[resource_id].update(
+            {
+                "resource_type": RESOURCE_TYPE_SPOT_FLEET,
+                "use_spot_fleet": True,
+                "fleet_request_id": fleet_id,
+                "launch_template_id": template_id,
+                "instance_ids": instance_ids,
+                # No stack_name: there is no stack. get_job_status() keys off
+                # this, and cleanup_resources() must not try to delete one.
+            }
+        )
+
+        if not instance_ids:
+            # An instant fleet reports a pool it could not fill inline instead of
+            # failing, so an empty fleet is a successful API call. The fleet is
+            # still deleted, since it holds nothing and will never grow -- an
+            # instant fleet makes no further attempts.
+            try:
+                delete_ec2_fleet(ec2_client, fleet_id)
+            except Exception as e:
+                logger.warning(f"Failed to delete unfilled fleet {fleet_id}: {e}")
+            raise JobSubmissionError(
+                f"EC2 Fleet {fleet_id} launched no instances for job {job_id}; "
+                "no spot capacity was available in any of the requested pools "
+                f"({', '.join(instance_types)})."
+            )
+
+        # Registration is immediate now: the fleet ID comes back from CreateFleet
+        # itself. It used to require polling stack outputs for up to 3 minutes,
+        # during which an interruption would have gone unhandled.
+        if (
+            self.spot_interruption_handling
+            and self.spot_interruption_monitor
+            and self.spot_interruption_handler
+        ):
+            self.spot_interruption_monitor.register_fleet(
+                fleet_id,
+                self.spot_interruption_handler.handle_fleet_interruption,
+            )
+            logger.info(f"Registered EC2 Fleet {fleet_id} for interruption handling")
+
+        logger.info(
+            f"Created EC2 Fleet {fleet_id} with {len(instance_ids)} instance(s) "
+            f"for job {job_id}"
+        )
+
+    def _reclaim_fleet(self, ec2_client: Any, resource: Dict[str, Any]) -> None:
+        """Delete a job's fleet and its launch template.
+
+        Deleting the fleet terminates its instances; that is not optional for an
+        ``instant`` fleet, which AWS refuses to leave running without its fleet
+        (#86). The template is deleted afterwards -- doing so does not affect
+        instances already launched from it, but leaving it behind would strand a
+        per-job resource that only the orphan sweep could find.
+
+        Both steps log rather than raise: this runs from cancellation and cleanup
+        paths, where one unreclaimable resource must not prevent the rest from
+        being reclaimed.
+
+        Parameters
+        ----------
+        ec2_client : Any
+            A boto3 EC2 client.
+        resource : Dict[str, Any]
+            Resource record carrying ``fleet_request_id`` and, optionally,
+            ``launch_template_id``.
+        """
+        fleet_request_id = resource.get("fleet_request_id")
+        if fleet_request_id:
+            try:
+                delete_ec2_fleet(ec2_client, fleet_request_id)
+                logger.info(
+                    f"Deleted EC2 Fleet {fleet_request_id} for job "
+                    f"{resource.get('job_id')}"
+                )
+            except Exception as e:
+                logger.warning(f"Error deleting EC2 Fleet {fleet_request_id}: {e}")
+
+        template_id = resource.get("launch_template_id")
+        if template_id:
+            try:
+                delete_launch_template(ec2_client, template_id)
+            except Exception as e:
+                logger.warning(f"Error deleting launch template {template_id}: {e}")
+
+    def _build_fleet_tags(self, job_id: str) -> List[Dict[str, str]]:
+        """Build the tags applied to a job's fleet, instances, and template.
+
+        The keys match what the orphan sweep looks for, so anything this leaves
+        behind is findable: ``ParslWorkflowId`` is one of
+        ``spot_fleet_cleanup.WORKFLOW_ID_TAG_KEYS``.
+        """
+        return [
+            {"Key": "ParslResource", "Value": "true"},
+            {"Key": "ParslWorkflowId", "Value": self.provider_id},
+            {"Key": "ParslJobId", "Value": job_id},
+            {
+                "Key": "Name",
+                "Value": f"parsl-fleet-{self.provider_id[:8]}-{job_id[:8]}",
+            },
+        ]
+
+    def _build_fleet_user_data(self, command: str) -> str:
+        """Build the user data a fleet instance runs.
+
+        Mirrors what the template's ``UserData`` did, with the command written to
+        a file and executed. ``shutdown -h now`` is deliberate and pairs with the
+        template's ``InstanceInitiatedShutdownBehavior=terminate``: the instance
+        exists to run one command, so it should terminate when that is done
+        instead of idling at full price.
+        """
+        return (
+            "#!/bin/bash\n"
+            'echo "Starting Parsl worker..."\n'
+            "mkdir -p /tmp/parsl\n"
+            f"cat > /tmp/parsl/command.sh <<'PARSL_EOF'\n{command}\nPARSL_EOF\n"
+            "chmod +x /tmp/parsl/command.sh\n"
+            "/tmp/parsl/command.sh\n"
+            'echo "Parsl worker completed."\n'
+            "shutdown -h now\n"
+        )
+
+    def _resolve_fleet_image_id(self) -> str:
+        """Return the AMI the EC2 Fleet's instances should boot.
+
+        Prefers an explicitly configured ``image_id``, otherwise resolves the
+        current Amazon Linux 2023 image for the session's region from AWS's
+        public SSM alias (#83).
+
+        This has to be resolved here rather than in the template: the template's
+        old ``RegionMap`` was never wired to a ``FindInMap``, so its fleet
+        launched with no ``ImageId`` at all and EC2 rejected every request with
+        "Parameter 'amiIdList' cannot be empty" -- confirmed against both fleet
+        APIs. The fleet path in this mode has therefore never worked.
+
+        Returns
+        -------
+        str
+            AMI ID.
+        """
+        if self.image_id:
+            return self.image_id
+
+        region = self.session.region_name or DEFAULT_REGION
+        architecture = architecture_for_instance_type(self.instance_types[0])
+        return get_default_ami(region, architecture, session=self.session)
+
+    def _fleet_instance_types(self) -> List[str]:
+        """Return the instance types the fleet may draw from, deduplicated.
+
+        Order is preserved, since the allocation strategy treats the list as a
+        preference order. Duplicates are dropped because ``CreateFleet`` rejects
+        the request outright when two overrides name the same capacity pool:
+
+            InvalidFleetConfig: The fleet configuration contains duplicate
+            instance pools.
+
+        A ``DryRun`` does *not* catch this -- verified against real EC2, which
+        accepted the identical duplicate-bearing request with ``DryRun=True`` and
+        rejected it without. This is why the fleet is no longer built by
+        CloudFormation at all; see :meth:`_create_job_fleet`.
+
+        Returns
+        -------
+        List[str]
+            Instance types in preference order, each appearing once.
+        """
+        seen: Dict[str, None] = {}
+        for instance_type in self.instance_types:
+            seen.setdefault(instance_type, None)
+        return list(seen) or [DEFAULT_INSTANCE_TYPE]
+
+    def _resolve_max_total_price(self) -> str:
+        """Translate ``spot_max_price_percentage`` into a fleet ``MaxTotalPrice``.
+
+        Returns an empty string when no cap is configured, which is the
+        recommended setting -- AWS: "We do not recommend using this parameter
+        because it can lead to increased interruptions." An uncapped fleet pays
+        the prevailing spot price, already far below on-demand.
+
+        The percentage is of on-demand, which is what the setting has always
+        documented. There is no cheap API for an on-demand price, so the same
+        3x-current-spot proxy that ``SpotFleetManager`` uses is applied here.
+        Unlike the legacy per-instance-hour ``SpotPrice``, ``MaxTotalPrice``
+        covers the whole fleet, so it is multiplied by the node count.
+
+        Returns
+        -------
+        str
+            Fleet-wide hourly maximum in USD, or "" for no cap.
+        """
+        if not self.spot_max_price_percentage:
+            return ""
+
+        try:
+            history = (
+                self.session.client("ec2")
+                .describe_spot_price_history(
+                    InstanceTypes=[self.instance_types[0]],
+                    ProductDescriptions=["Linux/UNIX"],
+                    MaxResults=1,
+                )
+                .get("SpotPriceHistory", [])
+            )
+            current_spot = float(history[0]["SpotPrice"]) if history else 1.0
+            on_demand_price = current_spot * 3
+        except Exception as e:
+            logger.warning(f"Could not read spot price history, assuming $1.00/hr: {e}")
+            on_demand_price = 1.0
+
+        per_instance = on_demand_price * (self.spot_max_price_percentage / 100.0)
+        return str(per_instance * max(1, self.nodes_per_block))
+
     def _get_spot_fleet_status(self, fleet_request_id: str) -> str:
-        """Get the status of a Spot Fleet request.
+        """Get the status of an EC2 Fleet.
 
         Parameters
         ----------
         fleet_request_id : str
-            ID of the Spot Fleet request
+            ID of the EC2 Fleet
 
         Returns
         -------
@@ -1060,60 +1292,42 @@ class ServerlessMode(OperatingMode):
         ec2_client = self.session.client("ec2")
 
         try:
-            # Get Spot Fleet request details
-            response = ec2_client.describe_spot_fleet_requests(
-                SpotFleetRequestIds=[fleet_request_id]
-            )
+            fleet = describe_ec2_fleet(ec2_client, fleet_request_id)
+            if fleet is None:
+                # EC2 has forgotten the fleet, so its instances are long gone.
+                # Terminal, so Parsl can free the block.
+                return STATUS_COMPLETED
 
-            if not response.get("SpotFleetRequestConfigs"):
-                return STATUS_UNKNOWN
+            fleet_status = fleet["FleetState"]
 
-            fleet_config = response["SpotFleetRequestConfigs"][0]
-            fleet_status = fleet_config["SpotFleetRequestState"]
-
-            # Map fleet status to Parsl status
-            if fleet_status == "submitted":
+            if fleet_status in ("submitted", "modifying"):
                 return STATUS_PENDING
             elif fleet_status == "active":
-                # Check if target capacity is fulfilled. Both capacities live in
-                # the nested SpotFleetRequestConfig; the entry itself carries only
-                # ActivityStatus/CreateTime/SpotFleetRequestConfig/
-                # SpotFleetRequestId/SpotFleetRequestState/Tags. Reading
-                # FulfilledCapacity from the top level always yielded the 0
-                # default, so `0 >= target_capacity` was false for any capacity
-                # >= 1 and a fully provisioned fleet reported PENDING forever --
-                # never terminal, so Parsl polled it and never freed the block
-                # (#114).
-                config_data = fleet_config.get("SpotFleetRequestConfig", {})
-                fulfilled_capacity = config_data.get("FulfilledCapacity", 0)
-                target_capacity = config_data.get("TargetCapacity", 0)
-
-                if fulfilled_capacity >= target_capacity:
-                    # All requested instances are running
-                    # To determine if job is complete, ideally we'd check instance status
-                    # For now, we assume running
+                # An instant fleet does not maintain capacity, so FleetState
+                # stays "active" for the fleet's whole life regardless of what
+                # became of its instances. Capacity counters cannot decide this
+                # either: they reflect the original launch. Only the instances
+                # can, so ask them.
+                #
+                # The capacity comparison this replaced was also the site of
+                # #114: FulfilledCapacity was read from the wrong nesting level
+                # and always came back 0, so a fully provisioned fleet reported
+                # PENDING forever and Parsl never freed the block.
+                if get_ec2_fleet_instance_ids(ec2_client, fleet_request_id):
                     return STATUS_RUNNING
-                else:
-                    # Still waiting for instances
-                    return STATUS_PENDING
-            elif fleet_status == "cancelled_running":
-                # Fleet is being cancelled but instances still running
+                return STATUS_COMPLETED
+            elif fleet_status == "deleted_running":
+                # Fleet is being deleted but instances are still running
                 return STATUS_RUNNING
-            elif fleet_status == "cancelled_terminating":
-                # Fleet is cancelled and instances are terminating
-                return STATUS_CANCELLED
-            elif fleet_status == "cancelled":
-                # Fleet is fully cancelled
+            elif fleet_status in ("deleted", "deleted_terminating"):
                 return STATUS_CANCELLED
             elif fleet_status == "failed":
                 return STATUS_FAILED
-            elif fleet_status == "modify_in_progress":
-                return STATUS_RUNNING
             else:
                 return STATUS_UNKNOWN
 
         except Exception as e:
-            logger.error(f"Error getting Spot Fleet status for {fleet_request_id}: {e}")
+            logger.error(f"Error getting EC2 Fleet status for {fleet_request_id}: {e}")
             return STATUS_UNKNOWN
 
     def _get_ecs_status(self, cluster_name: str, service_name: str) -> str:
@@ -1236,6 +1450,15 @@ class ServerlessMode(OperatingMode):
                 cancel_map[resource_id] = STATUS_UNKNOWN
                 continue
 
+            # A fleet-backed job has no stack; deleting the fleet *is* the
+            # cancellation. Handled before the stack_name check below, which
+            # would otherwise report UNKNOWN and leave the instances running.
+            if resource.get("resource_type") == RESOURCE_TYPE_SPOT_FLEET:
+                self._reclaim_fleet(ec2_client, resource)
+                self.resources[resource_id]["status"] = STATUS_CANCELLED
+                cancel_map[resource_id] = STATUS_CANCELLED
+                continue
+
             # Get stack name
             stack_name = resource.get("stack_name")
             if not stack_name:
@@ -1243,29 +1466,7 @@ class ServerlessMode(OperatingMode):
                 continue
 
             try:
-                # Check if this is a SpotFleet resource and handle it specially
-                from parsl_ephemeral_aws.constants import RESOURCE_TYPE_SPOT_FLEET
-
-                if resource.get(
-                    "resource_type"
-                ) == RESOURCE_TYPE_SPOT_FLEET and resource.get("fleet_request_id"):
-                    fleet_request_id = resource.get("fleet_request_id")
-
-                    # Cancel the Spot Fleet request directly for immediate termination
-                    try:
-                        ec2_client.cancel_spot_fleet_requests(
-                            SpotFleetRequestIds=[fleet_request_id],
-                            TerminateInstances=True,
-                        )
-                        logger.info(
-                            f"Cancelled Spot Fleet request {fleet_request_id} for job {resource.get('job_id')}"
-                        )
-                    except Exception as e:
-                        logger.warning(
-                            f"Error cancelling Spot Fleet request {fleet_request_id}: {e}"
-                        )
-
-                # Always delete the CloudFormation stack to cancel the job
+                # Delete the CloudFormation stack to cancel the job
                 self.cf_client.delete_stack(StackName=stack_name)
 
                 # Mark as cancelled
@@ -1316,6 +1517,15 @@ class ServerlessMode(OperatingMode):
             # Drop the staged Lambda deployment package, if any. Done before the
             # stack delete so the object goes even when the stack is already gone.
             self._delete_staged_lambda_code(resource)
+
+            # A fleet-backed job has no stack, so it has to be reclaimed here.
+            # Falling through to the stack_name check below would delete the
+            # tracking record and leave the fleet's instances running with
+            # nothing left that knows their IDs.
+            if resource.get("resource_type") == RESOURCE_TYPE_SPOT_FLEET:
+                self._reclaim_fleet(self.session.client("ec2"), resource)
+                del self.resources[resource_id]
+                continue
 
             # Get stack name
             stack_name = resource.get("stack_name")
@@ -1442,10 +1652,9 @@ class ServerlessMode(OperatingMode):
             except Exception as e:
                 logger.error(f"Error cleaning up ECS manager resources: {e}")
 
-        # Cleanup SpotFleet resources if needed
+        # Sweep any fleet resources the per-job stack deletes missed.
         if self.use_spot_fleet:
             try:
-                # Import and use SpotFleet cleanup utility
                 from parsl_ephemeral_aws.compute.spot_fleet_cleanup import (
                     cleanup_all_spot_fleet_resources,
                 )
@@ -1459,10 +1668,16 @@ class ServerlessMode(OperatingMode):
 
                 # Log cleanup results
                 if cleanup_result:
-                    # Log successful operations
+                    if cleanup_result.get("deleted_fleets"):
+                        logger.info(
+                            f"Deleted {len(cleanup_result['deleted_fleets'])} EC2 Fleets"
+                        )
+
+                    # Only non-empty for a workflow that predates #86.
                     if cleanup_result.get("cancelled_requests"):
                         logger.info(
-                            f"Cancelled {len(cleanup_result['cancelled_requests'])} SpotFleet requests"
+                            f"Cancelled {len(cleanup_result['cancelled_requests'])} "
+                            "legacy Spot Fleet requests"
                         )
 
                     if cleanup_result.get("cleaned_roles"):
@@ -1473,9 +1688,9 @@ class ServerlessMode(OperatingMode):
                     # Log errors
                     if cleanup_result.get("errors"):
                         for error in cleanup_result["errors"]:
-                            logger.warning(f"SpotFleet cleanup error: {error}")
+                            logger.warning(f"Fleet cleanup error: {error}")
             except Exception as e:
-                logger.error(f"Error cleaning up SpotFleet resources: {e}")
+                logger.error(f"Error cleaning up fleet resources: {e}")
 
         # Clear initialization flag
         self.initialized = False
@@ -1527,8 +1742,10 @@ class ServerlessMode(OperatingMode):
                             "job_name": resource.get("job_name"),
                             "status": resource.get("status"),
                             "created_at": resource.get("created_at"),
-                            "stack_name": resource.get("stack_name"),
+                            # No stack_name: a fleet is created directly (#86).
                             "fleet_request_id": resource.get("fleet_request_id"),
+                            "launch_template_id": resource.get("launch_template_id"),
+                            "instance_ids": resource.get("instance_ids", []),
                         }
                     )
                 else:
@@ -1650,7 +1867,8 @@ class ServerlessMode(OperatingMode):
                                 "Initializing SpotInterruptionMonitor and Handler after state load"
                             )
                             self.spot_interruption_monitor = SpotInterruptionMonitor(
-                                self.session
+                                self.session,
+                                provider_id=self.provider_id,
                             )
                             self.spot_interruption_handler = (
                                 ParslSpotInterruptionHandler(

--- a/parsl_ephemeral_aws/modes/standard.py
+++ b/parsl_ephemeral_aws/modes/standard.py
@@ -17,6 +17,7 @@ import boto3
 from botocore.exceptions import ClientError
 
 from parsl_ephemeral_aws.constants import (
+    DEFAULT_RESOURCE_CREATION_TIMEOUT,
     DEFAULT_SPOT_ALLOCATION_STRATEGY,
     EC2_STATUS_MAPPING,
     IMDSV2_METADATA_OPTIONS,
@@ -275,7 +276,9 @@ class StandardMode(OperatingMode):
                 )
             else:
                 logger.debug("Initializing SpotInterruptionMonitor and Handler")
-                self.spot_interruption_monitor = SpotInterruptionMonitor(self.session)
+                self.spot_interruption_monitor = SpotInterruptionMonitor(
+                    self.session, provider_id=self.provider_id
+                )
                 self.spot_interruption_handler = ParslSpotInterruptionHandler(
                     session=self.session,
                     checkpoint_bucket=self.checkpoint_bucket,
@@ -669,7 +672,8 @@ class StandardMode(OperatingMode):
                                 "Initializing SpotInterruptionMonitor and Handler after state load"
                             )
                             self.spot_interruption_monitor = SpotInterruptionMonitor(
-                                self.session
+                                self.session,
+                                provider_id=self.provider_id,
                             )
                             self.spot_interruption_handler = (
                                 ParslSpotInterruptionHandler(
@@ -716,25 +720,28 @@ class StandardMode(OperatingMode):
                         f"Loaded SpotFleetManager state with {len(self.spot_fleet_manager.blocks)} blocks"
                     )
 
-                    # Re-register spot fleets with interruption monitor if needed
+                    # Re-register fleets with the interruption monitor. Reads the
+                    # block's "fleet_request_id", which is the key the manager
+                    # actually writes; this used to iterate a "fleet_requests"
+                    # list that nothing has ever produced, so a resumed workflow
+                    # silently monitored none of its fleets.
                     if (
                         self.spot_interruption_handling
                         and self.spot_interruption_monitor
                         and self.spot_interruption_handler
                     ):
-                        for (
-                            block_id,
-                            block_data,
-                        ) in self.spot_fleet_manager.blocks.items():
-                            fleet_requests = block_data.get("fleet_requests", [])
-                            for fleet_request_id in fleet_requests:
-                                self.spot_interruption_monitor.register_fleet(
-                                    fleet_request_id,
-                                    self.spot_interruption_handler.handle_fleet_interruption,
-                                )
-                                logger.info(
-                                    f"Re-registered spot fleet {fleet_request_id} for interruption handling"
-                                )
+                        for block_data in self.spot_fleet_manager.blocks.values():
+                            fleet_id = block_data.get("fleet_request_id")
+                            if not fleet_id:
+                                continue
+                            self.spot_interruption_monitor.register_fleet(
+                                fleet_id,
+                                self.spot_interruption_handler.handle_fleet_interruption,
+                            )
+                            logger.info(
+                                f"Re-registered EC2 Fleet {fleet_id} for "
+                                "interruption handling"
+                            )
 
                 logger.debug(f"Loaded state with {len(self.resources)} resources")
                 return True
@@ -1603,68 +1610,99 @@ class StandardMode(OperatingMode):
             # Get the block ID (should be only one)
             block_id = next(iter(blocks.keys()))
 
-            logger.info(f"Created Spot Fleet block {block_id} for job {job_id}")
+            logger.info(f"Created EC2 Fleet block {block_id} for job {job_id}")
 
-            # Wait for block to be running
-            max_wait = 300  # 5 minutes
+            # An instant fleet reports fulfilment synchronously, so a block with
+            # no instances means EC2 could not fill the request at all -- fail
+            # now rather than after a timeout (#86).
+            if not blocks[block_id].get("instance_ids"):
+                self._discard_failed_fleet_block(block_id)
+                raise ResourceCreationError(
+                    f"EC2 Fleet block {block_id} launched no instances; no spot "
+                    "capacity was available for the requested instance types"
+                )
+
+            # The instances exist but have yet to reach "running". This wait now
+            # covers only that transition -- fulfilment was settled synchronously
+            # above -- so a timeout here no longer conflates "no spot capacity"
+            # with "slow to boot".
+            max_wait = DEFAULT_RESOURCE_CREATION_TIMEOUT
             start_time = time.time()
 
             while time.time() - start_time < max_wait:
                 status = self.spot_fleet_manager.get_block_status(block_id)
-                logger.debug(f"Spot Fleet block {block_id} status: {status}")
+                logger.debug(f"EC2 Fleet block {block_id} status: {status}")
 
                 if status == STATUS_RUNNING:
                     break
                 elif status in [STATUS_FAILED, STATUS_CANCELED, STATUS_COMPLETED]:
+                    self._discard_failed_fleet_block(block_id)
                     raise ResourceCreationError(
-                        f"Spot Fleet block failed with status {status}"
+                        f"EC2 Fleet block failed with status {status}"
                     )
 
                 time.sleep(10)
-
-            if time.time() - start_time >= max_wait:
+            else:
                 logger.error(
-                    f"Timeout waiting for Spot Fleet block {block_id} to reach RUNNING"
+                    f"Timeout waiting for EC2 Fleet block {block_id} to reach RUNNING"
                 )
-                try:
-                    self.spot_fleet_manager.terminate_block(block_id)
-                    self.blocks.pop(block_id, None)
-                except Exception as cleanup_err:
-                    logger.error(
-                        f"Failed to clean up timed-out fleet block {block_id}: {cleanup_err}"
-                    )
+                self._discard_failed_fleet_block(block_id)
                 raise ResourceCreationError(
-                    f"Spot Fleet block {block_id} did not reach RUNNING "
+                    f"EC2 Fleet block {block_id} did not reach RUNNING "
                     f"state within {max_wait}s"
                 )
 
-            # Register spot fleet with spot interruption monitor if enabled
+            # Register the fleet with the spot interruption monitor if enabled.
+            # The block records a single "fleet_request_id"; this used to read a
+            # "fleet_requests" list that no code has ever written, so no fleet
+            # was ever actually registered.
             if (
                 self.spot_interruption_handling
                 and self.spot_interruption_monitor
                 and self.spot_interruption_handler
             ):
-                # Get fleet instances
-                fleet_requests = self.spot_fleet_manager.blocks.get(block_id, {}).get(
-                    "fleet_requests", []
+                fleet_id = self.spot_fleet_manager.blocks.get(block_id, {}).get(
+                    "fleet_request_id"
                 )
-                for fleet_request_id in fleet_requests:
+                if fleet_id:
                     self.spot_interruption_monitor.register_fleet(
-                        fleet_request_id,
+                        fleet_id,
                         self.spot_interruption_handler.handle_fleet_interruption,
                     )
                     logger.info(
-                        f"Registered spot fleet {fleet_request_id} for interruption handling"
+                        f"Registered EC2 Fleet {fleet_id} for interruption handling"
                     )
 
             return block_id
 
         except SpotFleetError as e:
-            logger.error(f"Failed to create Spot Fleet: {e}")
+            logger.error(f"Failed to create EC2 Fleet: {e}")
             raise
         except Exception as e:
-            logger.error(f"Unexpected error creating Spot Fleet: {e}")
-            raise ResourceCreationError(f"Failed to create Spot Fleet: {e}") from e
+            logger.error(f"Unexpected error creating EC2 Fleet: {e}")
+            raise ResourceCreationError(f"Failed to create EC2 Fleet: {e}") from e
+
+    def _discard_failed_fleet_block(self, block_id: str) -> None:
+        """Tear down a fleet block that will never become usable.
+
+        Deletes the fleet, terminating any instances it did launch, and drops the
+        manager's record of the block so a later ``cleanup_all_resources`` does
+        not report a fleet that is already gone. Never raises: the caller is
+        already on its way to raising something more informative.
+
+        Parameters
+        ----------
+        block_id : str
+            Block to discard.
+        """
+        if not self.spot_fleet_manager:
+            return
+        try:
+            self.spot_fleet_manager.terminate_block(block_id)
+        except Exception as e:
+            logger.error(f"Failed to clean up failed fleet block {block_id}: {e}")
+        finally:
+            self.spot_fleet_manager.blocks.pop(block_id, None)
 
     def get_job_status(self, resource_ids: List[str]) -> Dict[str, str]:
         """Get the status of jobs.

--- a/parsl_ephemeral_aws/provider.py
+++ b/parsl_ephemeral_aws/provider.py
@@ -34,6 +34,7 @@ from parsl_ephemeral_aws.constants import (
     DEFAULT_WARM_POOL_SIZE,
     DEFAULT_WARM_POOL_TTL,
     DEFAULT_WORKER_INIT,
+    MAX_WARM_POOL_SIZE,
     STATUS_WARM,
 )
 from parsl_ephemeral_aws.exceptions import (
@@ -218,9 +219,21 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
         Requires ``auto_create_instance_profile=True`` or
         ``iam_instance_profile_arn`` (SSM SendCommand needs an IAM role).
         Default is 0 (disabled).  ``mode="standard"`` only.
+
+        **This costs money while idle.** A warm instance is left *Running*, not
+        Stopped, so it bills at the full instance rate for up to
+        ``warm_pool_ttl`` seconds after its job finishes — ``warm_pool_size``
+        instances × ``warm_pool_ttl`` seconds of instance time per idle period,
+        whether or not another job ever arrives to use them. Capped at
+        ``MAX_WARM_POOL_SIZE`` (20). Instances must stay Running because
+        dispatch is SSM ``SendCommand`` and a Stopped instance runs no SSM
+        agent; issue #130 tracks moving to a pull model so the pool can be
+        Stopped instead.
     warm_pool_ttl : int, optional
-        Seconds a warm idle instance stays alive before being terminated.
-        Default is 600 (10 minutes).  ``mode="standard"`` only.
+        Seconds a warm *running* instance stays alive before being terminated.
+        Default is 120 (2 minutes); this was 600 in v0.6.0 and was reduced
+        because the instance bills for the whole window.  ``mode="standard"``
+        only.
     bake_ami : bool, optional
         When True, run ``worker_init`` on a builder instance during
         ``initialize()``, snapshot it into a custom AMI, and use that AMI for
@@ -437,6 +450,39 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
                 "The option would be silently ignored by the mode while the "
                 "provider still acted on it, leaking instances that no mode "
                 "would clean up."
+            )
+
+        # Guard: cap the warm pool. Every warm instance is a *running* instance,
+        # billing for up to warm_pool_ttl seconds after its job ends, so an
+        # oversized pool is a silent cost rather than an error -- EC2 refuses
+        # nothing and no quota is necessarily reached.
+        if warm_pool_size < 0:
+            raise ValueError(
+                f"warm_pool_size must be >= 0, got {warm_pool_size} "
+                "(0 disables the warm pool)"
+            )
+        if warm_pool_size > MAX_WARM_POOL_SIZE:
+            raise ValueError(
+                f"warm_pool_size={warm_pool_size} exceeds the maximum of "
+                f"{MAX_WARM_POOL_SIZE}. Warm instances are held Running, not "
+                "Stopped, so each one bills at the full instance rate for up to "
+                "warm_pool_ttl seconds per idle period. If you need more than "
+                f"{MAX_WARM_POOL_SIZE} instances ready, raise init_blocks "
+                "instead so they are actually running work."
+            )
+        if warm_pool_ttl < 0:
+            raise ValueError(f"warm_pool_ttl must be >= 0, got {warm_pool_ttl}")
+
+        # A warm pool is a cost the caller may not have registered from the
+        # kwarg name alone, so state it once at construction with the actual
+        # numbers rather than only in the docstring.
+        if warm_pool_size > 0:
+            logger.warning(
+                f"Warm pool enabled: up to {warm_pool_size} instance(s) will be "
+                f"left RUNNING for {warm_pool_ttl}s after each job completes, "
+                f"billing for that whole window even when idle (up to "
+                f"{warm_pool_size * warm_pool_ttl}s of instance time per idle "
+                "period). Set warm_pool_size=0 to disable."
             )
 
         # Guard: one_shot is incompatible with warm pool (instances are terminated immediately)

--- a/parsl_ephemeral_aws/templates/cloudformation/bastion.yml
+++ b/parsl_ephemeral_aws/templates/cloudformation/bastion.yml
@@ -122,19 +122,61 @@ Resources:
       Roles:
         - !Ref BastionHostRole
 
+  # A single template serves both the on-demand and the spot bastion. The spot
+  # variant differs only by InstanceMarketOptions, which AWS::EC2::Instance does
+  # not accept directly -- verified against the resource schema -- but which a
+  # launch template does, and an Instance referencing that template launches as
+  # spot. That replaces the AWS::EC2::SpotFleet resource this template used to
+  # carry for the spot case (#86), which is on an API AWS describes as legacy and
+  # which needed a service role the template never correctly provided.
+  #
+  # IMDSv2 is required here for the same reason as on every other launch path
+  # (#85): the bastion holds an IAM role that can terminate instances.
+  BastionLaunchTemplate:
+    Type: AWS::EC2::LaunchTemplate
+    Properties:
+      LaunchTemplateName: !Sub 'parsl-bastion-lt-${WorkflowId}'
+      LaunchTemplateData:
+        InstanceType: !Ref InstanceType
+        ImageId: !Ref ImageId
+        IamInstanceProfile:
+          Arn: !GetAtt BastionHostInstanceProfile.Arn
+        KeyName: !If [HasKeyName, !Ref KeyName, !Ref 'AWS::NoValue']
+        UserData: !If [HasUserData, !Ref UserData, !Ref 'AWS::NoValue']
+        InstanceInitiatedShutdownBehavior: terminate
+        Monitoring:
+          Enabled: true
+        MetadataOptions:
+          HttpTokens: required
+          HttpEndpoint: enabled
+        InstanceMarketOptions: !If
+          - UseSpot
+          - MarketType: spot
+            SpotOptions:
+              SpotInstanceType: one-time
+              InstanceInterruptionBehavior: terminate
+              MaxPrice: !If
+                - HasSpotMaxPrice
+                - !Ref SpotMaxPrice
+                - !Ref 'AWS::NoValue'
+          - !Ref 'AWS::NoValue'
+      TagSpecifications:
+        - ResourceType: launch-template
+          Tags:
+            - Key: ParslResource
+              Value: 'true'
+            - Key: ParslWorkflowId
+              Value: !Ref WorkflowId
+
   BastionHost:
     Type: AWS::EC2::Instance
     Properties:
-      InstanceType: !Ref InstanceType
-      ImageId: !Ref ImageId
+      LaunchTemplate:
+        LaunchTemplateId: !Ref BastionLaunchTemplate
+        Version: !GetAtt BastionLaunchTemplate.LatestVersionNumber
       SubnetId: !Ref SubnetId
       SecurityGroupIds:
         - !Ref SecurityGroupId
-      IamInstanceProfile: !Ref BastionHostInstanceProfile
-      KeyName: !If [HasKeyName, !Ref KeyName, !Ref 'AWS::NoValue']
-      UserData: !If [HasUserData, !Ref UserData, !Ref 'AWS::NoValue']
-      InstanceInitiatedShutdownBehavior: terminate
-      Monitoring: true
       Tags:
         - Key: Name
           Value: !Sub 'parsl-bastion-${WorkflowId}'
@@ -147,47 +189,10 @@ Resources:
         - Key: ParslIdleTimeout
           Value: !Ref IdleTimeout
 
-  SpotBastionHost:
-    Type: AWS::EC2::SpotFleet
-    Condition: UseSpot
-    Properties:
-      SpotFleetRequestConfigData:
-        IamFleetRole: !GetAtt BastionHostRole.Arn
-        AllocationStrategy: lowestPrice
-        TargetCapacity: 1
-        SpotPrice: !If [HasSpotMaxPrice, !Ref SpotMaxPrice, !Ref 'AWS::NoValue']
-        TerminateInstancesWithExpiration: true
-        Type: maintain
-        LaunchSpecifications:
-          - InstanceType: !Ref InstanceType
-            ImageId: !Ref ImageId
-            SubnetId: !Ref SubnetId
-            SecurityGroups:
-              - GroupId: !Ref SecurityGroupId
-            IamInstanceProfile:
-              Arn: !GetAtt BastionHostInstanceProfile.Arn
-            KeyName: !If [HasKeyName, !Ref KeyName, !Ref 'AWS::NoValue']
-            UserData: !If [HasUserData, !Ref UserData, !Ref 'AWS::NoValue']
-            Monitoring:
-              Enabled: true
-            TagSpecifications:
-              - ResourceType: instance
-                Tags:
-                  - Key: Name
-                    Value: !Sub 'parsl-bastion-spot-${WorkflowId}'
-                  - Key: ParslResource
-                    Value: 'true'
-                  - Key: ParslWorkflowId
-                    Value: !Ref WorkflowId
-                  - Key: ParslResourceType
-                    Value: 'bastion'
-                  - Key: ParslIdleTimeout
-                    Value: !Ref IdleTimeout
-
 Outputs:
   BastionHostId:
     Description: ID of the bastion host
-    Value: !If [UseSpot, !Ref SpotBastionHost, !Ref BastionHost]
+    Value: !Ref BastionHost
 
   BastionHostRole:
     Description: IAM role for the bastion host

--- a/parsl_ephemeral_aws/templates/cloudformation/ecs_worker.yml
+++ b/parsl_ephemeral_aws/templates/cloudformation/ecs_worker.yml
@@ -1,38 +1,9 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: 'Parsl Ephemeral AWS Provider - ECS/Fargate Worker Resources'
 
-Mappings:
-  RegionMap:
-    us-east-1:
-      AMI: ami-0c55b159cbfafe1f0
-    us-east-2:
-      AMI: ami-002068ed284fb165b
-    us-west-1:
-      AMI: ami-0d382e80be7ffdae5
-    us-west-2:
-      AMI: ami-0a634ae95e11c6f91
-    eu-west-1:
-      AMI: ami-0860a63209d7da3d6
-    eu-west-2:
-      AMI: ami-0bca7a6ffed76bcca
-    eu-west-3:
-      AMI: ami-068a45d114884a8fe
-    eu-central-1:
-      AMI: ami-076431be45f8fcbf8
-    ap-northeast-1:
-      AMI: ami-0318ecd6d05daa212
-    ap-northeast-2:
-      AMI: ami-0a10b2721688ce9d2
-    ap-southeast-1:
-      AMI: ami-0d728fd4e52be968f
-    ap-southeast-2:
-      AMI: ami-075a72b1992cb0687
-    ap-south-1:
-      AMI: ami-0ebc1ac48dfd14136
-    ca-central-1:
-      AMI: ami-0b8cfb6b86d697313
-    sa-east-1:
-      AMI: ami-0b032e878a66c3b68
+# The RegionMap that used to sit here was dead: no FindInMap referenced it
+# anywhere, and its AMIs dated from a Python 3.9 era. The EC2 path now takes an
+# ImageId parameter, which the caller resolves from SSM (#83).
 
 Parameters:
   ClusterName:
@@ -48,7 +19,7 @@ Parameters:
   ContainerImage:
     Type: String
     Description: Docker image for the container
-    Default: 'python:3.9-slim'
+    Default: 'python:3.12-slim'
 
   TaskCpu:
     Type: Number
@@ -128,30 +99,6 @@ Parameters:
       - 'true'
       - 'false'
 
-  UseSpotFleet:
-    Type: String
-    Description: Whether to use EC2 Spot Fleet instead of Fargate/Fargate Spot
-    Default: 'false'
-    AllowedValues:
-      - 'true'
-      - 'false'
-
-  InstanceTypes:
-    Type: String
-    Description: JSON-encoded list of instance types to use with Spot Fleet
-    Default: '[]'
-
-  NodesPerBlock:
-    Type: Number
-    Description: Number of nodes per block for Spot Fleet
-    Default: 1
-    MinValue: 1
-
-  SpotMaxPricePercentage:
-    Type: String
-    Description: Maximum spot price as percentage of on-demand price (empty for on-demand max)
-    Default: ''
-
   Tags:
     Type: String
     Description: JSON encoded tags to apply to resources
@@ -161,12 +108,8 @@ Conditions:
   HasVpcConfig: !Not [!Equals [!Ref VpcId, '']]
   HasCommand: !Not [!Equals [!Ref Command, '']]
   UseFargateSpot: !Equals [!Ref UseSpot, 'true']
-  UseSpotFleet: !Equals [!Ref UseSpotFleet, 'true']
   HasClusterName: !Not [!Equals [!Ref ClusterName, '']]
   HasTaskFamily: !Not [!Equals [!Ref TaskFamily, '']]
-  HasSpotMaxPrice: !Not [!Equals [!Ref SpotMaxPricePercentage, '']]
-  UseFargate: !Not [!Condition UseSpotFleet]
-  AssignPublicIpEnabled: !Equals [!Ref AssignPublicIp, 'ENABLED']
 
 Resources:
   ECSCluster:
@@ -226,27 +169,10 @@ Resources:
         - Key: ParslJobId
           Value: !Ref JobId
 
-  SpotFleetRole:
-    Type: AWS::IAM::Role
-    Condition: UseSpotFleet
-    Properties:
-      RoleName: !Sub 'parsl-aws-spot-fleet-role-${WorkflowId}-${JobId}'
-      AssumeRolePolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service: spotfleet.amazonaws.com
-            Action: sts:AssumeRole
-      ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
-      Tags:
-        - Key: ParslResource
-          Value: 'true'
-        - Key: ParslWorkflowId
-          Value: !Ref WorkflowId
-        - Key: ParslJobId
-          Value: !Ref JobId
+  # The SpotFleetRole that used to live here is gone with the API it served:
+  # CreateFleet has no IamFleetRole member, so an EC2 Fleet needs no service
+  # role at all (#86). Its name also carried the prefix the orphan sweep did not
+  # know about, so every one it made was leaked.
 
   LogGroup:
     Type: AWS::Logs::LogGroup
@@ -296,7 +222,6 @@ Resources:
 
   ECSService:
     Type: AWS::ECS::Service
-    Condition: UseFargate
     Properties:
       Cluster: !Ref ECSCluster
       TaskDefinition: !Ref TaskDefinition
@@ -320,86 +245,24 @@ Resources:
         - Key: ParslJobId
           Value: !Ref JobId
 
-
-  SpotFleetRequest:
-    Type: AWS::EC2::SpotFleet
-    Condition: UseSpotFleet
-    Properties:
-      SpotFleetRequestConfigData:
-        AllocationStrategy: diversified
-        IamFleetRole: !GetAtt SpotFleetRole.Arn
-        TargetCapacity: !Ref NodesPerBlock
-        TerminateInstancesWithExpiration: true
-        Type: maintain
-        ReplaceUnhealthyInstances: true
-        InstanceInterruptionBehavior: terminate
-        LaunchTemplateConfigs:
-          - LaunchTemplateSpecification:
-              LaunchTemplateId: !Ref SpotFleetLaunchTemplate
-              Version: !GetAtt SpotFleetLaunchTemplate.LatestVersionNumber
-            Overrides:
-              - InstanceType: t3.small
-                SubnetId: !Select [0, !Ref SubnetIds]
-              - InstanceType: t3a.small
-                SubnetId: !Select [0, !Ref SubnetIds]
-              - InstanceType: t3.medium
-                SubnetId: !Select [0, !Ref SubnetIds]
-              - InstanceType: t3a.medium
-                SubnetId: !Select [0, !Ref SubnetIds]
-              - InstanceType: m5.large
-                SubnetId: !Select [0, !Ref SubnetIds]
-              - InstanceType: m5a.large
-                SubnetId: !Select [0, !Ref SubnetIds]
-        TagSpecifications:
-          - ResourceType: spot-fleet-request
-            Tags:
-              - Key: ParslResource
-                Value: 'true'
-              - Key: ParslWorkflowId
-                Value: !Ref WorkflowId
-              - Key: ParslJobId
-                Value: !Ref JobId
-              - Key: Name
-                Value: !Sub 'parsl-spot-fleet-${WorkflowId}-${JobId}'
-          - ResourceType: instance
-            Tags:
-              - Key: ParslResource
-                Value: 'true'
-              - Key: ParslWorkflowId
-                Value: !Ref WorkflowId
-              - Key: ParslJobId
-                Value: !Ref JobId
-              - Key: Name
-                Value: !Sub 'parsl-spot-fleet-instance-${WorkflowId}-${JobId}'
-
-  SpotFleetLaunchTemplate:
-    Type: AWS::EC2::LaunchTemplate
-    Condition: UseSpotFleet
-    Properties:
-      LaunchTemplateData:
-        NetworkInterfaces:
-          - DeviceIndex: 0
-            Groups: !Ref SecurityGroupIds
-            AssociatePublicIpAddress: !If [AssignPublicIpEnabled, true, false]
-        UserData:
-          Fn::Base64:
-            !Sub |
-              #!/bin/bash
-              echo "Starting Parsl worker..."
-              mkdir -p /tmp/parsl
-              echo "${Command}" > /tmp/parsl/command.sh
-              chmod +x /tmp/parsl/command.sh
-              /tmp/parsl/command.sh
-              echo "Parsl worker completed."
-        TagSpecifications:
-          - ResourceType: launch-template
-            Tags:
-              - Key: ParslResource
-                Value: 'true'
-              - Key: ParslWorkflowId
-                Value: !Ref WorkflowId
-              - Key: ParslJobId
-                Value: !Ref JobId
+  # This template no longer carries a fleet. It used to hold an AWS::EC2::SpotFleet
+  # and then, briefly, an AWS::EC2::EC2Fleet -- but CloudFormation cannot express
+  # the resource this package needs (#86):
+  #
+  #   The Overrides list is variable-length, one entry per instance type, and
+  #   CFN has no way to build one. Fn::ForEach (AWS::LanguageExtensions) expands
+  #   to a *map*, confirmed by reading the processed template off a change set.
+  #   A fixed set of !Select slots cannot be left partly filled either, because
+  #   an out-of-range !Select fails validation even inside the untaken branch of
+  #   an !If: "Fn::Select cannot select nonexistent value at index 2". Padding
+  #   the slots by repeating a type is rejected by EC2 itself --
+  #   "InvalidFleetConfig: The fleet configuration contains duplicate instance
+  #   pools" -- which a DryRun does not catch.
+  #
+  # ServerlessMode._create_job_fleet() calls CreateFleet directly instead, which
+  # takes the override list natively. Deploying this stack to obtain one fleet
+  # also created an ECS cluster, a task definition, two IAM roles, and a log
+  # group that an EC2 fleet never uses.
 
 Outputs:
   ClusterName:
@@ -412,13 +275,7 @@ Outputs:
 
   ServiceName:
     Description: Name of the ECS service
-    Condition: UseFargate
     Value: !GetAtt ECSService.Name
-
-  SpotFleetRequestId:
-    Description: ID of the Spot Fleet request
-    Condition: UseSpotFleet
-    Value: !Ref SpotFleetRequest
 
   LogGroupName:
     Description: Name of the CloudWatch Logs log group

--- a/parsl_ephemeral_aws/utils/aws.py
+++ b/parsl_ephemeral_aws/utils/aws.py
@@ -31,9 +31,17 @@ from parsl_ephemeral_aws.constants import (
     DEFAULT_AMI_MAPPING,
     DEFAULT_ARCHITECTURE,
     DEFAULT_REGION,
+    EC2_FLEET_ALLOCATION_STRATEGIES,
+    EC2_FLEET_TERMINATE_INSTANCES,
+    EC2_FLEET_TYPE_INSTANT,
     IMDSV2_METADATA_OPTIONS,
+    RESOURCE_TYPE_FLEET,
     RESOURCE_TYPE_LAUNCH_TEMPLATE,
     SPOT_FLEET_ALLOCATION_STRATEGIES,
+    SPOT_INTERRUPTION_EVENT_DETAIL_TYPE,
+    SPOT_INTERRUPTION_EVENT_SOURCE,
+    SPOT_INTERRUPTION_QUEUE_RETENTION_SECONDS,
+    TAG_AWS_FLEET_ID,
 )
 from parsl_ephemeral_aws.exceptions import (
     AMINotFoundError,
@@ -293,6 +301,539 @@ def normalize_spot_fleet_allocation_strategy(strategy: str) -> str:
         f"{sorted(SPOT_FLEET_ALLOCATION_STRATEGIES)} or their kebab-case "
         f"equivalents."
     )
+
+
+def normalize_ec2_fleet_allocation_strategy(strategy: str) -> str:
+    """Translate an allocation strategy to the spelling CreateFleet takes.
+
+    The mirror image of :func:`normalize_spot_fleet_allocation_strategy`:
+    ``CreateFleet`` accepts only kebab-case, and rejects the camelCase spelling
+    ``RequestSpotFleet`` demands. The provider's ``spot_allocation_strategy``
+    kwarg is documented in kebab-case, so the common case is a pass-through --
+    but a caller who supplied the camelCase form (or read it off the legacy
+    constant) is converted rather than punished.
+
+    Validating here matters more than it does on the legacy path, because EC2
+    does *not* catch this for you until real capacity is requested: verified
+    against real EC2 that both ``DryRun=True`` and
+    ``TotalTargetCapacity=0`` accept ``"priceCapacityOptimized"``, and
+    ``describe_fleets`` then shows the bad value stored verbatim.
+
+    Parameters
+    ----------
+    strategy : str
+        Allocation strategy in either spelling.
+
+    Returns
+    -------
+    str
+        The kebab-case spelling ``CreateFleet`` accepts.
+
+    Raises
+    ------
+    ValueError
+        If the strategy is not one EC2 recognises, or is not a string.
+    """
+    if strategy in EC2_FLEET_ALLOCATION_STRATEGIES:
+        return strategy
+
+    if not isinstance(strategy, str):
+        raise ValueError(
+            f"Spot allocation strategy must be a string, got "
+            f"{type(strategy).__name__}: {strategy!r}"
+        )
+
+    # "priceCapacityOptimized" -> "price-capacity-optimized"
+    kebab = re.sub(r"(?<!^)(?=[A-Z])", "-", strategy).lower()
+    if kebab in EC2_FLEET_ALLOCATION_STRATEGIES:
+        return kebab
+
+    raise ValueError(
+        f"Unsupported spot allocation strategy {strategy!r}. Expected one of "
+        f"{sorted(EC2_FLEET_ALLOCATION_STRATEGIES)} or their camelCase "
+        f"equivalents."
+    )
+
+
+def build_fleet_launch_template_configs(
+    template_id: str,
+    template_version: str,
+    instance_types: List[str],
+    subnet_id: str,
+) -> List[Dict[str, Any]]:
+    """Build the ``LaunchTemplateConfigs`` for a CreateFleet request (#86).
+
+    One config referencing one template, with an override per instance type so a
+    single template still covers every pool the fleet may draw from.
+
+    ``CreateFleet``'s override shape is richer than Spot Fleet's -- it also
+    accepts ``ImageId``, ``MaxPrice``, and ``BlockDeviceMappings`` -- but it
+    still has no ``UserData``, which is why the per-block user data has to live
+    in the template rather than here.
+
+    Parameters
+    ----------
+    template_id : str
+        Launch template to draw the baseline definition from.
+    template_version : str
+        Pinned version. Not ``$Latest``: a fleet must launch the definition the
+        caller built, not whatever a concurrent provider added afterwards.
+    instance_types : List[str]
+        Types to emit as overrides, in preference order.
+    subnet_id : str
+        Subnet every override launches into.
+
+    Returns
+    -------
+    List[Dict[str, Any]]
+        A single-element ``LaunchTemplateConfigs`` list.
+    """
+    return [
+        {
+            "LaunchTemplateSpecification": {
+                "LaunchTemplateId": template_id,
+                "Version": template_version,
+            },
+            "Overrides": [
+                {"InstanceType": instance_type, "SubnetId": subnet_id}
+                for instance_type in instance_types
+            ],
+        }
+    ]
+
+
+def create_ec2_fleet(
+    ec2_client: Any,
+    launch_template_configs: List[Dict[str, Any]],
+    target_capacity: int,
+    allocation_strategy: str,
+    client_token: Optional[str] = None,
+    tags: Optional[List[Dict[str, str]]] = None,
+    max_total_price: Optional[str] = None,
+) -> Tuple[str, List[str]]:
+    """Create an ``instant`` EC2 Fleet and return its ID and instance IDs.
+
+    Replaces ``RequestSpotFleet``, which AWS describes as "a legacy API with no
+    planned investment" (#86).
+
+    Fleet type ``instant`` is deliberate: it places a synchronous request and
+    returns the launched instance IDs in the response, so a block knows its
+    instances without polling. That is what the rest of this package assumes,
+    and the asynchronous types cannot provide it.
+
+    Several parameters the legacy path sent are *rejected* for this fleet type --
+    verified against real EC2, with ``InvalidParameter`` rather than silent
+    acceptance -- so they are deliberately absent here:
+
+    * ``ReplaceUnhealthyInstances`` and ``TerminateInstancesWithExpiration``
+      ("not supported for given fleet type")
+    * ``SpotOptions.MaintenanceStrategies``, i.e. Capacity Rebalance ("only
+      compatible with fleet type maintain")
+
+    Parameters
+    ----------
+    ec2_client : Any
+        A boto3 EC2 client.
+    launch_template_configs : List[Dict[str, Any]]
+        As returned by :func:`build_fleet_launch_template_configs`.
+    target_capacity : int
+        Number of instances to request, all spot.
+    allocation_strategy : str
+        Spot allocation strategy; normalised to the kebab-case spelling
+        ``CreateFleet`` requires.
+    client_token : Optional[str]
+        Idempotency token. EC2 generates one when omitted.
+    tags : Optional[List[Dict[str, str]]]
+        Applied to both the fleet resource and the instances it launches, so
+        either can be found by the cleanup sweep.
+    max_total_price : Optional[str]
+        Maximum hourly spot price for the whole fleet. Left unset by default:
+        AWS warns that capping the price increases interruptions.
+
+    Returns
+    -------
+    Tuple[str, List[str]]
+        The fleet ID, and the IDs of the instances it launched. The instance
+        list may be shorter than *target_capacity*, or empty, if EC2 could not
+        fill the request; the caller decides whether that is fatal.
+
+    Raises
+    ------
+    ClientError
+        Propagated unchanged from ``CreateFleet``, so the caller can discriminate
+        on the EC2 error code. See the note at the call itself.
+    ValueError
+        If *allocation_strategy* is not one EC2 recognises.
+    """
+    spot_options: Dict[str, Any] = {
+        "AllocationStrategy": normalize_ec2_fleet_allocation_strategy(
+            allocation_strategy
+        ),
+        # An interrupted worker's instance should go away, not linger stopped
+        # with a billed EBS volume that nothing is tracking.
+        "InstanceInterruptionBehavior": "terminate",
+    }
+    if max_total_price is not None:
+        spot_options["MaxTotalPrice"] = max_total_price
+
+    kwargs: Dict[str, Any] = {
+        "Type": EC2_FLEET_TYPE_INSTANT,
+        "LaunchTemplateConfigs": launch_template_configs,
+        "TargetCapacitySpecification": {
+            "TotalTargetCapacity": target_capacity,
+            "DefaultTargetCapacityType": "spot",
+        },
+        "SpotOptions": spot_options,
+    }
+    if client_token:
+        kwargs["ClientToken"] = client_token
+    if tags:
+        kwargs["TagSpecifications"] = [
+            {"ResourceType": RESOURCE_TYPE_FLEET, "Tags": tags},
+            {"ResourceType": "instance", "Tags": tags},
+        ]
+
+    # ClientError is deliberately *not* caught and wrapped here. Callers
+    # discriminate on the EC2 error code -- SpotFleetManager._create_fleet maps it
+    # onto this package's exception hierarchy, audit-logs the failure, and deletes
+    # the launch template the fleet was built for. Wrapping it in
+    # ResourceCreationError made all three unreachable, since the caller's
+    # ``except ClientError`` no longer matched.
+    response = ec2_client.create_fleet(**kwargs)
+
+    fleet_id = str(response["FleetId"])
+    instance_ids = [
+        instance_id
+        for entry in response.get("Instances", [])
+        for instance_id in entry.get("InstanceIds", [])
+    ]
+
+    # An instant fleet reports per-instance failures inline instead of failing
+    # the call, so a partially-filled fleet looks like success. Surface them:
+    # "no capacity in this pool" is the single most common fleet outcome and is
+    # otherwise invisible.
+    for error in response.get("Errors", []):
+        logger.warning(
+            f"EC2 Fleet {fleet_id} could not launch an instance: "
+            f"{error.get('ErrorCode')} - {error.get('ErrorMessage')}"
+        )
+
+    logger.info(
+        f"Created EC2 Fleet {fleet_id} with {len(instance_ids)}/{target_capacity} "
+        f"instances: {instance_ids}"
+    )
+    return fleet_id, instance_ids
+
+
+def describe_ec2_fleet(ec2_client: Any, fleet_id: str) -> Optional[Dict[str, Any]]:
+    """Return the fleet's ``FleetData``, or None if EC2 has forgotten it.
+
+    The ID is always passed explicitly, and not merely as an optimisation: AWS
+    documents that "if a fleet is of type instant, you must specify the fleet ID
+    in the request, otherwise the fleet does not appear in the response".
+    Verified -- ``describe_fleets()`` with no ``FleetIds`` returned an empty list
+    while an instant fleet was active.
+
+    Parameters
+    ----------
+    ec2_client : Any
+        A boto3 EC2 client.
+    fleet_id : str
+        Fleet to describe.
+
+    Returns
+    -------
+    Optional[Dict[str, Any]]
+        The ``FleetData`` document, or None when the fleet no longer exists.
+    """
+    try:
+        fleets = ec2_client.describe_fleets(FleetIds=[fleet_id]).get("Fleets", [])
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "InvalidFleetId.NotFound":
+            logger.debug(f"EC2 Fleet {fleet_id} no longer exists")
+            return None
+        raise
+    return fleets[0] if fleets else None
+
+
+def get_ec2_fleet_instance_ids(ec2_client: Any, fleet_id: str) -> List[str]:
+    """Return the IDs of instances belonging to *fleet_id*.
+
+    Goes through ``describe_instances`` filtered on the ``aws:ec2:fleet-id`` tag
+    EC2 applies to every fleet-launched instance, because the two obvious
+    routes do not work for an instant fleet -- verified against real EC2:
+
+    * ``describe_fleet_instances`` refuses it outright with ``Unsupported``:
+      "Describe fleet instances is not supported by this type of fleet."
+    * ``describe_fleets`` does return an ``Instances`` list, but only reflects
+      the original launch; it does not drop instances that have since
+      terminated.
+
+    Terminated instances are excluded, so the result answers "what is this fleet
+    still running" rather than "what did it ever launch".
+
+    Parameters
+    ----------
+    ec2_client : Any
+        A boto3 EC2 client.
+    fleet_id : str
+        Fleet whose instances to list.
+
+    Returns
+    -------
+    List[str]
+        Instance IDs that are not terminated. Empty if the fleet launched
+        nothing, or everything it launched is gone.
+    """
+    instance_ids: List[str] = []
+    try:
+        paginator = ec2_client.get_paginator("describe_instances")
+        pages = paginator.paginate(
+            Filters=[
+                {"Name": f"tag:{TAG_AWS_FLEET_ID}", "Values": [fleet_id]},
+                {
+                    "Name": "instance-state-name",
+                    "Values": ["pending", "running", "stopping", "stopped"],
+                },
+            ]
+        )
+        for page in pages:
+            for reservation in page.get("Reservations", []):
+                for instance in reservation.get("Instances", []):
+                    instance_ids.append(instance["InstanceId"])
+    except ClientError as e:
+        logger.warning(f"Could not list instances for EC2 Fleet {fleet_id}: {e}")
+    return instance_ids
+
+
+def delete_ec2_fleet(ec2_client: Any, fleet_id: str) -> None:
+    """Delete an EC2 Fleet, terminating its instances.
+
+    Instance termination is not optional for an instant fleet: AWS rejects
+    ``NoTerminateInstances`` for this type, and "a deleted instant fleet with
+    running instances is not supported".
+
+    Tolerates a fleet that is already gone, and a repeat call on one already
+    deleting -- verified that deleting twice succeeds both times, reporting
+    ``deleted_terminating``, and that an unknown ID comes back as a
+    ``fleetIdDoesNotExist`` entry in ``UnsuccessfulFleetDeletions`` rather than
+    as a raised error. Both are the desired outcome for a cleanup path, so
+    neither raises.
+
+    Parameters
+    ----------
+    ec2_client : Any
+        A boto3 EC2 client.
+    fleet_id : str
+        Fleet to delete.
+
+    Raises
+    ------
+    ResourceDeletionError
+        If EC2 refuses the deletion for any reason other than the fleet not
+        existing.
+    """
+    try:
+        response = ec2_client.delete_fleets(
+            FleetIds=[fleet_id],
+            TerminateInstances=EC2_FLEET_TERMINATE_INSTANCES,
+        )
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "InvalidFleetId.NotFound":
+            logger.debug(f"EC2 Fleet {fleet_id} already deleted")
+            return
+        raise ResourceDeletionError(
+            f"Failed to delete EC2 Fleet {fleet_id}: {e}"
+        ) from e
+
+    for failure in response.get("UnsuccessfulFleetDeletions", []):
+        code = failure.get("Error", {}).get("Code")
+        if code == "fleetIdDoesNotExist":
+            logger.debug(f"EC2 Fleet {fleet_id} already deleted")
+            continue
+        raise ResourceDeletionError(
+            f"Failed to delete EC2 Fleet {fleet_id}: {code} - "
+            f"{failure.get('Error', {}).get('Message')}"
+        )
+
+    for success in response.get("SuccessfulFleetDeletions", []):
+        logger.info(
+            f"Deleted EC2 Fleet {fleet_id}: "
+            f"{success.get('PreviousFleetState')} -> "
+            f"{success.get('CurrentFleetState')}"
+        )
+
+
+def create_spot_interruption_notifier(
+    events_client: Any,
+    sqs_client: Any,
+    name: str,
+    tags: Optional[List[Dict[str, str]]] = None,
+) -> Tuple[str, str, str]:
+    """Wire an EventBridge spot-interruption rule to a fresh SQS queue (#86).
+
+    This is what supplies the two-minute advance warning. Polling EC2 state
+    cannot: an interrupted instance is only observable once it reaches
+    ``shutting-down``, which is after the reclaim, far too late to checkpoint.
+    An ``instant`` fleet also gets no Capacity Rebalance -- ``CreateFleet``
+    rejects ``SpotOptions.MaintenanceStrategies`` for the type -- so EventBridge
+    is the mechanism, and it has the further advantage of working for instances
+    that are already running.
+
+    **No IAM role is created, and none is needed.** Verified against real
+    EventBridge: ``put_targets`` with an SQS ARN and no ``RoleArn`` returned
+    ``FailedEntryCount=0``. Unlike most target types, delivery to SQS is
+    authorised by the *queue's* resource policy, which is why this sets one
+    granting ``events.amazonaws.com`` permission to ``sqs:SendMessage``,
+    conditioned on ``aws:SourceArn`` being this rule -- so no other rule, in this
+    account or any other, can post to the queue.
+
+    Verified end to end with a Fault Injection Simulator experiment
+    (``aws:ec2:send-spot-instance-interruptions``): the warning reached the queue
+    15.2s after the experiment started, while the instance was still
+    ``running``.
+
+    Parameters
+    ----------
+    events_client : Any
+        A boto3 EventBridge client.
+    sqs_client : Any
+        A boto3 SQS client.
+    name : str
+        Name for both the rule and the queue. Must be unique per provider.
+    tags : Optional[List[Dict[str, str]]]
+        Applied to the rule so a leaked one is traceable. Not applied to the
+        queue: SQS takes tags as a flat mapping, and the queue is named after
+        the same provider anyway.
+
+    Returns
+    -------
+    Tuple[str, str, str]
+        The rule name, the queue URL, and the queue ARN.
+
+    Raises
+    ------
+    ResourceCreationError
+        If the rule, the queue, or the wiring between them cannot be created.
+    """
+    pattern = json.dumps(
+        {
+            "source": [SPOT_INTERRUPTION_EVENT_SOURCE],
+            "detail-type": [SPOT_INTERRUPTION_EVENT_DETAIL_TYPE],
+        }
+    )
+
+    try:
+        queue_url = sqs_client.create_queue(
+            QueueName=name,
+            Attributes={
+                # A warning is worthless once its two minutes are up, so let an
+                # undelivered message expire rather than be replayed against a
+                # long-dead instance.
+                "MessageRetentionPeriod": str(
+                    SPOT_INTERRUPTION_QUEUE_RETENTION_SECONDS
+                ),
+            },
+        )["QueueUrl"]
+        queue_arn = sqs_client.get_queue_attributes(
+            QueueUrl=queue_url, AttributeNames=["QueueArn"]
+        )["Attributes"]["QueueArn"]
+
+        rule_kwargs: Dict[str, Any] = {
+            "Name": name,
+            "EventPattern": pattern,
+            "State": "ENABLED",
+            "Description": "Parsl ephemeral AWS provider spot interruption warnings",
+        }
+        if tags:
+            rule_kwargs["Tags"] = tags
+        rule_arn = events_client.put_rule(**rule_kwargs)["RuleArn"]
+
+        # Set the queue policy *before* adding the target, so no window exists in
+        # which EventBridge has a target it cannot deliver to.
+        sqs_client.set_queue_attributes(
+            QueueUrl=queue_url,
+            Attributes={
+                "Policy": json.dumps(
+                    {
+                        "Version": "2012-10-17",
+                        "Statement": [
+                            {
+                                "Sid": "AllowEventBridgeRule",
+                                "Effect": "Allow",
+                                "Principal": {"Service": "events.amazonaws.com"},
+                                "Action": "sqs:SendMessage",
+                                "Resource": queue_arn,
+                                "Condition": {"ArnEquals": {"aws:SourceArn": rule_arn}},
+                            }
+                        ],
+                    }
+                )
+            },
+        )
+
+        response = events_client.put_targets(
+            Rule=name, Targets=[{"Id": "parsl-spot-warning-queue", "Arn": queue_arn}]
+        )
+        if response.get("FailedEntryCount"):
+            failures = response.get("FailedEntries", [])
+            raise ResourceCreationError(
+                f"EventBridge refused the SQS target for rule {name}: {failures}"
+            )
+    except ClientError as e:
+        raise ResourceCreationError(
+            f"Failed to create spot interruption notifier {name}: {e}"
+        ) from e
+
+    logger.info(
+        f"Created spot interruption notifier {name}: EventBridge rule -> {queue_arn}"
+    )
+    return name, queue_url, queue_arn
+
+
+def delete_spot_interruption_notifier(
+    events_client: Any,
+    sqs_client: Any,
+    rule_name: Optional[str],
+    queue_url: Optional[str],
+) -> None:
+    """Tear down what :func:`create_spot_interruption_notifier` built.
+
+    Order matters: the target has to go before the rule, because EventBridge
+    refuses to delete a rule that still has one. Every step logs rather than
+    raises -- this runs from cleanup paths, where a rule that is already gone is
+    the desired end state and must not stop the queue from being deleted too.
+
+    Parameters
+    ----------
+    events_client : Any
+        A boto3 EventBridge client.
+    sqs_client : Any
+        A boto3 SQS client.
+    rule_name : Optional[str]
+        Rule to delete. Ignored when None.
+    queue_url : Optional[str]
+        Queue to delete. Ignored when None.
+    """
+    if rule_name:
+        try:
+            events_client.remove_targets(
+                Rule=rule_name, Ids=["parsl-spot-warning-queue"]
+            )
+        except ClientError as e:
+            logger.warning(f"Could not remove targets from rule {rule_name}: {e}")
+        try:
+            events_client.delete_rule(Name=rule_name)
+            logger.info(f"Deleted spot interruption rule {rule_name}")
+        except ClientError as e:
+            logger.warning(f"Could not delete rule {rule_name}: {e}")
+
+    if queue_url:
+        try:
+            sqs_client.delete_queue(QueueUrl=queue_url)
+            logger.info(f"Deleted spot interruption queue {queue_url}")
+        except ClientError as e:
+            logger.warning(f"Could not delete queue {queue_url}: {e}")
 
 
 def encode_user_data(user_data: str) -> str:

--- a/tests/aws/test_spot_warning_e2e.py
+++ b/tests/aws/test_spot_warning_e2e.py
@@ -1,0 +1,607 @@
+"""Real-AWS end-to-end tests for the spot interruption warning (issue #86).
+
+Unit tests can prove the provider sends the right calls in the right order.
+Only AWS can prove the three claims that actually matter here:
+
+* **EventBridge delivers to SQS with no IAM role.** Every other common target
+  type needs one, so ``put_targets`` succeeding without a ``RoleArn`` is a
+  property of SQS's resource-policy authorisation, not something a mock can
+  confirm. If it were wrong, the rule would exist, the queue would exist, and no
+  warning would ever arrive -- indistinguishable from an account that simply had
+  no interruptions.
+* **The warning arrives while the instance is still running.** That is the entire
+  point: the EC2-state poll it replaces can only see ``shutting-down``, after the
+  reclaim, too late to checkpoint. A previous manual probe measured 15.2s from
+  the Fault Injection Simulator experiment starting to the message landing in
+  SQS, with the instance still ``running``.
+* **The rule and queue are deleted on shutdown.** EventBridge caps rules per
+  account per region, and SQS refuses to recreate a queue for 60 seconds after
+  deletion -- so a leaked queue also blocks the next provider that picks the same
+  provider-ID prefix.
+
+The interruption itself is driven by AWS Fault Injection Simulator
+(``aws:ec2:send-spot-instance-interruptions``), which is the only way to make a
+real spot interruption happen on demand. ``ec2:send-spot-instance-interruptions``
+is not an EC2 API -- boto3 has no such method -- and ``events:PutEvents`` cannot
+be used to fake one either: EventBridge rejects a hand-written event whose
+``Source`` starts with ``aws.`` outright, with
+``NotAuthorizedForSourceException``. So a genuine interruption is the only
+interruption available, and FIS is how to cause one.
+
+Requires an IAM role FIS can assume, holding
+``AWSFaultInjectionSimulatorEC2Access``. Set ``AWS_TEST_FIS_ROLE_ARN``; the FIS
+tests skip without it, and the notifier-wiring tests above them do not need it.
+
+Run with::
+
+    AWS_TEST_REGION=us-east-1 AWS_TEST_VPC_ID=vpc-xxx \\
+    AWS_TEST_SUBNET_ID=subnet-xxx AWS_TEST_SG_ID=sg-xxx \\
+    AWS_TEST_FIS_ROLE_ARN=arn:aws:iam::NNN:role/FISRole \\
+    AWS_PROFILE=aws uv run pytest tests/aws/test_spot_warning_e2e.py \\
+        -m aws --no-cov -v
+
+SPDX-License-Identifier: Apache-2.0
+SPDX-FileCopyrightText: 2025 Scott Friedman and Project Contributors
+"""
+
+import json
+import logging
+import os
+import time
+import uuid
+
+import pytest
+
+from parsl_ephemeral_aws.compute.spot_interruption import SpotInterruptionMonitor
+from parsl_ephemeral_aws.constants import (
+    SPOT_INTERRUPTION_EVENT_DETAIL_TYPE,
+    SPOT_INTERRUPTION_EVENT_SOURCE,
+    SPOT_INTERRUPTION_QUEUE_RETENTION_SECONDS,
+    SPOT_INTERRUPTION_RULE_NAME_PREFIX,
+    TAG_MANAGED,
+)
+from parsl_ephemeral_aws.provider import EphemeralAWSProvider
+from parsl_ephemeral_aws.utils.aws import (
+    create_spot_interruption_notifier,
+    delete_spot_interruption_notifier,
+)
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [pytest.mark.aws, pytest.mark.slow]
+
+AWS_TEST_FIS_ROLE_ARN = os.environ.get("AWS_TEST_FIS_ROLE_ARN")
+
+# The warning arrived 15.2s in when this was measured by hand. Three minutes
+# leaves room for FIS to resolve its targets and for one long-poll cycle, while
+# still failing well inside the two-minute notice the experiment then honours.
+WARNING_TIMEOUT_S = 180
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+
+def _rule_arn(events, name):
+    return events.describe_rule(Name=name)["Arn"]
+
+
+def _drain(sqs, queue_url, deadline):
+    """Yield parsed message bodies until *deadline*, deleting as it goes.
+
+    Long-polls, because a warning that is one second late is still a warning and
+    a tight loop would just spend the budget on empty receives.
+    """
+    while time.time() < deadline:
+        response = sqs.receive_message(
+            QueueUrl=queue_url, MaxNumberOfMessages=10, WaitTimeSeconds=20
+        )
+        for message in response.get("Messages", []):
+            sqs.delete_message(
+                QueueUrl=queue_url, ReceiptHandle=message["ReceiptHandle"]
+            )
+            try:
+                yield json.loads(message["Body"])
+            except ValueError:
+                logger.warning("unparseable message body: %s", message.get("Body"))
+
+
+@pytest.fixture
+def notifier(aws_session, aws_region, test_run_id):
+    """A real EventBridge rule wired to a real SQS queue, torn down after.
+
+    Named with the run ID rather than a provider ID so a leaked one is traceable
+    to the test that leaked it.
+    """
+    events = aws_session.client("events", region_name=aws_region)
+    sqs = aws_session.client("sqs", region_name=aws_region)
+    name = f"{SPOT_INTERRUPTION_RULE_NAME_PREFIX}-e2e-{test_run_id}"
+
+    rule_name, queue_url, queue_arn = create_spot_interruption_notifier(
+        events, sqs, name, tags=[{"Key": TAG_MANAGED, "Value": "true"}]
+    )
+
+    yield dict(
+        events=events,
+        sqs=sqs,
+        rule_name=rule_name,
+        queue_url=queue_url,
+        queue_arn=queue_arn,
+    )
+
+    delete_spot_interruption_notifier(events, sqs, rule_name, queue_url)
+
+
+# ---------------------------------------------------------------------------
+# TestNotifierWiring
+# ---------------------------------------------------------------------------
+
+
+class TestNotifierWiring:
+    """What AWS stored, as against what the provider sent."""
+
+    def test_the_rule_targets_the_queue_without_a_role(self, notifier):
+        """SQS delivery is authorised by the queue policy, not by a role.
+
+        This is the claim a mock cannot check. ``put_targets`` answers
+        ``FailedEntryCount=0`` here with no ``RoleArn`` sent, and the target is
+        readable back -- which is what makes creating and leaking a role for
+        this unnecessary.
+        """
+        targets = notifier["events"].list_targets_by_rule(Rule=notifier["rule_name"])[
+            "Targets"
+        ]
+
+        assert len(targets) == 1
+        assert targets[0]["Arn"] == notifier["queue_arn"]
+        assert targets[0]["Id"] == "parsl-spot-warning-queue"
+        assert "RoleArn" not in targets[0]
+
+    def test_the_rule_is_enabled_and_scoped_to_the_warning(self, notifier):
+        """A disabled rule matches nothing and reports no error for it."""
+        rule = notifier["events"].describe_rule(Name=notifier["rule_name"])
+
+        assert rule["State"] == "ENABLED"
+        assert json.loads(rule["EventPattern"]) == {
+            "source": [SPOT_INTERRUPTION_EVENT_SOURCE],
+            "detail-type": [SPOT_INTERRUPTION_EVENT_DETAIL_TYPE],
+        }
+
+    def test_the_queue_policy_names_this_rule_only(self, notifier):
+        """``aws:SourceArn`` has to resolve to the rule AWS actually created.
+
+        The ARN is composed from the account and region at rule creation, so a
+        wrong one is not a syntax error -- it is a policy that silently
+        authorises nothing, and the queue receives no warnings at all.
+        """
+        attributes = notifier["sqs"].get_queue_attributes(
+            QueueUrl=notifier["queue_url"], AttributeNames=["Policy"]
+        )["Attributes"]
+        statement = json.loads(attributes["Policy"])["Statement"][0]
+
+        assert statement["Resource"] == notifier["queue_arn"]
+        assert statement["Condition"]["ArnEquals"]["aws:SourceArn"] == _rule_arn(
+            notifier["events"], notifier["rule_name"]
+        )
+
+    def test_the_queue_retention_was_accepted(self, notifier):
+        """SQS clamps out-of-range values rather than rejecting them.
+
+        The floor is 60 seconds; a shorter request comes back as 60, so reading
+        it from SQS is the only way to know what retention is really in force.
+        """
+        attributes = notifier["sqs"].get_queue_attributes(
+            QueueUrl=notifier["queue_url"], AttributeNames=["MessageRetentionPeriod"]
+        )["Attributes"]
+
+        assert attributes["MessageRetentionPeriod"] == str(
+            SPOT_INTERRUPTION_QUEUE_RETENTION_SECONDS
+        )
+
+    def test_the_rule_is_tagged_for_cleanup(self, notifier):
+        tags = notifier["events"].list_tags_for_resource(
+            ResourceARN=_rule_arn(notifier["events"], notifier["rule_name"])
+        )["Tags"]
+
+        assert {"Key": TAG_MANAGED, "Value": "true"} in tags
+
+    def test_deleting_the_notifier_removes_both(self, aws_session, aws_region):
+        """The rule cannot be deleted while it has a target, so order matters.
+
+        Deleted here rather than in the fixture teardown so the assertion
+        happens inside a test: a teardown that silently failed would leave the
+        rule counting against the account's per-region limit and nothing would
+        report it.
+        """
+        events = aws_session.client("events", region_name=aws_region)
+        sqs = aws_session.client("sqs", region_name=aws_region)
+        name = f"{SPOT_INTERRUPTION_RULE_NAME_PREFIX}-del-{uuid.uuid4().hex[:8]}"
+
+        rule_name, queue_url, _ = create_spot_interruption_notifier(events, sqs, name)
+        delete_spot_interruption_notifier(events, sqs, rule_name, queue_url)
+
+        with pytest.raises(events.exceptions.ResourceNotFoundException):
+            events.describe_rule(Name=rule_name)
+        with pytest.raises(sqs.exceptions.QueueDoesNotExist):
+            sqs.get_queue_url(QueueName=name)
+
+    def test_deleting_twice_is_not_an_error(self, aws_session, aws_region):
+        """Cleanup runs from ``except`` handlers and from ``shutdown()``.
+
+        Both can fire for the same provider, so the second pass has to be a
+        no-op rather than a raise that masks the original failure.
+        """
+        events = aws_session.client("events", region_name=aws_region)
+        sqs = aws_session.client("sqs", region_name=aws_region)
+        name = f"{SPOT_INTERRUPTION_RULE_NAME_PREFIX}-twice-{uuid.uuid4().hex[:8]}"
+
+        rule_name, queue_url, _ = create_spot_interruption_notifier(events, sqs, name)
+        delete_spot_interruption_notifier(events, sqs, rule_name, queue_url)
+        delete_spot_interruption_notifier(events, sqs, rule_name, queue_url)
+
+
+# ---------------------------------------------------------------------------
+# TestMonitorAgainstRealAWS
+# ---------------------------------------------------------------------------
+
+
+class TestMonitorAgainstRealAWS:
+    """The monitor's own create/poll/delete cycle, against real services."""
+
+    def test_start_and_stop_create_and_delete_the_notifier(
+        self, aws_session, test_run_id
+    ):
+        """No orphan rule after a full cycle, and none before ``start``.
+
+        The monitor is built in every mode's ``__init__``, so a construction
+        that created the rule would leave one behind for every provider that
+        then failed to initialise -- with no ``stop_monitoring`` ever reached.
+        """
+        monitor = SpotInterruptionMonitor(
+            aws_session, check_interval=1, provider_id=f"e2e{test_run_id}"
+        )
+        events = aws_session.client("events")
+
+        assert monitor.warning_rule_name is None
+
+        monitor.start_monitoring()
+        try:
+            assert monitor.warning_queue_url, (
+                "notifier was not created; without it the monitor degrades to "
+                "the post-facto EC2 poll and there is no advance warning"
+            )
+            # Captured before the stop clears it, or there is nothing left to
+            # look the deleted rule up by.
+            created_rule = monitor.warning_rule_name
+            rule = events.describe_rule(Name=created_rule)
+            assert rule["State"] == "ENABLED"
+        finally:
+            monitor.stop_monitoring()
+
+        assert monitor.warning_rule_name is None
+        with pytest.raises(events.exceptions.ResourceNotFoundException):
+            events.describe_rule(Name=created_rule)
+
+    def test_the_monitor_receives_a_warning_it_is_watching_for(
+        self, aws_session, test_run_id
+    ):
+        """A hand-placed message on the real queue reaches the real handler.
+
+        Not a real interruption -- that needs FIS, and is covered below. What
+        this isolates is the SQS half: a message whose envelope matches what
+        EventBridge delivers is received, deleted, attributed to the registered
+        instance, and passed to the handler. Splitting it out means a failure in
+        the FIS test can be read as "the warning did not arrive" rather than
+        "something in the receive path is broken".
+        """
+        monitor = SpotInterruptionMonitor(
+            aws_session, check_interval=1, provider_id=f"rx{test_run_id}"
+        )
+        received = []
+        monitor.register_instance(
+            "i-0123456789abcdef0", lambda i, d: received.append(d)
+        )
+
+        monitor.start_monitoring()
+        try:
+            assert monitor.warning_queue_url, "notifier was not created"
+            sqs = aws_session.client("sqs")
+            sqs.send_message(
+                QueueUrl=monitor.warning_queue_url,
+                MessageBody=json.dumps(
+                    {
+                        "source": SPOT_INTERRUPTION_EVENT_SOURCE,
+                        "detail-type": SPOT_INTERRUPTION_EVENT_DETAIL_TYPE,
+                        "detail": {
+                            "instance-id": "i-0123456789abcdef0",
+                            "instance-action": "terminate",
+                        },
+                    }
+                ),
+            )
+
+            deadline = time.time() + 60
+            while time.time() < deadline and not received:
+                time.sleep(2)
+
+            assert received, (
+                "the monitoring thread did not deliver a warning placed directly "
+                "on its queue within 60s"
+            )
+            assert received[0]["InstanceId"] == "i-0123456789abcdef0"
+            assert received[0]["Source"] == "eventbridge"
+        finally:
+            monitor.stop_monitoring()
+
+
+# ---------------------------------------------------------------------------
+# TestFISInterruption
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not AWS_TEST_FIS_ROLE_ARN,
+    reason="Set AWS_TEST_FIS_ROLE_ARN to a role FIS can assume to run these",
+)
+class TestFISInterruption:
+    """A genuine spot interruption, and where the warning is in its timeline."""
+
+    def _experiment_template(self, fis, tag_value):
+        """Create a template targeting spot instances by tag.
+
+        ``durationBeforeInterruption`` is the *total* window, and its minimum is
+        two minutes -- FIS sends the warning immediately and terminates at the
+        end. So the instance really does stay alive for the notice period, which
+        is what makes the "still running when the warning arrives" assertion
+        meaningful rather than a race that happened to be won.
+        """
+        return fis.create_experiment_template(
+            description="parsl-ephemeral-aws E2E spot interruption warning (#86)",
+            targets={
+                "workers": {
+                    "resourceType": "aws:ec2:spot-instance",
+                    "resourceTags": {"E2ETestRunId": tag_value},
+                    "selectionMode": "ALL",
+                }
+            },
+            actions={
+                "interrupt": {
+                    "actionId": "aws:ec2:send-spot-instance-interruptions",
+                    "parameters": {"durationBeforeInterruption": "PT2M"},
+                    "targets": {"SpotInstances": "workers"},
+                }
+            },
+            stopConditions=[{"source": "none"}],
+            roleArn=AWS_TEST_FIS_ROLE_ARN,
+            tags={"ManagedBy": "parsl-ephemeral-aws-e2e"},
+        )["experimentTemplate"]["id"]
+
+    def test_the_warning_arrives_before_the_instance_dies(
+        self, tmp_path, aws_session, aws_region, test_run_id, network_ids, notifier
+    ):
+        """The claim the whole of 6.3 rests on.
+
+        The EC2-state poll this replaces reports an interruption only once the
+        instance reaches ``shutting-down``. If the warning arrived no earlier
+        than that, the EventBridge machinery would be pure cost -- so the
+        assertion is not just that a message arrives, but that the instance is
+        still ``running`` when it does, with time left to checkpoint.
+
+        Uses its own provider rather than ``spot_provider`` so the E2E run tag
+        FIS targets is the only thing selected: ``selectionMode: ALL`` would
+        otherwise interrupt every tagged spot instance in the account.
+        """
+        fis = aws_session.client("fis", region_name=aws_region)
+        ec2 = aws_session.client("ec2", region_name=aws_region)
+
+        provider = EphemeralAWSProvider(
+            region=aws_region,
+            instance_type="t3.micro",
+            mode="standard",
+            use_spot=True,
+            spot_interruption_handling=False,
+            state_store_type="file",
+            state_file_path=str(tmp_path / f"state-warn-{test_run_id}.json"),
+            auto_shutdown=True,
+            auto_create_instance_profile=True,
+            profile_name=aws_session.profile_name or "aws",
+            additional_tags={"E2ETestRunId": test_run_id, "AutoCleanup": "true"},
+            waiter_delay=15,
+            waiter_max_attempts=40,
+            debug=True,
+            **network_ids,
+        )
+
+        template_id = None
+        job_id = None
+        try:
+            job_id = provider.submit("sleep 600", tasks_per_node=1)
+            instance_id = provider.job_map[job_id]["resource_id"]
+            logger.info("submitted spot instance %s for job %s", instance_id, job_id)
+
+            # FIS resolves targets at experiment start, so the instance has to be
+            # running first -- an experiment that resolves nothing fails outright
+            # under emptyTargetResolutionMode: fail.
+            ec2.get_waiter("instance_running").wait(InstanceIds=[instance_id])
+
+            template_id = self._experiment_template(fis, test_run_id)
+            experiment = fis.start_experiment(experimentTemplateId=template_id)[
+                "experiment"
+            ]
+            started = time.time()
+            logger.info("started FIS experiment %s", experiment["id"])
+
+            deadline = started + WARNING_TIMEOUT_S
+            warning = None
+            for body in _drain(notifier["sqs"], notifier["queue_url"], deadline):
+                if body.get("detail", {}).get("instance-id") == instance_id:
+                    warning = body
+                    break
+
+            elapsed = time.time() - started
+            assert warning is not None, (
+                f"no interruption warning for {instance_id} within "
+                f"{WARNING_TIMEOUT_S}s of the FIS experiment starting; the "
+                "rule, the queue policy, or the target is not delivering"
+            )
+
+            # The assertion that distinguishes this from the poll it replaces.
+            state = ec2.describe_instances(InstanceIds=[instance_id])["Reservations"][
+                0
+            ]["Instances"][0]["State"]["Name"]
+            logger.info(
+                "warning for %s arrived after %.1fs, instance state %s",
+                instance_id,
+                elapsed,
+                state,
+            )
+            assert state == "running", (
+                f"the warning arrived at {elapsed:.1f}s but {instance_id} was "
+                f"already {state}; there is no lead time to checkpoint in and "
+                "the EventBridge notifier buys nothing over the EC2-state poll"
+            )
+
+            assert warning["detail-type"] == SPOT_INTERRUPTION_EVENT_DETAIL_TYPE
+            assert warning["source"] == SPOT_INTERRUPTION_EVENT_SOURCE
+            assert warning["detail"]["instance-action"] in (
+                "terminate",
+                "stop",
+                "hibernate",
+            )
+        finally:
+            if job_id:
+                try:
+                    provider.cancel([job_id])
+                except Exception as exc:
+                    logger.warning("cancel raised (ignored): %s", exc)
+            try:
+                provider.shutdown()
+            except Exception as exc:
+                logger.warning("shutdown raised (ignored): %s", exc)
+            if template_id:
+                try:
+                    fis.delete_experiment_template(id=template_id)
+                except Exception as exc:
+                    logger.warning("FIS template cleanup: %s (ignored)", exc)
+
+    def test_a_registered_handler_fires_on_a_real_interruption(
+        self, tmp_path, aws_session, aws_region, test_run_id, network_ids
+    ):
+        """The provider's own monitor, not a hand-driven queue drain.
+
+        The test above proves the message arrives. This proves the wiring the
+        provider builds for itself carries it the rest of the way: mode
+        initialisation creates the notifier, ``_create_spot_instance`` registers
+        the instance, the background thread polls, and the registered handler is
+        called with ``Source: eventbridge`` -- the flag telling a checkpointing
+        handler it still has time.
+
+        The handler is swapped for a recorder rather than left as the real
+        S3-checkpointing one, so the assertion is about delivery and not about
+        whether a checkpoint happened to succeed. ``checkpoint_bucket`` is still
+        required, because it is what makes the mode build a monitor at all.
+        """
+        fis = aws_session.client("fis", region_name=aws_region)
+        ec2 = aws_session.client("ec2", region_name=aws_region)
+        s3 = aws_session.client("s3", region_name=aws_region)
+        bucket = f"parsl-e2e-warn-{test_run_id}"
+        if aws_region == "us-east-1":
+            s3.create_bucket(Bucket=bucket)
+        else:
+            s3.create_bucket(
+                Bucket=bucket,
+                CreateBucketConfiguration={"LocationConstraint": aws_region},
+            )
+
+        provider = EphemeralAWSProvider(
+            region=aws_region,
+            instance_type="t3.micro",
+            mode="standard",
+            use_spot=True,
+            spot_interruption_handling=True,
+            checkpoint_bucket=bucket,
+            state_store_type="file",
+            state_file_path=str(tmp_path / f"state-hdl-{test_run_id}.json"),
+            auto_shutdown=True,
+            auto_create_instance_profile=True,
+            profile_name=aws_session.profile_name or "aws",
+            additional_tags={"E2ETestRunId": test_run_id, "AutoCleanup": "true"},
+            waiter_delay=15,
+            waiter_max_attempts=40,
+            debug=True,
+            **network_ids,
+        )
+
+        template_id = None
+        job_id = None
+        try:
+            mode = provider.operating_mode
+            monitor = mode.spot_interruption_monitor
+            assert monitor is not None, (
+                "no interruption monitor was built despite "
+                "spot_interruption_handling=True and a checkpoint bucket"
+            )
+
+            received = []
+            job_id = provider.submit("sleep 600", tasks_per_node=1)
+            instance_id = provider.job_map[job_id]["resource_id"]
+
+            # Registered by _create_spot_instance during submit; replaced here so
+            # the assertion is about delivery rather than about S3.
+            assert instance_id in monitor.instance_handlers, (
+                f"{instance_id} was never registered with the monitor, so no "
+                "warning for it can ever be routed"
+            )
+            monitor.register_instance(instance_id, lambda i, d: received.append((i, d)))
+            assert monitor.warning_queue_url, (
+                "the monitor degraded to the EC2-state poll; check events/sqs "
+                "permissions on the test profile"
+            )
+
+            ec2.get_waiter("instance_running").wait(InstanceIds=[instance_id])
+
+            template_id = self._experiment_template(fis, test_run_id)
+            fis.start_experiment(experimentTemplateId=template_id)
+            started = time.time()
+
+            while time.time() - started < WARNING_TIMEOUT_S and not received:
+                time.sleep(5)
+
+            assert received, (
+                f"the registered handler was not called within "
+                f"{WARNING_TIMEOUT_S}s of a real interruption of {instance_id}"
+            )
+            handled_id, details = received[0]
+            assert handled_id == instance_id
+            assert details["Source"] == "eventbridge", (
+                "the warning was attributed to the post-facto EC2-state poll, "
+                "so a handler would skip checkpointing"
+            )
+        finally:
+            if job_id:
+                try:
+                    provider.cancel([job_id])
+                except Exception as exc:
+                    logger.warning("cancel raised (ignored): %s", exc)
+            try:
+                provider.shutdown()
+            except Exception as exc:
+                logger.warning("shutdown raised (ignored): %s", exc)
+            if template_id:
+                try:
+                    fis.delete_experiment_template(id=template_id)
+                except Exception as exc:
+                    logger.warning("FIS template cleanup: %s (ignored)", exc)
+            try:
+                paginator = s3.get_paginator("list_objects_v2")
+                for page in paginator.paginate(Bucket=bucket):
+                    objects = page.get("Contents", [])
+                    if objects:
+                        s3.delete_objects(
+                            Bucket=bucket,
+                            Delete={"Objects": [{"Key": o["Key"]} for o in objects]},
+                        )
+                s3.delete_bucket(Bucket=bucket)
+            except Exception as exc:
+                logger.warning("checkpoint bucket cleanup: %s (ignored)", exc)

--- a/tests/unit/test_allocation_strategy.py
+++ b/tests/unit/test_allocation_strategy.py
@@ -174,6 +174,14 @@ class TestBastionScriptInjection:
     the replacement actually substitutes. A substitution whose search string
     drifts from the template fails silently -- ``str.replace`` finding nothing is
     not an error -- so the generated text is what has to be asserted on.
+
+    The spelling asserted on is kebab-case, and the *whole point* of these two
+    tests is which one. The bastion called ``RequestSpotFleet`` when they were
+    written, which takes camelCase; it now calls ``CreateFleet`` (#86), which
+    rejects camelCase outright with ``InvalidParameter``. So the conversion these
+    tests used to demand would break every fleet the bastion launches -- and it
+    would break it *on the bastion*, in a standalone script on a remote instance,
+    where the error surfaces only in that instance's log.
     """
 
     def _script(self, **kwargs):
@@ -202,16 +210,29 @@ class TestBastionScriptInjection:
                 )
         raise AssertionError("script defines no ALLOCATION_STRATEGY constant")
 
-    def test_configured_strategy_is_injected_as_camel_case(self):
+    def test_configured_strategy_is_injected_as_kebab_case(self):
+        """The value must reach the script in the spelling CreateFleet takes."""
         script = self._script(spot_allocation_strategy="capacity-optimized")
 
-        assert self._injected_value(script) == "capacityOptimized"
+        assert self._injected_value(script) == "capacity-optimized"
 
     def test_default_strategy_is_injected(self):
         assert (
             self._injected_value(self._script())
-            == SPOT_FLEET_DEFAULT_ALLOCATION_STRATEGY
+            == EC2_FLEET_DEFAULT_ALLOCATION_STRATEGY
         )
+
+    def test_a_camel_case_strategy_is_converted_for_the_bastion(self):
+        """A caller may supply either spelling; only one works on the bastion.
+
+        ``normalize_ec2_fleet_allocation_strategy`` runs at the substitution, so a
+        caller who passed the ``RequestSpotFleet`` spelling still gets a script
+        that ``CreateFleet`` accepts. Without it the value would travel verbatim
+        and fail on the instance rather than here.
+        """
+        script = self._script(spot_allocation_strategy="capacityOptimized")
+
+        assert self._injected_value(script) == "capacity-optimized"
 
     def test_generated_script_is_valid_python(self):
         """The substitution must not break the script the bastion has to run."""
@@ -222,3 +243,17 @@ class TestBastionScriptInjection:
 
         assert "'AllocationStrategy': 'lowestPrice'" not in script
         assert "lowestPrice" not in script
+
+    def test_the_script_calls_create_fleet_and_not_the_legacy_api(self):
+        """The strategy's spelling only makes sense against one of the two APIs.
+
+        Pinning which API the script calls is what makes the kebab-case
+        assertions above meaningful rather than arbitrary -- if the bastion went
+        back to ``RequestSpotFleet``, they would be asserting the spelling that
+        breaks it.
+        """
+        script = self._script()
+
+        assert "ec2.create_fleet(" in script
+        assert "request_spot_fleet" not in script
+        assert "cancel_spot_fleet_requests" not in script

--- a/tests/unit/test_aws_mocking.py
+++ b/tests/unit/test_aws_mocking.py
@@ -25,7 +25,6 @@ import json
 import os
 import uuid
 from types import SimpleNamespace
-from unittest.mock import patch
 
 import boto3
 import pytest
@@ -345,43 +344,76 @@ class TestSpotFleetWithMoto:
 
     @mock_aws
     def test_fleet_block_lifecycle(self, moto_session):
-        """``create_blocks`` requests the fleet; ``terminate_block`` cancels it.
+        """``create_blocks`` creates an EC2 Fleet; ``terminate_block`` deletes it.
 
-        The public surface is ``create_blocks``/``get_block_status``/
-        ``terminate_block``, not ``request_spot_fleet``/
-        ``get_spot_fleet_request_status``/``cancel_spot_fleet_request``.
-        ``time.sleep`` is patched out because ``_get_iam_fleet_role`` sleeps 10s
-        for IAM propagation.
+        Retargeted from the legacy Spot Fleet API onto ``CreateFleet`` (#86). The
+        two assertions that went with the old API are gone for good reasons
+        rather than convenience:
+
+        * ``describe_spot_fleet_requests`` cannot see this fleet at all -- the two
+          APIs keep separate registries, so the call returns nothing and indexing
+          ``[0]`` is the ``IndexError`` this test failed with.
+        * the IAM-role assertions had nothing left to assert. ``CreateFleet`` has
+          no ``IamFleetRole`` member, so no service role is created; that is now
+          pinned negatively here, and the surviving cleanup of a role named by a
+          pre-#86 state document is covered in ``test_spot_fleet.py``.
+
+        Kept under moto because this is the only unit test where the
+        ``CreateFleet`` request *shape* is validated by something other than a
+        MagicMock -- a launch template really has to exist, and be referenced by
+        ID and version, for the call to succeed.
+
+        ``time.sleep`` is no longer patched: the 10-second IAM propagation wait
+        belonged to the role fetch that is gone.
         """
         vpc_id, subnet_id, sg_id = provision_network(moto_session)
+        # A real AMI: moto validates the ID at launch, and the fleet resolves its
+        # image through the launch template, so a placeholder would fail the call.
+        image_id = moto_session.client("ec2").describe_images()["Images"][0]["ImageId"]
         manager = SpotFleetManager(
-            make_provider(vpc_id=vpc_id, subnet_id=subnet_id, security_group_id=sg_id)
+            make_provider(
+                vpc_id=vpc_id,
+                subnet_id=subnet_id,
+                security_group_id=sg_id,
+                image_id=image_id,
+                instance_types=["t3.micro", "t3.small"],
+            )
         )
         ec2 = moto_session.client("ec2")
 
-        with patch("parsl_ephemeral_aws.compute.spot_fleet.time.sleep"):
-            blocks = manager.create_blocks(1)
+        blocks = manager.create_blocks(1)
 
         block_id, block = next(iter(blocks.items()))
-        fleet_request_id = block["fleet_request_id"]
+        fleet_id = block["fleet_request_id"]
+        assert fleet_id.startswith("fleet-")
 
-        config = ec2.describe_spot_fleet_requests(
-            SpotFleetRequestIds=[fleet_request_id]
-        )["SpotFleetRequestConfigs"][0]
-        assert config["SpotFleetRequestState"] == "active"
+        fleet = ec2.describe_fleets(FleetIds=[fleet_id])["Fleets"][0]
+        assert fleet["FleetState"] == "active"
+        # Type "instant" is what makes the instance IDs available synchronously,
+        # which every caller here relies on.
+        assert fleet["Type"] == "instant"
+
+        # The instances came back from the create call itself rather than from a
+        # polling loop, and the block records them.
+        assert block["instance_ids"]
+        instances = ec2.describe_instances(InstanceIds=block["instance_ids"])
+        instance = instances["Reservations"][0]["Instances"][0]
+        tags = tag_dict(instance["Tags"])
+        assert tags[TAG_MANAGED] == "true"
+        assert tags[TAG_WORKFLOW_ID] == manager.provider.workflow_id
+
         assert manager.get_block_status(block_id) in ("PENDING", "RUNNING")
 
-        # The fleet role was created and the managed policy attached -- the whole
-        # reason MOTO_IAM_LOAD_MANAGED_POLICIES has to be set.
+        # No IAM role was created for the fleet, and none was asked for.
+        assert manager.iam_fleet_role_arn is None
         iam = moto_session.client("iam")
-        role_name = manager.iam_fleet_role_arn.split("/")[-1]
-        attached = iam.list_attached_role_policies(RoleName=role_name)[
-            "AttachedPolicies"
-        ]
-        assert any("SpotFleet" in p["PolicyName"] for p in attached)
+        assert iam.list_roles()["Roles"] == []
 
         manager.terminate_block(block_id)
         assert manager.blocks[block_id]["status"] == STATUS_CANCELLED
+        assert ec2.describe_fleets(FleetIds=[fleet_id])["Fleets"][0][
+            "FleetState"
+        ].startswith("deleted")
 
     @mock_aws
     def test_missing_network_is_rejected(self, moto_session):

--- a/tests/unit/test_detached_mode_spot_fleet.py
+++ b/tests/unit/test_detached_mode_spot_fleet.py
@@ -244,7 +244,23 @@ class TestDetachedModeSpotFleet:
         mock_ec2_client,
         mock_cf_client,
     ):
-        """Test initialize method with SpotFleet options."""
+        """The bastion stack must carry no fleet parameters at all.
+
+        This used to assert the opposite -- that ``UseSpotFleet``,
+        ``NodesPerBlock``, ``SpotMaxPricePercentage`` and ``InstanceTypes`` were
+        sent. ``bastion.yml`` declares none of them, and CloudFormation rejects an
+        undeclared parameter outright: "ValidationError: Parameters:
+        [UseSpotFleet] do not exist in the template". Since ``bastion_host_type``
+        defaults to ``"cloudformation"``, that made the default bastion path fail
+        on every initialize.
+
+        They were dropped rather than added to the template because all four
+        describe a *worker fleet* and the bastion is a single host; the fleet
+        settings reach the workers through the manager script's environment. So
+        the assertion is inverted, and the network parameters the stack does need
+        are checked in their place -- an empty ``Parameters`` list would satisfy a
+        purely negative test.
+        """
         # Setup mocks
         mock_get_default_ami.return_value = "ami-default"
         mock_get_cf_template.return_value = "CloudFormation Template"
@@ -260,20 +276,24 @@ class TestDetachedModeSpotFleet:
         assert detached_mode_with_spot_fleet.bastion_id == "stack-12345"
         assert detached_mode_with_spot_fleet.initialized is True
 
-        # Verify CloudFormation parameters include SpotFleet options
+        assert mock_cf_client.create_stack.call_args_list
         for call_args in mock_cf_client.create_stack.call_args_list:
             cf_params = call_args[1].get("Parameters", [])
-
-            # Convert parameters to a dict for easier checking
             param_dict = {p["ParameterKey"]: p["ParameterValue"] for p in cf_params}
 
-            # Verify SpotFleet parameters are present
-            assert param_dict.get("UseSpotFleet") == "true"
-            assert param_dict.get("NodesPerBlock") == "2"
-            assert param_dict.get("SpotMaxPricePercentage") == "80"
-            assert "t3.small" in param_dict.get("InstanceTypes", "")
-            assert "t3.medium" in param_dict.get("InstanceTypes", "")
-            assert "m5.small" in param_dict.get("InstanceTypes", "")
+            for fleet_param in (
+                "UseSpotFleet",
+                "NodesPerBlock",
+                "SpotMaxPricePercentage",
+                "InstanceTypes",
+            ):
+                assert fleet_param not in param_dict
+
+            # What the bastion genuinely needs, so this is not vacuously true.
+            assert param_dict["VpcId"] == "vpc-12345"
+            assert param_dict["SubnetId"] == "subnet-12345"
+            assert param_dict["SecurityGroupId"] == "sg-12345"
+            assert param_dict["WorkflowId"] == "test-workflow"
 
     def test_submit_job_with_spot_fleet(
         self, detached_mode_with_spot_fleet, mock_ssm_client
@@ -404,7 +424,15 @@ class TestDetachedModeSpotFleet:
     def test_cleanup_spot_fleet_resources(
         self, detached_mode_with_spot_fleet, mock_ec2_client, mock_ssm_client
     ):
-        """Test cleaning up SpotFleet resources."""
+        """Cleanup must delete the fleet through the EC2 Fleet API (#86).
+
+        The fleet a job holds is now created by ``CreateFleet``, so
+        ``CancelSpotFleetRequests`` cannot reach it -- it would answer
+        ``InvalidSpotFleetRequestId.NotFound`` and the instances would keep
+        running and billing. ``DeleteFleets`` is the counterpart, and
+        ``TerminateInstances=True`` is not optional: it is a required member, and
+        omitting it leaves the instances behind.
+        """
         # Setup mock resource with SpotFleet details
         resource_id = "spot-fleet-job-1"
         detached_mode_with_spot_fleet.resources = {
@@ -420,10 +448,10 @@ class TestDetachedModeSpotFleet:
         # Cleanup the resource
         detached_mode_with_spot_fleet.cleanup_resources([resource_id])
 
-        # Verify EC2 cancel_spot_fleet_requests was called
-        mock_ec2_client.cancel_spot_fleet_requests.assert_called_once_with(
-            SpotFleetRequestIds=["sfr-12345"], TerminateInstances=True
+        mock_ec2_client.delete_fleets.assert_called_once_with(
+            FleetIds=["sfr-12345"], TerminateInstances=True
         )
+        mock_ec2_client.cancel_spot_fleet_requests.assert_not_called()
 
         # Verify SSM parameters were deleted
         mock_ssm_client.delete_parameter.assert_any_call(
@@ -442,16 +470,41 @@ class TestDetachedModeSpotFleet:
     def test_bastion_script_includes_spot_fleet_support(
         self, detached_mode_with_spot_fleet
     ):
-        """Test that the bastion manager script includes SpotFleet support."""
+        """The bastion script must carry the EC2 Fleet helpers, not the old ones.
+
+        Two of the three functions this asserted on are gone with the legacy API
+        (#86). ``get_spot_fleet_role()`` provisioned the ``IamFleetRole`` that
+        ``RequestSpotFleet`` requires; ``CreateFleet`` has no such member at all,
+        so the role -- and the IAM permissions to create it -- are no longer
+        needed. ``wait_for_fleet_instances()`` polled
+        ``describe_spot_fleet_instances``; an ``instant`` fleet returns its
+        instance IDs in the ``CreateFleet`` response, so there is nothing to wait
+        for, and ``get_fleet_instance_ids()`` looks them up by the reserved
+        ``aws:ec2:fleet-id`` tag -- the only way to find an instant fleet's
+        instances, since ``DescribeFleetInstances`` refuses them outright.
+
+        Checked against the generated text rather than the module source because
+        the bastion cannot import from this package: the script is assembled by
+        string substitution and runs standalone on the instance, where a missing
+        helper surfaces only as a ``NameError`` in that instance's log.
+        """
         # Generate the bastion manager script
         manager_script = detached_mode_with_spot_fleet._get_bastion_manager_script()
 
-        # Verify script content includes SpotFleet functionality
-        assert "def get_spot_fleet_role()" in manager_script
-        assert "def wait_for_fleet_instances(" in manager_script
         assert "def launch_spot_fleet(" in manager_script
+        assert "def get_fleet_instance_ids(" in manager_script
+        assert "def delete_launch_template(" in manager_script
         assert "RESOURCE_TYPE_SPOT_FLEET" in manager_script
         assert "USE_SPOT_FLEET" in manager_script
+
+        assert "get_spot_fleet_role" not in manager_script
+        assert "wait_for_fleet_instances" not in manager_script
+
+        # Scoped to the two ways the role could be *passed* rather than a bare
+        # substring check: the script's own header explains why CreateFleet has
+        # no IamFleetRole member, and that explanation should not fail this.
+        assert "'IamFleetRole'" not in manager_script
+        assert "IamFleetRole=" not in manager_script
 
     def test_load_state_with_spot_fleet(
         self, detached_mode_with_spot_fleet, mock_state_store

--- a/tests/unit/test_error_handling.py
+++ b/tests/unit/test_error_handling.py
@@ -504,8 +504,32 @@ class TestSpotFleetManagerErrors:
             spot_max_price_percentage=80,
         )
 
+    def _fail_create_fleet(self, manager, code, message):
+        """Make ``CreateFleet`` fail with *code*, answering the mandatory template.
+
+        The launch template has to be answered even on a failure path: it is
+        created *before* the fleet, and ``CreateFleet`` has no
+        ``LaunchSpecifications`` member, so there is no launch form that skips it
+        (#86). An unstubbed ``create_launch_template`` would fail the test on the
+        template's MagicMock return rather than on the error under test.
+        """
+        manager.ec2_client.create_launch_template.return_value = {
+            "LaunchTemplate": {"LaunchTemplateId": "lt-12345", "LatestVersionNumber": 1}
+        }
+        manager.ec2_client.describe_spot_price_history.return_value = {
+            "SpotPriceHistory": [{"SpotPrice": "0.01"}]
+        }
+        manager.ec2_client.create_fleet.side_effect = ClientError(
+            {"Error": {"Code": code, "Message": message}}, "CreateFleet"
+        )
+
     def _request_fleet(self, manager):
-        """Call ``_create_spot_fleet_request`` -- the layer that classifies errors.
+        """Call ``_create_fleet`` -- the layer that classifies errors.
+
+        Retargeted from ``_create_spot_fleet_request``, which is gone with the
+        legacy API (#86). Note the shorter signature: there is no
+        ``fleet_role_arn`` parameter any more, because ``CreateFleet`` has no
+        ``IamFleetRole`` member and an EC2 Fleet needs no service role at all.
 
         ``create_blocks`` deliberately wraps everything it catches as
         ``ResourceCreationError``, and because ``SpotFleetError`` descends from
@@ -514,7 +538,7 @@ class TestSpotFleetManagerErrors:
         itself is asserted separately in
         ``test_create_blocks_wraps_fleet_errors``.
         """
-        return manager._create_spot_fleet_request(
+        return manager._create_fleet(
             block_id="block-1",
             network={
                 "vpc_id": "vpc-12345",
@@ -522,19 +546,22 @@ class TestSpotFleetManagerErrors:
                 "security_group_id": "sg-12345",
             },
             target_capacity=1,
-            fleet_role_arn="arn:aws:iam::123456789012:role/fleet",
         )
 
     def test_spot_fleet_request_error(self, spot_fleet_manager):
-        """An invalid fleet configuration surfaces as SpotFleetError."""
-        spot_fleet_manager.ec2_client.request_spot_fleet.side_effect = ClientError(
-            {
-                "Error": {
-                    "Code": "InvalidSpotFleetRequestConfig",
-                    "Message": "Invalid Spot Fleet request configuration",
-                }
-            },
-            "RequestSpotFleet",
+        """An invalid fleet configuration surfaces as SpotFleetError.
+
+        The code is ``InvalidFleetConfig``, not the ``InvalidSpotFleetRequestConfig``
+        this asserted before: that code belongs to ``RequestSpotFleet``, and
+        ``CreateFleet`` never returns it. Verified against real EC2 -- a fleet
+        whose ``Overrides`` repeat an instance pool comes back as
+        ``InvalidFleetConfig: The fleet configuration contains duplicate instance
+        pools``, and ``DryRun=True`` does not catch it.
+        """
+        self._fail_create_fleet(
+            spot_fleet_manager,
+            "InvalidFleetConfig",
+            "The fleet configuration contains duplicate instance pools",
         )
 
         with pytest.raises(SpotFleetError):
@@ -547,29 +574,29 @@ class TestSpotFleetManagerErrors:
         distinguishing it -- a caller can back off for the interval AWS named
         instead of retrying blind.
         """
-        spot_fleet_manager.ec2_client.request_spot_fleet.side_effect = ClientError(
-            {
-                "Error": {
-                    "Code": "RequestLimitExceeded",
-                    "Message": "Request limit exceeded",
-                }
-            },
-            "RequestSpotFleet",
+        self._fail_create_fleet(
+            spot_fleet_manager, "RequestLimitExceeded", "Request limit exceeded"
         )
 
         with pytest.raises(SpotFleetThrottlingError):
             self._request_fleet(spot_fleet_manager)
 
     def test_spot_fleet_instance_limit_error(self, spot_fleet_manager):
-        """InstanceLimitExceeded surfaces as the request subclass."""
-        spot_fleet_manager.ec2_client.request_spot_fleet.side_effect = ClientError(
-            {
-                "Error": {
-                    "Code": "InstanceLimitExceeded",
-                    "Message": "You have reached your instance limit",
-                }
-            },
-            "RequestSpotFleet",
+        """A spot quota rejection surfaces as the request subclass.
+
+        ``MaxSpotInstanceCountExceeded`` replaces the ``InstanceLimitExceeded``
+        this used to send: that code is ``RunInstances``', and a fleet that
+        exceeds the account's spot limit is refused with the spot-specific one.
+
+        The distinction from ``InsufficientInstanceCapacity`` matters to callers
+        and is why this maps to the request subclass rather than the base: a
+        quota is not a transient shortage, so the fix is a limit increase, not a
+        retry or a different pool.
+        """
+        self._fail_create_fleet(
+            spot_fleet_manager,
+            "MaxSpotInstanceCountExceeded",
+            "Max spot instance count exceeded",
         )
 
         with pytest.raises(SpotFleetRequestError):
@@ -580,16 +607,18 @@ class TestSpotFleetManagerErrors:
 
         Pinning the wrapping is what makes the subclass tests above meaningful:
         callers of ``create_blocks`` get the generic type, callers of
-        ``_create_spot_fleet_request`` get the specific one.
+        ``_create_fleet`` get the specific one.
+
+        Only ``_setup_network_resources`` is patched now. This also patched
+        ``_get_iam_fleet_role``, which no longer exists -- and ``patch.object``
+        raises ``AttributeError`` for a missing attribute rather than creating
+        one, so the patch itself is what failed, before the fleet was ever
+        requested.
         """
-        spot_fleet_manager.ec2_client.request_spot_fleet.side_effect = ClientError(
-            {
-                "Error": {
-                    "Code": "InvalidSpotFleetRequestConfig",
-                    "Message": "Invalid Spot Fleet request configuration",
-                }
-            },
-            "RequestSpotFleet",
+        self._fail_create_fleet(
+            spot_fleet_manager,
+            "InvalidFleetConfig",
+            "The fleet configuration contains duplicate instance pools",
         )
         network = {
             "vpc_id": "vpc-12345",
@@ -597,69 +626,147 @@ class TestSpotFleetManagerErrors:
             "security_group_id": "sg-12345",
         }
 
-        with (
-            patch.object(
-                spot_fleet_manager, "_setup_network_resources", return_value=network
-            ),
-            patch.object(
-                spot_fleet_manager,
-                "_get_iam_fleet_role",
-                return_value="arn:aws:iam::123456789012:role/fleet",
-            ),
+        with patch.object(
+            spot_fleet_manager, "_setup_network_resources", return_value=network
         ):
             with pytest.raises(ResourceCreationError):
                 spot_fleet_manager.create_blocks(1)
 
     def test_spot_fleet_cancellation_error(self, spot_fleet_manager):
-        """A refused cancellation surfaces as SpotFleetError."""
-        spot_fleet_manager.blocks["block-1"] = {
-            "id": "block-1",
-            "fleet_request_id": "sfr-12345",
-            "status": "running",
-            "instance_ids": [],
-        }
-        spot_fleet_manager.ec2_client.cancel_spot_fleet_requests.side_effect = (
-            ClientError(
-                {
-                    "Error": {
-                        "Code": "UnauthorizedOperation",
-                        "Message": "You are not authorized to cancel this request",
-                    }
-                },
-                "CancelSpotFleetRequests",
-            )
-        )
+        """A refused deletion surfaces as SpotFleetError.
 
-        with pytest.raises(SpotFleetError):
-            spot_fleet_manager.terminate_block("block-1")
+        Retargeted at ``DeleteFleets``; ``CancelSpotFleetRequests`` cannot reach
+        a fleet ``CreateFleet`` made, and would answer
+        ``InvalidSpotFleetRequestId.NotFound``.
 
-    def test_cancelling_an_absent_fleet_is_not_an_error(self, spot_fleet_manager):
-        """A fleet AWS has already forgotten counts as cancelled, not as failure.
-
-        Termination has to be idempotent -- cleanup runs it on paths that may
-        have already run it.
+        This one caught a live defect rather than just a renamed API.
+        ``terminate_block`` calls ``delete_ec2_fleet``, which wraps the
+        ``ClientError`` in ``ResourceDeletionError`` -- so the
+        ``except ClientError`` branch that classifies these errors could never
+        run, and every refused deletion fell through to the generic
+        ``ResourceCleanupError`` handler. ``ResourceCleanupError`` is *not* a
+        ``SpotFleetError`` (it descends from ``ResourceDeletionError``, not
+        ``EC2InstanceError``), so this test failed as ``DID NOT RAISE`` even
+        though the deletion had genuinely failed. The handler now catches the
+        wrapper and reads the original from ``__cause__``.
         """
         spot_fleet_manager.blocks["block-1"] = {
             "id": "block-1",
-            "fleet_request_id": "sfr-12345",
+            "fleet_request_id": "fleet-12345",
             "status": "running",
             "instance_ids": [],
         }
-        spot_fleet_manager.ec2_client.cancel_spot_fleet_requests.side_effect = (
-            ClientError(
-                {
-                    "Error": {
-                        "Code": "InvalidSpotFleetRequestId.NotFound",
-                        "Message": "The spot fleet request does not exist",
-                    }
-                },
-                "CancelSpotFleetRequests",
-            )
+        spot_fleet_manager.ec2_client.delete_fleets.side_effect = ClientError(
+            {
+                "Error": {
+                    "Code": "UnauthorizedOperation",
+                    "Message": "You are not authorized to delete this fleet",
+                }
+            },
+            "DeleteFleets",
         )
+
+        with pytest.raises(SpotFleetError) as excinfo:
+            spot_fleet_manager.terminate_block("block-1")
+
+        # The EC2 code must survive the double wrapping, or the message names
+        # only the wrapper and the operator cannot tell a permissions failure
+        # from a transient one.
+        assert "UnauthorizedOperation" in str(excinfo.value)
+
+    def test_a_throttled_deletion_surfaces_its_retry_interval(self, spot_fleet_manager):
+        """Throttling must stay distinguishable through the wrapper.
+
+        Same defect as above, but this is the case where the erasure cost
+        something concrete: ``SpotFleetThrottlingError`` carries the
+        ``retry_after`` AWS supplied, and reporting it as a generic
+        ``ResourceCleanupError`` discarded that value -- leaving a caller to
+        retry blind against a throttle.
+        """
+        spot_fleet_manager.blocks["block-1"] = {
+            "id": "block-1",
+            "fleet_request_id": "fleet-12345",
+            "status": "running",
+            "instance_ids": [],
+        }
+        spot_fleet_manager.ec2_client.delete_fleets.side_effect = ClientError(
+            {
+                "Error": {"Code": "RequestLimitExceeded", "Message": "Slow down"},
+                "ResponseMetadata": {"RetryAfter": 45},
+            },
+            "DeleteFleets",
+        )
+
+        with pytest.raises(SpotFleetThrottlingError) as excinfo:
+            spot_fleet_manager.terminate_block("block-1")
+
+        assert excinfo.value.retry_after == 45
+        assert excinfo.value.operation == "delete_fleets"
+
+    def test_deleting_an_absent_fleet_is_not_an_error(self, spot_fleet_manager):
+        """A fleet AWS has already forgotten counts as deleted, not as failure.
+
+        Termination has to be idempotent -- cleanup runs it on paths that may
+        have already run it.
+
+        Retargeted at ``DeleteFleets`` (#86), which also makes the test do
+        something: stubbing ``cancel_spot_fleet_requests`` was inert once the
+        manager stopped calling it, and it passed vacuously because the
+        unstubbed ``delete_fleets`` returned a MagicMock whose
+        ``UnsuccessfulFleetDeletions`` iterated as empty.
+
+        EC2 reports the absent fleet two different ways, and both are exercised
+        here because only one of them is an exception: an ID that never existed
+        raises ``InvalidFleetId.NotFound``, while a well-formed one EC2 has
+        forgotten comes back as a ``fleetIdDoesNotExist`` entry in
+        ``UnsuccessfulFleetDeletions`` on an otherwise successful call -- so a
+        handler that only caught the raise would treat the ordinary case as a
+        cleanup failure.
+        """
+        spot_fleet_manager.ec2_client.delete_fleets.side_effect = ClientError(
+            {
+                "Error": {
+                    "Code": "InvalidFleetId.NotFound",
+                    "Message": "The fleet does not exist",
+                }
+            },
+            "DeleteFleets",
+        )
+        spot_fleet_manager.blocks["block-1"] = {
+            "id": "block-1",
+            "fleet_request_id": "fleet-12345",
+            "status": "running",
+            "instance_ids": [],
+        }
 
         spot_fleet_manager.terminate_block("block-1")
 
         assert spot_fleet_manager.blocks["block-1"]["status"] == STATUS_CANCELLED
+
+        # The inline form, on a call that did not raise at all.
+        spot_fleet_manager.ec2_client.delete_fleets.side_effect = None
+        spot_fleet_manager.ec2_client.delete_fleets.return_value = {
+            "SuccessfulFleetDeletions": [],
+            "UnsuccessfulFleetDeletions": [
+                {
+                    "FleetId": "fleet-67890",
+                    "Error": {
+                        "Code": "fleetIdDoesNotExist",
+                        "Message": "The fleet ID does not exist",
+                    },
+                }
+            ],
+        }
+        spot_fleet_manager.blocks["block-2"] = {
+            "id": "block-2",
+            "fleet_request_id": "fleet-67890",
+            "status": "running",
+            "instance_ids": [],
+        }
+
+        spot_fleet_manager.terminate_block("block-2")
+
+        assert spot_fleet_manager.blocks["block-2"]["status"] == STATUS_CANCELLED
 
 
 class TestLambdaManagerErrors:

--- a/tests/unit/test_launch_templates.py
+++ b/tests/unit/test_launch_templates.py
@@ -683,7 +683,13 @@ class TestStandardModeLaunchPaths:
 
 
 class TestSpotFleetLaunchTemplate:
-    """Spot Fleet reaches IMDSv2 only through a launch template."""
+    """An EC2 Fleet reaches its instances only through a launch template.
+
+    True by construction since #86: ``CreateFleet`` has no
+    ``LaunchSpecifications`` member, so there is nothing to fall back to and no
+    way to launch without a template. Under the legacy ``RequestSpotFleet`` the
+    template was merely preferred, and the fallback silently dropped IMDSv2.
+    """
 
     @pytest.fixture
     def ec2(self):
@@ -691,7 +697,13 @@ class TestSpotFleetLaunchTemplate:
         client.create_launch_template.return_value = {
             "LaunchTemplate": {"LaunchTemplateId": "lt-fleet", "LatestVersionNumber": 1}
         }
-        client.request_spot_fleet.return_value = {"SpotFleetRequestId": "sfr-1"}
+        client.create_fleet.return_value = {
+            "FleetId": "fleet-1",
+            "Instances": [{"InstanceIds": ["i-1"]}],
+        }
+        client.describe_spot_price_history.return_value = {
+            "SpotPriceHistory": [{"SpotPrice": "0.01"}]
+        }
         return client
 
     @pytest.fixture
@@ -728,7 +740,7 @@ class TestSpotFleetLaunchTemplate:
             return SpotFleetManager(provider)
 
     def _request(self, manager):
-        manager._create_spot_fleet_request(
+        manager._create_fleet(
             "block-1",
             {
                 "vpc_id": "vpc-1",
@@ -736,23 +748,25 @@ class TestSpotFleetLaunchTemplate:
                 "security_group_id": "sg-1",
             },
             1,
-            "arn:aws:iam::1:role/fleet",
         )
-        return manager.ec2_client.request_spot_fleet.call_args.kwargs[
-            "SpotFleetRequestConfig"
-        ]
+        return manager.ec2_client.create_fleet.call_args.kwargs
 
     def test_fleet_request_sends_only_the_template_form(self, manager):
-        """EC2 accepts both keys, then silently ignores the template.
+        """There is no other form to send.
 
-        DryRun against real EC2 returns ``DryRunOperation`` for a request
-        carrying ``LaunchSpecifications`` *and* ``LaunchTemplateConfigs`` -- and
-        the specifications win, taking IMDSv2 with them.
+        Under ``RequestSpotFleet`` this was a real hazard: EC2 accepted a request
+        carrying ``LaunchSpecifications`` *and* ``LaunchTemplateConfigs`` --
+        DryRun against real EC2 returned ``DryRunOperation`` -- then let the
+        specifications win, taking IMDSv2 with them. ``CreateFleet`` has no
+        ``LaunchSpecifications`` member at all, so the hazard is structural now
+        rather than a matter of care (#86). Asserted anyway: the legacy key would
+        be rejected outright, so sending it would fail every launch.
         """
         config = self._request(manager)
 
         assert "LaunchTemplateConfigs" in config
         assert "LaunchSpecifications" not in config
+        assert "SpotFleetRequestConfig" not in config
 
     def test_fleet_template_requires_imdsv2(self, manager, ec2):
         """The only route: ``SpotFleetLaunchSpecification`` has no
@@ -783,34 +797,56 @@ class TestSpotFleetLaunchTemplate:
         }
 
     def test_every_instance_type_becomes_an_override(self, manager):
-        """One template covers every pool the fleet may draw from."""
+        """One template covers every pool the fleet may draw from.
+
+        Each type must appear exactly once. ``CreateFleet`` rejects a repeated
+        pool -- "InvalidFleetConfig: The fleet configuration contains duplicate
+        instance pools" -- and ``DryRun=True`` does *not* catch it, so a
+        duplicate would only surface on a real launch.
+        """
         config = self._request(manager)
 
         overrides = config["LaunchTemplateConfigs"][0]["Overrides"]
+        pools = [(o["InstanceType"], o["SubnetId"]) for o in overrides]
+        assert len(pools) == len(set(pools))
         assert [o["InstanceType"] for o in overrides] == ["t3.micro", "t3.small"]
         assert all(o["SubnetId"] == "subnet-1" for o in overrides)
 
-    def test_template_failure_falls_back_to_launch_specifications(self, manager, ec2):
-        """Unavoidably without IMDSv2, but a working fleet beats no fleet."""
+    def test_template_failure_fails_the_block(self, manager, ec2):
+        """A template that cannot be created must fail the block, not degrade it.
+
+        This inverts what the legacy path did. ``RequestSpotFleet`` accepted
+        inline ``LaunchSpecifications``, so a failed template fell back to them
+        -- launching a working fleet, but silently without IMDSv2, since
+        ``SpotFleetLaunchSpecification`` has no ``MetadataOptions`` member.
+        ``CreateFleet`` has no such member either, so there is nothing to fall
+        back to and the failure surfaces (#86). Worth asserting rather than
+        assuming: a fallback reintroduced here would be an unannounced security
+        downgrade.
+        """
         ec2.create_launch_template.side_effect = _client_error(
             "UnauthorizedOperation", "CreateLaunchTemplate"
         )
 
+        with pytest.raises(ResourceCreationError):
+            self._request(manager)
+
+        ec2.create_fleet.assert_not_called()
+
+    def test_no_fleet_is_requested_without_a_template(self, manager, ec2):
+        """Every launch goes through the template, so every launch gets IMDSv2.
+
+        The one property the fallback used to break. Asserting on the encoded
+        UserData is how the launch is shown to be template-borne: the fleet
+        request itself carries none, because ``CreateFleet``'s ``Overrides``
+        shape has no ``UserData`` member.
+        """
         config = self._request(manager)
 
-        assert "LaunchSpecifications" in config
-        assert "LaunchTemplateConfigs" not in config
-
-    def test_fallback_user_data_is_encoded(self, manager, ec2):
-        """``SpotFleetLaunchSpecification`` is not auto-encoded either."""
-        ec2.create_launch_template.side_effect = _client_error(
-            "UnauthorizedOperation", "CreateLaunchTemplate"
-        )
-
-        config = self._request(manager)
-
-        spec = config["LaunchSpecifications"][0]
-        assert base64.b64decode(spec["UserData"]).decode().startswith("#!/bin/bash")
+        assert "UserData" not in config
+        data = ec2.create_launch_template.call_args.kwargs["LaunchTemplateData"]
+        assert base64.b64decode(data["UserData"]).decode().startswith("#!/bin/bash")
+        assert data["MetadataOptions"]["HttpTokens"] == "required"
 
     def test_template_is_tracked_per_block(self, manager):
         self._request(manager)
@@ -820,7 +856,7 @@ class TestSpotFleetLaunchTemplate:
     def test_terminating_a_block_deletes_its_template(self, manager, ec2):
         self._request(manager)
         manager.blocks["block-1"] = {
-            "fleet_request_id": "sfr-1",
+            "fleet_request_id": "fleet-1",
             "instance_ids": [],
             "status": "RUNNING",
         }

--- a/tests/unit/test_provider_edge_cases.py
+++ b/tests/unit/test_provider_edge_cases.py
@@ -14,6 +14,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from parsl_ephemeral_aws.constants import (
+    DEFAULT_WARM_POOL_SIZE,
+    DEFAULT_WARM_POOL_TTL,
+)
 from parsl_ephemeral_aws.exceptions import ProviderConfigurationError, ProviderError
 from parsl_ephemeral_aws.provider import EphemeralAWSProvider
 from parsl_ephemeral_aws.state.base import STATE_KEY_MODE, STATE_KEY_PROVIDER
@@ -173,11 +177,26 @@ class TestWarmPool:
     # --- parameter / guard tests ---
 
     def test_warm_pool_disabled_by_default(self, tmp_dir):
-        """warm_pool_size defaults to 0 and warm_pool_ttl to 600."""
+        """The pool is off by default, and a warm instance's TTL is short.
+
+        A warm instance is *Running*, not Stopped, so it bills at the full rate
+        for the whole TTL -- AWS calls keeping warm instances running "highly
+        discouraged to avoid incurring unnecessary charges". This package cannot
+        use the native ASG warm pool that holds them Stopped, because dispatch is
+        SSM ``SendCommand`` and a Stopped instance runs no agent (#130 tracks the
+        pull model that would allow it). So the cost is bounded instead: the TTL
+        default was cut from the 600s v0.6.0 shipped with to
+        ``DEFAULT_WARM_POOL_TTL`` (#86).
+
+        Asserted against the constant rather than a literal, so the intent -- off
+        by default, and short-lived when on -- survives the next revision of the
+        number.
+        """
         provider, _ = _make_provider(tmp_dir)
 
-        assert provider.warm_pool_size == 0
-        assert provider.warm_pool_ttl == 600
+        assert provider.warm_pool_size == DEFAULT_WARM_POOL_SIZE == 0
+        assert provider.warm_pool_ttl == DEFAULT_WARM_POOL_TTL
+        assert DEFAULT_WARM_POOL_TTL <= 120
 
     def test_warm_pool_iam_guard_raises(self, tmp_dir):
         """warm_pool_size > 0 without an IAM profile raises ValueError."""
@@ -1126,11 +1145,15 @@ class TestStandardOnlyOptionGuard:
 
         The guard compares against the default rather than testing presence, so
         ``warm_pool_size=0`` -- which asks for nothing -- must be allowed.
+
+        The values come from the constants, not literals: the TTL default moved
+        600 -> 120 in #86, and a hardcoded 600 here stopped being "the default"
+        without ceasing to look like it.
         """
         provider = _construct(
             mode,
-            warm_pool_size=0,
-            warm_pool_ttl=600,
+            warm_pool_size=DEFAULT_WARM_POOL_SIZE,
+            warm_pool_ttl=DEFAULT_WARM_POOL_TTL,
             bake_ami=False,
             baked_ami_id=None,
             one_shot=False,

--- a/tests/unit/test_serverless_mode_spot_fleet.py
+++ b/tests/unit/test_serverless_mode_spot_fleet.py
@@ -4,16 +4,19 @@ SPDX-License-Identifier: Apache-2.0
 SPDX-FileCopyrightText: 2025 Scott Friedman and Project Contributors
 """
 
+import base64
 import pytest
 from unittest.mock import MagicMock, patch
 import boto3
 import time
 
+from parsl_ephemeral_aws.exceptions import OperatingModeError
 from parsl_ephemeral_aws.modes.serverless import ServerlessMode
 from parsl_ephemeral_aws.constants import (
     RESOURCE_TYPE_SPOT_FLEET,
     WORKER_TYPE_LAMBDA,
     WORKER_TYPE_ECS,
+    STATUS_COMPLETED,
     STATUS_PENDING,
     STATUS_RUNNING,
     STATUS_FAILED,
@@ -66,66 +69,110 @@ class TestServerlessModeSpotFleet:
 
     @pytest.fixture
     def mock_ec2_client(self):
-        """Create a mock EC2 client."""
+        """Create a mock EC2 client, answering the EC2 Fleet API (#86).
+
+        The legacy ``describe_spot_fleet_requests`` /
+        ``cancel_spot_fleet_requests`` answers this fixture used to carry are
+        gone with the API: the mode now calls ``CreateFleet``, ``DescribeFleets``
+        and ``DeleteFleets``. They are left unstubbed deliberately, so a
+        reintroduced call shows up as a bare MagicMock rather than quietly
+        passing.
+
+        ``create_launch_template`` has to be answered because the template is
+        mandatory -- ``CreateFleet`` has no ``LaunchSpecifications`` member, and
+        ``Overrides`` cannot carry ``UserData``, so the per-job command has
+        nowhere else to live.
+        """
         client = MagicMock()
 
-        # Mock create_vpc
-        client.create_vpc.return_value = {"Vpc": {"VpcId": "vpc-12345"}}
-
-        # Mock describe_vpcs
+        # Mock describe_vpcs / describe_subnets / describe_security_groups, which
+        # _verify_resources() reads. Nothing creates any of the three since #69.
         client.describe_vpcs.return_value = {"Vpcs": [{"VpcId": "vpc-12345"}]}
-
-        # Mock create_subnet
-        client.create_subnet.return_value = {"Subnet": {"SubnetId": "subnet-12345"}}
-
-        # Mock describe_subnets
         client.describe_subnets.return_value = {
             "Subnets": [{"SubnetId": "subnet-12345"}]
         }
-
-        # Mock create_security_group
-        client.create_security_group.return_value = {"GroupId": "sg-12345"}
-
-        # Mock describe_security_groups
         client.describe_security_groups.return_value = {
             "SecurityGroups": [{"GroupId": "sg-12345"}]
         }
 
-        # Mock describe_spot_fleet_requests. Both capacities live inside the
-        # nested SpotFleetRequestConfig — the entry itself carries only
-        # ActivityStatus/CreateTime/SpotFleetRequestConfig/SpotFleetRequestId/
-        # SpotFleetRequestState/Tags. These fixtures put FulfilledCapacity at the
-        # top level, which is precisely the misreading #114 fixed in the package.
-        client.describe_spot_fleet_requests.return_value = {
-            "SpotFleetRequestConfigs": [
-                {
-                    "SpotFleetRequestId": "sfr-12345",
-                    "SpotFleetRequestState": "active",
-                    "SpotFleetRequestConfig": {
-                        "TargetCapacity": 2,
-                        "FulfilledCapacity": 2,
-                    },
-                }
-            ]
+        client.create_launch_template.return_value = {
+            "LaunchTemplate": {
+                "LaunchTemplateId": "lt-12345",
+                "LatestVersionNumber": 1,
+            }
         }
 
-        # Mock cancel_spot_fleet_requests
-        client.cancel_spot_fleet_requests.return_value = {
-            "SuccessfulFleetRequests": [
+        # An instant fleet returns its instance IDs synchronously, which is why
+        # this fleet type was chosen: the block knows its instances without
+        # polling, and the fleet ID no longer has to be recovered from stack
+        # outputs.
+        client.create_fleet.return_value = {
+            "FleetId": "fleet-12345",
+            "Instances": [{"InstanceIds": ["i-11111111", "i-22222222"]}],
+        }
+
+        client.describe_fleets.return_value = {
+            "Fleets": [{"FleetId": "fleet-12345", "FleetState": "active"}]
+        }
+
+        client.delete_fleets.return_value = {
+            "SuccessfulFleetDeletions": [
                 {
-                    "SpotFleetRequestId": "sfr-12345",
-                    "CurrentSpotFleetRequestState": "cancelled_terminating",
-                    "PreviousSpotFleetRequestState": "active",
+                    "FleetId": "fleet-12345",
+                    "CurrentFleetState": "deleted_terminating",
+                    "PreviousFleetState": "active",
                 }
             ],
-            "UnsuccessfulFleetRequests": [],
+            "UnsuccessfulFleetDeletions": [],
+        }
+
+        # An instant fleet's live instances are found only by filtering
+        # describe_instances on the aws:ec2:fleet-id tag: describe_fleet_instances
+        # refuses the fleet type outright, and describe_fleets' own Instances list
+        # reflects the original launch and never drops terminated instances.
+        instances_paginator = MagicMock()
+        instances_paginator.paginate.return_value = [
+            {
+                "Reservations": [
+                    {
+                        "Instances": [
+                            {"InstanceId": "i-11111111"},
+                            {"InstanceId": "i-22222222"},
+                        ]
+                    }
+                ]
+            }
+        ]
+        client.get_paginator.return_value = instances_paginator
+
+        client.describe_spot_price_history.return_value = {
+            "SpotPriceHistory": [{"SpotPrice": "0.01"}]
         }
 
         return client
 
     @pytest.fixture
+    def mock_ssm_client(self):
+        """Answer the public AL2023 AMI alias the fleet resolves its image from.
+
+        ``image_id`` is unset on this mode, so ``_resolve_fleet_image_id()`` goes
+        to SSM (#83). Answering it here keeps the resolved AMI a real string that
+        the launch-template assertions can check, instead of a MagicMock repr.
+        """
+        client = MagicMock()
+        client.get_parameter.return_value = {
+            "Parameter": {"Value": "ami-0abcdef1234567890"}
+        }
+        return client
+
+    @pytest.fixture
     def serverless_mode_with_spot_fleet(
-        self, mock_session, mock_state_store, mock_ec2_client, mock_cf_client
+        self,
+        mock_session,
+        mock_state_store,
+        mock_ec2_client,
+        mock_cf_client,
+        mock_ssm_client,
     ):
         """Create a ServerlessMode instance with SpotFleet enabled."""
 
@@ -135,6 +182,8 @@ class TestServerlessModeSpotFleet:
                 return mock_ec2_client
             elif service_name == "cloudformation":
                 return mock_cf_client
+            elif service_name == "ssm":
+                return mock_ssm_client
             return MagicMock()
 
         mock_session.client.side_effect = get_client
@@ -190,14 +239,25 @@ class TestServerlessModeSpotFleet:
         assert "m5.large" in mode.instance_types
 
     def test_submit_job_with_spot_fleet(
-        self, serverless_mode_with_spot_fleet, mock_cf_client
+        self, serverless_mode_with_spot_fleet, mock_cf_client, mock_ec2_client
     ):
-        """Test job submission with SpotFleet options.
+        """A fleet-backed submit calls CreateFleet directly, with no stack (#86).
 
-        The packaged ``ecs_worker.yml`` is loaded for real. This used to patch
-        ``os.path.join`` *globally* and stub ``builtins.open`` to return "template
-        content"; the mode now goes through ``get_cf_template()`` (#113), and
-        patching every path join in the interpreter was never safe.
+        This used to assert on ``create_stack`` parameters
+        (``UseSpotFleet``/``UseSpot``/``NodesPerBlock``/``SpotMaxPricePercentage``/
+        ``InstanceTypes``), all of which fed an ``AWS::EC2::SpotFleet`` resource in
+        ``ecs_worker.yml``. CloudFormation cannot build this fleet at all: the
+        ``Overrides`` list is variable-length, ``Fn::ForEach`` expands to a map
+        rather than a list, an out-of-range ``!Select`` fails validation even
+        inside an untaken ``!If`` branch, and padding the slots by repeating a
+        type is rejected by EC2 as ``InvalidFleetConfig: duplicate instance
+        pools`` -- which a ``DryRun`` does *not* catch. Deploying the stack also
+        created an ECS cluster, task definition, two IAM roles and a log group
+        that an EC2 fleet never touches.
+
+        So the assertions move to the API the mode now calls, and the fact that no
+        stack is created is itself asserted: ``get_job_status()`` and
+        ``cleanup_resources()`` both branch on the *absence* of ``stack_name``.
         """
         # Setup for job submission
         serverless_mode_with_spot_fleet.initialized = True
@@ -207,124 +267,243 @@ class TestServerlessModeSpotFleet:
             "job-1", "echo hello", 2
         )
 
-        # Verify CloudFormation stack was created
-        mock_cf_client.create_stack.assert_called_once()
-        args, kwargs = mock_cf_client.create_stack.call_args
-        assert kwargs["StackName"].startswith("parsl-ecs-")
+        # No stack, and no ECS machinery -- the fleet is created directly.
+        mock_cf_client.create_stack.assert_not_called()
 
-        # Verify stack parameters include SpotFleet options
-        params = {p["ParameterKey"]: p["ParameterValue"] for p in kwargs["Parameters"]}
-        assert params["UseSpotFleet"] == "true"
-        assert params["UseSpot"] == "false"  # SpotFleet overrides Fargate Spot
-        assert params["NodesPerBlock"] == "2"
-        assert params["SpotMaxPricePercentage"] == "80"
-        assert "t3.small" in params["InstanceTypes"]
-        assert "t3.medium" in params["InstanceTypes"]
-        assert "m5.small" in params["InstanceTypes"]
+        # The launch template is mandatory, and the per-job command travels in it
+        # because a fleet override cannot carry UserData.
+        mock_ec2_client.create_launch_template.assert_called_once()
+        template_kwargs = mock_ec2_client.create_launch_template.call_args.kwargs
+        assert template_kwargs["LaunchTemplateName"].endswith("-ecs-job-1")
+        template_data = template_kwargs["LaunchTemplateData"]
+        assert template_data["ImageId"] == "ami-0abcdef1234567890"
+        # An instance that shuts itself down after its one command must terminate,
+        # not stop and leave a billed EBS volume behind.
+        assert template_data["InstanceInitiatedShutdownBehavior"] == "terminate"
+        assert template_data["MetadataOptions"]["HttpTokens"] == "required"
+        user_data = base64.b64decode(template_data["UserData"]).decode()
+        assert "echo hello" in user_data
+        assert "shutdown -h now" in user_data
+
+        # The fleet itself: one override per instance type, all spot, and the
+        # kebab-case allocation strategy CreateFleet requires -- it rejects the
+        # camelCase spelling RequestSpotFleet demanded.
+        mock_ec2_client.create_fleet.assert_called_once()
+        fleet_kwargs = mock_ec2_client.create_fleet.call_args.kwargs
+        assert fleet_kwargs["Type"] == "instant"
+        assert fleet_kwargs["TargetCapacitySpecification"] == {
+            "TotalTargetCapacity": 2,
+            "DefaultTargetCapacityType": "spot",
+        }
+        assert fleet_kwargs["SpotOptions"]["AllocationStrategy"] == (
+            "price-capacity-optimized"
+        )
+        overrides = fleet_kwargs["LaunchTemplateConfigs"][0]["Overrides"]
+        assert [o["InstanceType"] for o in overrides] == [
+            "t3.small",
+            "t3.medium",
+            "m5.small",
+        ]
+        # The template is referenced by pinned version, never $Latest: the fleet
+        # must launch the definition just built, not one a concurrent provider
+        # added afterwards.
+        spec = fleet_kwargs["LaunchTemplateConfigs"][0]["LaunchTemplateSpecification"]
+        assert spec == {"LaunchTemplateId": "lt-12345", "Version": "1"}
+        # spot_max_price_percentage=80 of the 3x-spot on-demand proxy (0.01),
+        # times the two nodes MaxTotalPrice covers.
+        assert fleet_kwargs["SpotOptions"]["MaxTotalPrice"] == str(0.03 * 0.8 * 2)
 
         # Verify resource tracking
         assert resource_id in serverless_mode_with_spot_fleet.resources
-        assert (
-            serverless_mode_with_spot_fleet.resources[resource_id]["job_id"] == "job-1"
-        )
-        assert (
-            serverless_mode_with_spot_fleet.resources[resource_id]["worker_type"]
-            == WORKER_TYPE_ECS
-        )
-        assert (
-            serverless_mode_with_spot_fleet.resources[resource_id]["status"]
-            == STATUS_PENDING
-        )
-        assert (
-            serverless_mode_with_spot_fleet.resources[resource_id]["use_spot_fleet"]
-            is True
-        )
+        resource = serverless_mode_with_spot_fleet.resources[resource_id]
+        assert resource["job_id"] == "job-1"
+        assert resource["worker_type"] == WORKER_TYPE_ECS
+        assert resource["status"] == STATUS_PENDING
+        assert resource["use_spot_fleet"] is True
+        assert resource["resource_type"] == RESOURCE_TYPE_SPOT_FLEET
+        assert resource["fleet_request_id"] == "fleet-12345"
+        # Both IDs are needed to reclaim the job: the fleet holds the instances,
+        # and the template is a per-job resource only this record names.
+        assert resource["launch_template_id"] == "lt-12345"
+        assert resource["instance_ids"] == ["i-11111111", "i-22222222"]
+        assert "stack_name" not in resource
 
         # Verify state was saved
         serverless_mode_with_spot_fleet.state_store.save_state.assert_called()
 
+    def test_submit_job_fails_when_the_fleet_is_unfilled(
+        self, serverless_mode_with_spot_fleet, mock_ec2_client
+    ):
+        """An instant fleet that filled nothing is a failed submit, not a pending one.
+
+        ``CreateFleet`` reports a pool it could not fill *inline*, in ``Errors``,
+        rather than failing the call -- so an empty fleet is a 200 response. Left
+        unchecked the block would sit PENDING forever waiting for instances that
+        an instant fleet will never make another attempt to launch.
+        """
+        serverless_mode_with_spot_fleet.initialized = True
+        serverless_mode_with_spot_fleet.ecs_manager = MagicMock()
+        mock_ec2_client.create_fleet.return_value = {
+            "FleetId": "fleet-12345",
+            "Instances": [],
+            "Errors": [
+                {
+                    "ErrorCode": "InsufficientInstanceCapacity",
+                    "ErrorMessage": "There is no Spot capacity available.",
+                }
+            ],
+        }
+
+        with pytest.raises(OperatingModeError, match="Failed to submit job job-1"):
+            serverless_mode_with_spot_fleet.submit_job("job-1", "echo hello", 2)
+
+        # The empty fleet is deleted rather than left as a resource that holds
+        # nothing and will never grow, and the per-job template goes with it.
+        #
+        # The fleet is deleted twice and that is deliberate rather than
+        # coincidental: ``_create_job_fleet`` drops it inline, and the record it
+        # already annotated then routes the failed submit through
+        # ``cleanup_resources() -> _reclaim_fleet()``, which drops it again along
+        # with the template. Asserting a count here would assert the coincidence.
+        # Deleting twice is safe -- verified against real EC2, where the second
+        # DeleteFleets also reports ``deleted_terminating`` -- and belt-and-braces
+        # is the right trade for instances that would otherwise bill untracked.
+        mock_ec2_client.delete_fleets.assert_called_with(
+            FleetIds=["fleet-12345"], TerminateInstances=True
+        )
+        # The template goes only through the submit-failure path: the unfilled
+        # raise sits *after* the try block whose handler deletes it inline.
+        mock_ec2_client.delete_launch_template.assert_called_once_with(
+            LaunchTemplateId="lt-12345"
+        )
+        # And the record is gone, so nothing later re-reports the dead job.
+        assert serverless_mode_with_spot_fleet.resources == {}
+
+    def test_submit_job_without_a_subnet_creates_no_template(
+        self, serverless_mode_with_spot_fleet, mock_ec2_client
+    ):
+        """A missing subnet has to be refused before anything is created.
+
+        Every fleet override names the subnet to launch into, so an unset one
+        reaches ``CreateFleet`` as a null and is refused there -- by which point
+        the launch template exists and has to be cleaned up on the way out. The
+        ECS guard in ``submit_job`` covers the Fargate path, but the fleet path
+        returns before reaching it.
+        """
+        serverless_mode_with_spot_fleet.initialized = True
+        serverless_mode_with_spot_fleet.ecs_manager = MagicMock()
+        serverless_mode_with_spot_fleet.subnet_id = None
+
+        with pytest.raises(OperatingModeError, match="Failed to submit job job-1"):
+            serverless_mode_with_spot_fleet.submit_job("job-1", "echo hello", 2)
+
+        mock_ec2_client.create_launch_template.assert_not_called()
+        mock_ec2_client.create_fleet.assert_not_called()
+
     def test_get_spot_fleet_status(
         self, serverless_mode_with_spot_fleet, mock_ec2_client
     ):
-        """Test getting status for a SpotFleet job."""
-        # Test with active, fulfilled fleet
-        status = serverless_mode_with_spot_fleet._get_spot_fleet_status("sfr-12345")
-        assert status == STATUS_RUNNING
+        """Status now comes from ``FleetState`` plus the fleet's live instances (#86).
 
-        # Test with active but not fulfilled fleet
-        mock_ec2_client.describe_spot_fleet_requests.return_value = {
-            "SpotFleetRequestConfigs": [
+        The capacity comparison this replaced cannot decide an instant fleet's
+        status at all: the fleet does not maintain capacity, so ``FleetState``
+        stays ``active`` for its whole life and the counters keep reporting the
+        original launch however many instances have since died. It was also the
+        site of #114, where ``FulfilledCapacity`` was read from the wrong nesting
+        level, came back 0 forever, and left every block PENDING.
+        """
+        mode = serverless_mode_with_spot_fleet
+
+        def set_state(state):
+            mock_ec2_client.describe_fleets.return_value = {
+                "Fleets": [{"FleetId": "fleet-12345", "FleetState": state}]
+            }
+
+        def set_instances(instance_ids):
+            mock_ec2_client.get_paginator.return_value.paginate.return_value = [
                 {
-                    "SpotFleetRequestId": "sfr-12345",
-                    "SpotFleetRequestState": "active",
-                    "SpotFleetRequestConfig": {
-                        "TargetCapacity": 2,
-                        "FulfilledCapacity": 1,  # Only half fulfilled
-                    },
+                    "Reservations": [
+                        {"Instances": [{"InstanceId": i} for i in instance_ids]}
+                    ]
                 }
             ]
-        }
-        status = serverless_mode_with_spot_fleet._get_spot_fleet_status("sfr-12345")
-        assert status == STATUS_PENDING
 
-        # Test with submitted fleet
-        mock_ec2_client.describe_spot_fleet_requests.return_value = {
-            "SpotFleetRequestConfigs": [
-                {
-                    "SpotFleetRequestId": "sfr-12345",
-                    "SpotFleetRequestState": "submitted",
-                }
-            ]
-        }
-        status = serverless_mode_with_spot_fleet._get_spot_fleet_status("sfr-12345")
-        assert status == STATUS_PENDING
+        # Active with live instances -> RUNNING.
+        assert mode._get_spot_fleet_status("fleet-12345") == STATUS_RUNNING
+        mock_ec2_client.describe_fleets.assert_called_with(FleetIds=["fleet-12345"])
+        # The ID is always passed: AWS returns instant fleets from DescribeFleets
+        # only when asked for by ID, so an unfiltered call finds nothing.
+        mock_ec2_client.describe_spot_fleet_requests.assert_not_called()
 
-        # Test with cancelled fleet
-        mock_ec2_client.describe_spot_fleet_requests.return_value = {
-            "SpotFleetRequestConfigs": [
-                {
-                    "SpotFleetRequestId": "sfr-12345",
-                    "SpotFleetRequestState": "cancelled",
-                }
-            ]
-        }
-        status = serverless_mode_with_spot_fleet._get_spot_fleet_status("sfr-12345")
-        assert status == STATUS_CANCELLED
+        # Active with nothing left running -> terminal, so Parsl frees the block.
+        # An instant fleet makes no further launch attempts, so there is nothing
+        # to wait for.
+        set_instances([])
+        assert mode._get_spot_fleet_status("fleet-12345") == STATUS_COMPLETED
+        # ...and the instances are found through the fleet-id tag EC2 stamps on
+        # them, the only route that works for this fleet type.
+        paginate_kwargs = (
+            mock_ec2_client.get_paginator.return_value.paginate.call_args.kwargs
+        )
+        assert {
+            "Name": "tag:aws:ec2:fleet-id",
+            "Values": ["fleet-12345"],
+        } in paginate_kwargs["Filters"]
 
-        # Test with failed fleet
-        mock_ec2_client.describe_spot_fleet_requests.return_value = {
-            "SpotFleetRequestConfigs": [
-                {"SpotFleetRequestId": "sfr-12345", "SpotFleetRequestState": "failed"}
-            ]
-        }
-        status = serverless_mode_with_spot_fleet._get_spot_fleet_status("sfr-12345")
-        assert status == STATUS_FAILED
+        set_instances(["i-11111111"])
+        for state, expected in [
+            ("submitted", STATUS_PENDING),
+            ("modifying", STATUS_PENDING),
+            # Deleting but the instances have not gone yet, so the workers are
+            # still live.
+            ("deleted_running", STATUS_RUNNING),
+            ("deleted", STATUS_CANCELLED),
+            ("deleted_terminating", STATUS_CANCELLED),
+            ("failed", STATUS_FAILED),
+        ]:
+            set_state(state)
+            assert mode._get_spot_fleet_status("fleet-12345") == expected, state
+
+        # A fleet EC2 has forgotten is terminal, not unknown: its instances are
+        # long gone, so reporting UNKNOWN would leave the block held forever.
+        mock_ec2_client.describe_fleets.return_value = {"Fleets": []}
+        assert mode._get_spot_fleet_status("fleet-12345") == STATUS_COMPLETED
 
     def test_get_job_status_for_spot_fleet(
         self, serverless_mode_with_spot_fleet, mock_cf_client, mock_ec2_client
     ):
-        """Test getting job status for a SpotFleet job."""
-        # Setup resources with SpotFleet
+        """A fleet-backed job's status is read from the fleet, never a stack (#86).
+
+        The fleet ID no longer has to be recovered by polling stack outputs -- it
+        comes back from ``CreateFleet`` itself, so the record carries it from the
+        moment of submit. That closes a real window: registration for interruption
+        handling used to wait up to three minutes for CREATE_COMPLETE, during which
+        an interruption went unhandled.
+
+        The stack branch has to stay unreached rather than merely unused: a
+        fleet-backed record has no ``stack_name``, so falling through to it would
+        report UNKNOWN and leave the instances running.
+        """
+        # Setup resources as _create_job_fleet leaves them: fleet and template
+        # IDs, and no stack name.
         resource_id = "serverless-ecs-job-1"
         serverless_mode_with_spot_fleet.resources = {
             resource_id: {
                 "job_id": "job-1",
                 "worker_type": WORKER_TYPE_ECS,
-                "stack_name": "parsl-ecs-12345",
                 "status": STATUS_PENDING,
                 "created_at": time.time() - 60,
                 "use_spot_fleet": True,
+                "resource_type": RESOURCE_TYPE_SPOT_FLEET,
+                "fleet_request_id": "fleet-12345",
+                "launch_template_id": "lt-12345",
             }
         }
 
-        # Get status (should detect and set fleet_request_id)
         status = serverless_mode_with_spot_fleet.get_job_status([resource_id])
 
-        # Verify CloudFormation and EC2 client calls
-        mock_cf_client.describe_stacks.assert_called_with(StackName="parsl-ecs-12345")
-        mock_ec2_client.describe_spot_fleet_requests.assert_called_with(
-            SpotFleetRequestIds=["sfr-12345"]
-        )
+        mock_cf_client.describe_stacks.assert_not_called()
+        mock_ec2_client.describe_fleets.assert_called_with(FleetIds=["fleet-12345"])
 
         # Verify status result and resource tracking updates
         assert status[resource_id] == STATUS_RUNNING
@@ -332,30 +511,29 @@ class TestServerlessModeSpotFleet:
             serverless_mode_with_spot_fleet.resources[resource_id]["status"]
             == STATUS_RUNNING
         )
-        assert (
-            serverless_mode_with_spot_fleet.resources[resource_id]["fleet_request_id"]
-            == "sfr-12345"
-        )
-        assert "resource_type" in serverless_mode_with_spot_fleet.resources[resource_id]
-        assert (
-            serverless_mode_with_spot_fleet.resources[resource_id]["resource_type"]
-            == RESOURCE_TYPE_SPOT_FLEET
-        )
 
     def test_cancel_spot_fleet_job(
         self, serverless_mode_with_spot_fleet, mock_cf_client, mock_ec2_client
     ):
-        """Test canceling a SpotFleet job."""
-        # Setup resources with SpotFleet
+        """Cancelling a fleet-backed job deletes the fleet and its template (#86).
+
+        Deleting the fleet *is* the cancellation, and it always terminates the
+        instances: AWS rejects ``NoTerminateInstances`` for an instant fleet, since
+        "a deleted instant fleet with running instances is not supported". The
+        template is deleted afterwards -- harmless to instances already launched
+        from it, but leaving it behind strands a per-job resource that only the
+        orphan sweep could find.
+        """
+        # Setup resources as _create_job_fleet leaves them.
         resource_id = "serverless-ecs-job-1"
         serverless_mode_with_spot_fleet.resources = {
             resource_id: {
                 "job_id": "job-1",
                 "worker_type": WORKER_TYPE_ECS,
-                "stack_name": "parsl-ecs-12345",
                 "status": STATUS_RUNNING,
                 "use_spot_fleet": True,
-                "fleet_request_id": "sfr-12345",
+                "fleet_request_id": "fleet-12345",
+                "launch_template_id": "lt-12345",
                 "resource_type": RESOURCE_TYPE_SPOT_FLEET,
             }
         }
@@ -363,13 +541,16 @@ class TestServerlessModeSpotFleet:
         # Cancel job
         status = serverless_mode_with_spot_fleet.cancel_jobs([resource_id])
 
-        # Verify EC2 client call to cancel SpotFleet
-        mock_ec2_client.cancel_spot_fleet_requests.assert_called_with(
-            SpotFleetRequestIds=["sfr-12345"], TerminateInstances=True
+        mock_ec2_client.delete_fleets.assert_called_once_with(
+            FleetIds=["fleet-12345"], TerminateInstances=True
         )
-
-        # Verify CloudFormation stack deletion
-        mock_cf_client.delete_stack.assert_called_with(StackName="parsl-ecs-12345")
+        mock_ec2_client.delete_launch_template.assert_called_once_with(
+            LaunchTemplateId="lt-12345"
+        )
+        # There is no stack to delete, and attempting one would raise from
+        # CloudFormation on a real account.
+        mock_cf_client.delete_stack.assert_not_called()
+        mock_ec2_client.cancel_spot_fleet_requests.assert_not_called()
 
         # Verify status result
         assert status[resource_id] == STATUS_CANCELLED

--- a/tests/unit/test_spot_fleet.py
+++ b/tests/unit/test_spot_fleet.py
@@ -13,7 +13,7 @@ import pytest
 
 from parsl_ephemeral_aws.compute.spot_fleet import SpotFleetManager
 from parsl_ephemeral_aws.constants import (
-    SPOT_FLEET_DEFAULT_ALLOCATION_STRATEGY,
+    EC2_FLEET_DEFAULT_ALLOCATION_STRATEGY,
     TAG_PREFIX,
 )
 from parsl_ephemeral_aws.exceptions import SpotFleetThrottlingError
@@ -37,6 +37,14 @@ class _SimpleProvider:
 
 class TestSpotFleetManager(unittest.TestCase):
     """Test suite for the SpotFleetManager class."""
+
+    # The resolved network every fleet launches into. Supplied by the caller
+    # since #69; the manager creates none of it.
+    NETWORK = {
+        "vpc_id": "vpc-12345678",
+        "subnet_id": "subnet-12345678",
+        "security_group_id": "sg-12345678",
+    }
 
     def setUp(self):
         """Set up the test environment."""
@@ -149,108 +157,29 @@ class TestSpotFleetManager(unittest.TestCase):
         self.assertIn("Starting Parsl worker setup for test-workflow-id", user_data)
         self.assertIn("Worker init script", user_data)
 
-    @patch("boto3.Session")
-    @patch("time.sleep", return_value=None)  # Don't actually sleep during tests
-    def test_get_iam_fleet_role_existing(self, mock_sleep, mock_session_cls):
-        """Test getting an existing IAM fleet role."""
-        # Configure mocks
-        mock_session = MagicMock()
-        mock_iam_client = MagicMock()
+    # The two tests that used to sit here covered ``_get_iam_fleet_role()``,
+    # which is gone with the API it served: ``CreateFleet`` has no
+    # ``IamFleetRole`` member, so an EC2 Fleet needs no service role at all
+    # (#86). Nothing creates the role any more, so there is nothing to assert
+    # about creating it. What *is* still worth asserting is that a fleet is
+    # requested without one, and that a role named by a pre-#86 state document is
+    # still cleaned up -- covered by
+    # ``test_fleet_request_carries_no_iam_fleet_role`` and
+    # ``test_legacy_iam_fleet_role_is_still_cleaned_up`` below.
 
-        mock_session_cls.return_value = mock_session
-        mock_session.client.side_effect = lambda service: {
-            "ec2": MagicMock(),
-            "iam": mock_iam_client,
-        }[service]
+    @patch("parsl_ephemeral_aws.compute.spot_fleet.CredentialManager")
+    def test_throttling_error_handling(self, mock_credential_manager_cls):
+        """A throttled ``CreateFleet`` must surface as SpotFleetThrottlingError.
 
-        # Mock get_role to return an existing role
-        mock_iam_client.get_role.return_value = {
-            "Role": {"Arn": "arn:aws:iam::123456789012:role/test-fleet-role"}
-        }
-
-        # Instantiate SpotFleetManager
-        manager = SpotFleetManager(self.mock_provider)
-
-        # Get IAM fleet role
-        role_arn = manager._get_iam_fleet_role()
-
-        # Verify the role ARN is correct
-        self.assertEqual(role_arn, "arn:aws:iam::123456789012:role/test-fleet-role")
-
-        # Verify get_role was called
-        # Derived from TAG_PREFIX, not spelled out, so a prefix change does not
-        # silently make this assertion stale again.
-        role_name = f"{TAG_PREFIX}-spot-fleet-role-{self.mock_provider.workflow_id[:8]}"
-        mock_iam_client.get_role.assert_called_with(RoleName=role_name)
-
-        # Verify create_role was not called
-        mock_iam_client.create_role.assert_not_called()
-
-    @patch("boto3.Session")
-    @patch("time.sleep", return_value=None)  # Don't actually sleep during tests
-    def test_get_iam_fleet_role_create_new(self, mock_sleep, mock_session_cls):
-        """Test creating a new IAM fleet role when one doesn't exist."""
-        # Configure mocks
-        mock_session = MagicMock()
-        mock_iam_client = MagicMock()
-
-        mock_session_cls.return_value = mock_session
-        mock_session.client.side_effect = lambda service: {
-            "ec2": MagicMock(),
-            "iam": mock_iam_client,
-        }[service]
-
-        # Mock get_role to raise NoSuchEntity error
-        mock_iam_client.get_role.side_effect = ClientError(
-            {
-                "Error": {"Code": "NoSuchEntity", "Message": "Role not found"},
-                "ResponseMetadata": {},
-            },
-            "GetRole",
-        )
-
-        # Mock create_role response
-        mock_iam_client.create_role.return_value = {
-            "Role": {"Arn": "arn:aws:iam::123456789012:role/new-fleet-role"}
-        }
-
-        # Instantiate SpotFleetManager
-        manager = SpotFleetManager(self.mock_provider)
-
-        # Get IAM fleet role (should create a new one)
-        role_arn = manager._get_iam_fleet_role()
-
-        # Verify the role ARN is correct
-        self.assertEqual(role_arn, "arn:aws:iam::123456789012:role/new-fleet-role")
-
-        # Verify get_role was called
-        # Derived from TAG_PREFIX, not spelled out, so a prefix change does not
-        # silently make this assertion stale again.
-        role_name = f"{TAG_PREFIX}-spot-fleet-role-{self.mock_provider.workflow_id[:8]}"
-        mock_iam_client.get_role.assert_called_with(RoleName=role_name)
-
-        # Verify create_role was called
-        mock_iam_client.create_role.assert_called_once()
-
-        # Verify attach_role_policy was called
-        mock_iam_client.attach_role_policy.assert_called_with(
-            RoleName=role_name,
-            PolicyArn="arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole",
-        )
-
-    @patch("boto3.Session")
-    def test_throttling_error_handling(self, mock_session_cls):
-        """Test handling of throttling errors."""
-        # Configure mocks
-        mock_session = MagicMock()
-        mock_ec2_client = MagicMock()
-
-        mock_session_cls.return_value = mock_session
-        mock_session.client.return_value = mock_ec2_client
-        mock_session.resource.return_value = MagicMock()
-
-        # Mock the request_spot_fleet to raise a throttling error
-        mock_ec2_client.request_spot_fleet.side_effect = ClientError(
+        Retargeted from ``request_spot_fleet`` to ``create_fleet`` (#86). The
+        translation happens in ``_translate_fleet_error``, and reaching it
+        requires the ``ClientError`` to arrive at ``_create_fleet`` unwrapped --
+        ``create_ec2_fleet`` used to wrap it in ``ResourceCreationError``, which
+        made the whole error branch, its audit log, and its launch-template
+        cleanup unreachable.
+        """
+        mock_ec2_client = self._mock_ec2(mock_credential_manager_cls)
+        mock_ec2_client.create_fleet.side_effect = ClientError(
             {
                 "Error": {
                     "Code": "RequestLimitExceeded",
@@ -258,78 +187,43 @@ class TestSpotFleetManager(unittest.TestCase):
                 },
                 "ResponseMetadata": {"RetryAfter": 30},
             },
-            "RequestSpotFleet",
+            "CreateFleet",
         )
 
-        # Instantiate SpotFleetManager
         manager = SpotFleetManager(self.mock_provider)
 
-        # Set up network resources (needed for _create_spot_fleet_request)
-        manager.vpc_id = "vpc-12345678"
-        manager.subnet_id = "subnet-12345678"
-        manager.security_group_id = "sg-12345678"
-        manager.iam_fleet_role_arn = "arn:aws:iam::123456789012:role/fleet-role"
-
-        # Attempt to create a spot fleet request, which should raise a SpotFleetThrottlingError
         with self.assertRaises(SpotFleetThrottlingError) as context:
-            manager._create_spot_fleet_request(
-                "block-123",
-                {
-                    "vpc_id": "vpc-12345678",
-                    "subnet_id": "subnet-12345678",
-                    "security_group_id": "sg-12345678",
-                },
-                1,
-                "arn:aws:iam::123456789012:role/fleet-role",
-            )
+            manager._create_fleet("block-123", self.NETWORK, 1)
 
-        # Verify the error message and attributes
-        self.assertIn("AWS throttled Spot Fleet request", str(context.exception))
-        self.assertEqual(context.exception.operation, "request_spot_fleet")
+        self.assertIn("AWS throttled the fleet request", str(context.exception))
+        self.assertEqual(context.exception.operation, "create_fleet")
         self.assertEqual(context.exception.retry_after, 30)
+
+        # The per-block launch template must not outlive the failed fleet it was
+        # built for; nothing else would ever reclaim it.
+        mock_ec2_client.delete_launch_template.assert_called_once()
+        self.assertEqual(manager.launch_templates, {})
 
     @patch("parsl_ephemeral_aws.compute.spot_fleet.CredentialManager")
     def test_no_duplicate_tag_keys_in_fleet_request(self, mock_credential_manager_cls):
         """No TagSpecification may repeat a tag key (#109).
 
-        EC2 rejects the whole request with ``InvalidSpotFleetRequestConfig:
-        Duplicate tag key 'Name' specified.``. The marker tag used to be emitted
-        as ``TAG_NAME``, which *is* the string ``"Name"``, so both the instance
-        and the fleet-request tag lists carried ``Name`` twice. moto accepts
-        duplicates and keeps the last value, so nothing caught it.
+        EC2 rejects the whole request outright -- verified against real AWS for
+        both ``request_spot_fleet`` ("Duplicate tag key 'Name' specified") and
+        ``run_instances``. The marker tag used to be emitted as ``TAG_NAME``,
+        which *is* the string ``"Name"``, so the tag lists carried ``Name``
+        twice. moto accepts duplicates and keeps the last value, so nothing
+        caught it.
         """
-        mock_ec2_client = MagicMock()
-        mock_session = MagicMock()
-        mock_session.client.return_value = mock_ec2_client
-        mock_session.resource.return_value = MagicMock()
-        mock_credential_manager_cls.return_value.create_boto3_session.return_value = (
-            mock_session
-        )
-        mock_ec2_client.request_spot_fleet.return_value = {
-            "SpotFleetRequestId": "sfr-123"
-        }
+        mock_ec2_client = self._mock_ec2(mock_credential_manager_cls)
 
-        manager = SpotFleetManager(self.mock_provider)
-        manager._create_spot_fleet_request(
-            "block-123",
-            {
-                "vpc_id": "vpc-12345678",
-                "subnet_id": "subnet-12345678",
-                "security_group_id": "sg-12345678",
-            },
-            1,
-            "arn:aws:iam::123456789012:role/fleet-role",
-        )
+        SpotFleetManager(self.mock_provider)._create_fleet("block-123", self.NETWORK, 1)
 
-        config = mock_ec2_client.request_spot_fleet.call_args.kwargs[
-            "SpotFleetRequestConfig"
-        ]
-        # Instance tags now travel in the launch *template* (#85), so gather them
-        # from CreateLaunchTemplate as well as from any LaunchSpecifications the
-        # fallback path would have emitted. Either form must be duplicate-free.
-        tag_specs = list(config["TagSpecifications"])
-        for launch_spec in config.get("LaunchSpecifications", []):
-            tag_specs.extend(launch_spec["TagSpecifications"])
+        # Instance tags travel in the launch *template* (#85) and the fleet's own
+        # tags in CreateFleet; both forms must be duplicate-free.
+        tag_specs = list(
+            mock_ec2_client.create_fleet.call_args.kwargs.get("TagSpecifications", [])
+        )
         for call in mock_ec2_client.create_launch_template.call_args_list:
             tag_specs.extend(call.kwargs.get("TagSpecifications", []))
             tag_specs.extend(
@@ -349,32 +243,106 @@ class TestSpotFleetManager(unittest.TestCase):
             name = next(tag["Value"] for tag in spec["Tags"] if tag["Key"] == "Name")
             self.assertTrue(name.startswith(TAG_PREFIX))
 
-    def _request_fleet_with(self, mock_credential_manager_cls, provider):
-        """Drive ``_create_spot_fleet_request`` and return the config it sent."""
+    @patch("parsl_ephemeral_aws.compute.spot_fleet.CredentialManager")
+    def test_fleet_request_carries_no_iam_fleet_role(self, mock_credential_manager_cls):
+        """``CreateFleet`` has no ``IamFleetRole``, so none may be sent (#86).
+
+        EC2 rejects an unknown member outright, so sending the parameter the
+        legacy ``RequestSpotFleet`` required would fail every launch. No IAM call
+        should be made at all on this path either -- the role the old API needed
+        simply is not part of it.
+        """
+        mock_ec2_client = self._mock_ec2(mock_credential_manager_cls)
+        mock_session = (
+            mock_credential_manager_cls.return_value.create_boto3_session.return_value
+        )
+
+        manager = SpotFleetManager(self.mock_provider)
+        mock_session.client.reset_mock()
+        manager._create_fleet("block-123", self.NETWORK, 1)
+
+        kwargs = mock_ec2_client.create_fleet.call_args.kwargs
+        self.assertNotIn("IamFleetRole", kwargs)
+        self.assertNotIn("SpotFleetRequestConfig", kwargs)
+        self.assertEqual(manager.iam_fleet_role_arn, None)
+        # And no IAM client was even asked for.
+        self.assertNotIn(
+            "iam", [call.args[0] for call in mock_session.client.call_args_list]
+        )
+        # The legacy API must not be called either.
+        mock_ec2_client.request_spot_fleet.assert_not_called()
+
+    @patch("parsl_ephemeral_aws.compute.spot_fleet.CredentialManager")
+    @patch("time.sleep", return_value=None)  # skip the propagation waits
+    def test_legacy_iam_fleet_role_is_still_cleaned_up(
+        self, mock_sleep, mock_credential_manager_cls
+    ):
+        """A role named by a pre-#86 state document must still be deleted.
+
+        Nothing creates one now, but a workflow resumed across the upgrade
+        carries the ARN in its state, and dropping the cleanup with the creation
+        would leak the role permanently.
+        """
+        mock_ec2_client = self._mock_ec2(mock_credential_manager_cls)
+        mock_session = (
+            mock_credential_manager_cls.return_value.create_boto3_session.return_value
+        )
+        mock_iam_client = MagicMock()
+        mock_session.client.side_effect = lambda service, **kwargs: {
+            "ec2": mock_ec2_client,
+            "iam": mock_iam_client,
+        }[service]
+
+        manager = SpotFleetManager(self.mock_provider)
+        manager.iam_fleet_role_arn = (
+            "arn:aws:iam::123456789012:role/parsl-ephemeral-spot-fleet-role-test-wor"
+        )
+
+        manager.cleanup_all_resources()
+
+        role_name = "parsl-ephemeral-spot-fleet-role-test-wor"
+        mock_iam_client.detach_role_policy.assert_called_with(
+            RoleName=role_name,
+            PolicyArn=(
+                "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole"
+            ),
+        )
+        mock_iam_client.delete_role.assert_called_with(RoleName=role_name)
+
+    def _mock_ec2(self, mock_credential_manager_cls):
+        """Wire a mock EC2 client through the credential manager, and return it.
+
+        ``create_launch_template`` is answered because a template is mandatory on
+        this path: ``CreateFleet`` has no ``LaunchSpecifications`` member, so
+        unlike the legacy API there is no inline-launch fallback (#86).
+        """
         mock_ec2_client = MagicMock()
+        mock_ec2_client.create_launch_template.return_value = {
+            "LaunchTemplate": {
+                "LaunchTemplateId": "lt-123",
+                "LatestVersionNumber": 1,
+            }
+        }
+        mock_ec2_client.create_fleet.return_value = {
+            "FleetId": "fleet-123",
+            "Instances": [{"InstanceIds": ["i-123"]}],
+        }
+        mock_ec2_client.describe_spot_price_history.return_value = {
+            "SpotPriceHistory": [{"SpotPrice": "0.01"}]
+        }
         mock_session = MagicMock()
         mock_session.client.return_value = mock_ec2_client
         mock_session.resource.return_value = MagicMock()
         mock_credential_manager_cls.return_value.create_boto3_session.return_value = (
             mock_session
         )
-        mock_ec2_client.request_spot_fleet.return_value = {
-            "SpotFleetRequestId": "sfr-123"
-        }
+        return mock_ec2_client
 
-        SpotFleetManager(provider)._create_spot_fleet_request(
-            "block-123",
-            {
-                "vpc_id": "vpc-12345678",
-                "subnet_id": "subnet-12345678",
-                "security_group_id": "sg-12345678",
-            },
-            1,
-            "arn:aws:iam::123456789012:role/fleet-role",
-        )
-        return mock_ec2_client.request_spot_fleet.call_args.kwargs[
-            "SpotFleetRequestConfig"
-        ]
+    def _fleet_spot_options(self, mock_credential_manager_cls, provider):
+        """Drive ``_create_fleet`` and return the ``SpotOptions`` it sent."""
+        mock_ec2_client = self._mock_ec2(mock_credential_manager_cls)
+        SpotFleetManager(provider)._create_fleet("block-123", self.NETWORK, 1)
+        return mock_ec2_client.create_fleet.call_args.kwargs["SpotOptions"]
 
     @patch("parsl_ephemeral_aws.compute.spot_fleet.CredentialManager")
     def test_configured_allocation_strategy_reaches_the_api(
@@ -388,12 +356,15 @@ class TestSpotFleetManager(unittest.TestCase):
         """
         self.mock_provider.spot_allocation_strategy = "capacity-optimized"
 
-        config = self._request_fleet_with(
+        spot_options = self._fleet_spot_options(
             mock_credential_manager_cls, self.mock_provider
         )
 
-        # Converted to the only spelling RequestSpotFleet accepts.
-        self.assertEqual(config["AllocationStrategy"], "capacityOptimized")
+        # Kebab-case: the only spelling CreateFleet accepts. It rejects the
+        # camelCase form RequestSpotFleet demands, and vice versa -- verified
+        # against real EC2, and neither DryRun nor TotalTargetCapacity=0 catches
+        # the wrong one.
+        self.assertEqual(spot_options["AllocationStrategy"], "capacity-optimized")
 
     @patch("parsl_ephemeral_aws.compute.spot_fleet.CredentialManager")
     def test_allocation_strategy_defaults_when_provider_omits_it(
@@ -407,14 +378,15 @@ class TestSpotFleetManager(unittest.TestCase):
         """
         self.assertFalse(hasattr(self.mock_provider, "spot_allocation_strategy"))
 
-        config = self._request_fleet_with(
+        spot_options = self._fleet_spot_options(
             mock_credential_manager_cls, self.mock_provider
         )
 
         self.assertEqual(
-            config["AllocationStrategy"], SPOT_FLEET_DEFAULT_ALLOCATION_STRATEGY
+            spot_options["AllocationStrategy"],
+            EC2_FLEET_DEFAULT_ALLOCATION_STRATEGY,
         )
-        self.assertNotEqual(config["AllocationStrategy"], "lowestPrice")
+        self.assertNotEqual(spot_options["AllocationStrategy"], "lowest-price")
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_spot_fleet_cleanup.py
+++ b/tests/unit/test_spot_fleet_cleanup.py
@@ -5,7 +5,7 @@ SPDX-FileCopyrightText: 2025 Scott Friedman and Project Contributors
 """
 
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 import boto3
 import pytest
 from botocore.exceptions import ClientError
@@ -121,13 +121,53 @@ class TestSpotFleetCleanup(unittest.TestCase):
         self.assertEqual(self.mock_iam.delete_role.call_count, 2)
 
     def test_cleanup_all_spot_fleet_resources(self):
-        """Test cleanup of all Spot Fleet resources."""
-        # Configure mock EC2 client for paginator
-        mock_paginator = MagicMock()
-        self.mock_ec2.get_paginator.return_value = mock_paginator
+        """Test cleanup of all fleet resources, EC2 Fleet and legacy alike.
 
-        # Configure paginator to return Spot Fleet requests
-        mock_paginator.paginate.return_value = [
+        The sweep now covers two generations of API (#86), so the paginator has
+        to be dispatched by operation rather than answering every call with the
+        same pages. It makes three calls: ``describe_instances`` once per
+        workflow-tag key -- ``describe_instances`` ANDs its filters, so
+        ``WorkflowId`` and ``ParslWorkflowId`` cannot be asked for together --
+        and then ``describe_spot_fleet_requests`` for anything predating #86.
+
+        An EC2 Fleet is found through its *instances*, never through
+        ``describe_fleets``: an ``instant`` fleet does not appear in a
+        fleet-level listing at all unless its ID is already known, and a tag
+        filter does not find it either (both verified against real EC2). The
+        ``aws:ec2:fleet-id`` tag EC2 stamps on every fleet-launched instance is
+        the only route, which is why the mock returns reservations carrying it.
+        """
+        # Configure mock EC2 paginators, dispatched by operation.
+        instances_paginator = MagicMock()
+        instances_paginator.paginate.return_value = [
+            {
+                "Reservations": [
+                    {
+                        "Instances": [
+                            {
+                                "InstanceId": "i-11111111",
+                                "Tags": [
+                                    {"Key": "WorkflowId", "Value": "test-workflow"},
+                                    {"Key": "aws:ec2:fleet-id", "Value": "fleet-abc"},
+                                ],
+                            },
+                            # Two instances from one fleet must yield one
+                            # deletion, not two.
+                            {
+                                "InstanceId": "i-22222222",
+                                "Tags": [
+                                    {"Key": "WorkflowId", "Value": "test-workflow"},
+                                    {"Key": "aws:ec2:fleet-id", "Value": "fleet-abc"},
+                                ],
+                            },
+                        ]
+                    }
+                ]
+            }
+        ]
+
+        legacy_paginator = MagicMock()
+        legacy_paginator.paginate.return_value = [
             {
                 "SpotFleetRequestConfigs": [
                     {
@@ -141,6 +181,22 @@ class TestSpotFleetCleanup(unittest.TestCase):
                 ]
             }
         ]
+
+        self.mock_ec2.get_paginator.side_effect = lambda operation: {
+            "describe_instances": instances_paginator,
+            "describe_spot_fleet_requests": legacy_paginator,
+        }[operation]
+
+        self.mock_ec2.delete_fleets.return_value = {
+            "SuccessfulFleetDeletions": [
+                {
+                    "FleetId": "fleet-abc",
+                    "CurrentFleetState": "deleted_terminating",
+                    "PreviousFleetState": "active",
+                }
+            ],
+            "UnsuccessfulFleetDeletions": [],
+        }
 
         # Configure describe_tags to identify requests from our workflow
         self.mock_ec2.describe_tags.side_effect = [
@@ -193,7 +249,9 @@ class TestSpotFleetCleanup(unittest.TestCase):
                 cleanup_iam_roles=True,
             )
 
-        # Verify result
+        # Verify result. The fleet is reported once even though two of its
+        # instances carried its tag, and both tag-key passes saw both.
+        self.assertEqual(result["deleted_fleets"], ["fleet-abc"])
         self.assertEqual(len(result["cancelled_requests"]), 1)
         self.assertEqual(result["cancelled_requests"][0], "sfr-12345")
         self.assertEqual(len(result["cleaned_roles"]), 1)
@@ -202,9 +260,39 @@ class TestSpotFleetCleanup(unittest.TestCase):
         )
         self.assertEqual(len(result["errors"]), 0)
 
-        # Verify client calls
-        self.mock_ec2.get_paginator.assert_called_once_with(
-            "describe_spot_fleet_requests"
+        # Verify client calls. Both workflow tag keys must be swept -- resources
+        # created before the key was renamed carry the other one, and missing a
+        # pass leaks every fleet tagged with it.
+        self.assertEqual(
+            self.mock_ec2.get_paginator.call_args_list,
+            [
+                call("describe_instances"),
+                call("describe_instances"),
+                call("describe_spot_fleet_requests"),
+            ],
+        )
+        self.assertEqual(
+            [
+                c.kwargs["Filters"][0]
+                for c in instances_paginator.paginate.call_args_list
+            ],
+            [
+                {"Name": "tag:WorkflowId", "Values": ["test-workflow"]},
+                {"Name": "tag:ParslWorkflowId", "Values": ["test-workflow"]},
+            ],
+        )
+        # Every pass also requires the fleet-id tag to be present, so a
+        # non-fleet instance of the same workflow is not mistaken for one.
+        for paginate_call in instances_paginator.paginate.call_args_list:
+            self.assertEqual(
+                paginate_call.kwargs["Filters"][1],
+                {"Name": "tag-key", "Values": ["aws:ec2:fleet-id"]},
+            )
+
+        # Deleting an instant fleet always terminates its instances; AWS rejects
+        # NoTerminateInstances for the type, so the flag is not optional.
+        self.mock_ec2.delete_fleets.assert_called_once_with(
+            FleetIds=["fleet-abc"], TerminateInstances=True
         )
         self.mock_ec2.describe_tags.assert_called_with(
             Filters=[{"Name": "resource-id", "Values": ["sfr-67890"]}]

--- a/tests/unit/test_spot_interruption.py
+++ b/tests/unit/test_spot_interruption.py
@@ -63,13 +63,25 @@ class TestSpotInterruptionMonitor:
             ]
         }
 
-        # Mock describe_spot_fleet_instances response
-        client.describe_spot_fleet_instances.return_value = {
-            "ActiveInstances": [
-                {"InstanceId": "i-test1", "SpotInstanceRequestId": "sir-test1"},
-                {"InstanceId": "i-test2", "SpotInstanceRequestId": "sir-test2"},
-            ]
-        }
+        # A fleet's instances are found by filtering describe_instances on the
+        # aws:ec2:fleet-id tag, not by describe_spot_fleet_instances, which
+        # refuses an EC2 Fleet of type instant outright with ``Unsupported``
+        # (#86, verified against real EC2). The paginator is what
+        # get_ec2_fleet_instance_ids drives.
+        fleet_paginator = MagicMock()
+        fleet_paginator.paginate.return_value = [
+            {
+                "Reservations": [
+                    {
+                        "Instances": [
+                            {"InstanceId": "i-test1"},
+                            {"InstanceId": "i-test2"},
+                        ]
+                    }
+                ]
+            }
+        ]
+        client.get_paginator.return_value = fleet_paginator
 
         return client
 
@@ -112,10 +124,10 @@ class TestSpotInterruptionMonitor:
         """Test registering a spot fleet for monitoring."""
         handler = MagicMock()
 
-        monitor.register_fleet("sfr-test1", handler)
+        monitor.register_fleet("fleet-test1", handler)
 
-        assert "sfr-test1" in monitor.fleet_handlers
-        assert monitor.fleet_handlers["sfr-test1"] == handler
+        assert "fleet-test1" in monitor.fleet_handlers
+        assert monitor.fleet_handlers["fleet-test1"] == handler
 
     def test_deregister_instance(self, monitor):
         """Test deregistering a spot instance."""
@@ -131,11 +143,11 @@ class TestSpotInterruptionMonitor:
         """Test deregistering a spot fleet."""
         handler = MagicMock()
 
-        monitor.register_fleet("sfr-test1", handler)
-        assert "sfr-test1" in monitor.fleet_handlers
+        monitor.register_fleet("fleet-test1", handler)
+        assert "fleet-test1" in monitor.fleet_handlers
 
-        monitor.deregister_fleet("sfr-test1")
-        assert "sfr-test1" not in monitor.fleet_handlers
+        monitor.deregister_fleet("fleet-test1")
+        assert "fleet-test1" not in monitor.fleet_handlers
 
     @patch("threading.Thread")
     def test_start_monitoring(self, mock_thread, monitor):
@@ -185,21 +197,47 @@ class TestSpotInterruptionMonitor:
 
     @patch("threading.Thread")
     def test_check_fleet_interruptions(self, mock_thread, monitor, mock_ec2_client):
-        """Test checking for fleet interruptions."""
-        # Register a fleet handler
-        handler = MagicMock()
-        monitor.register_fleet("sfr-test1", handler)
+        """A fleet's instances are found by tag, not by the Spot Fleet API (#86).
 
-        # Call the method directly
+        ``describe_spot_fleet_instances`` used to be the route, and this test
+        asserted on it. It cannot be: it rejects an EC2 Fleet of type instant
+        with ``Unsupported`` -- "Describe fleet instances is not supported by
+        this type of fleet" -- verified against real EC2. The reserved
+        ``aws:ec2:fleet-id`` tag EC2 stamps on every fleet-launched instance is
+        the only workable route.
+        """
+        handler = MagicMock()
+        monitor.register_fleet("fleet-test1", handler)
+
         monitor._check_fleet_interruptions(mock_ec2_client)
 
-        # Verify that describe_spot_fleet_instances was called
-        mock_ec2_client.describe_spot_fleet_instances.assert_called_with(
-            SpotFleetRequestId="sfr-test1"
+        # The legacy call must not be made at all -- it would raise.
+        mock_ec2_client.describe_spot_fleet_instances.assert_not_called()
+
+        mock_ec2_client.get_paginator.assert_called_with("describe_instances")
+        paginate_kwargs = (
+            mock_ec2_client.get_paginator.return_value.paginate.call_args.kwargs
+        )
+        assert {
+            "Name": "tag:aws:ec2:fleet-id",
+            "Values": ["fleet-test1"],
+        } in paginate_kwargs["Filters"]
+
+        # And the instances the tag search found are then described for state.
+        mock_ec2_client.describe_instances.assert_called_with(
+            InstanceIds=["i-test1", "i-test2"]
         )
 
-        # Verify that describe_instances was called with the fleet instances
-        mock_ec2_client.describe_instances.assert_called()
+        # i-test2 is shutting-down in the fixture, so the fleet handler is due an
+        # event -- naming only that instance, not the whole fleet.
+        assert not monitor.event_queue.empty()
+        event_type, fleet_id, instance_ids, event_details = monitor.event_queue.get()
+        assert event_type == "fleet"
+        assert fleet_id == "fleet-test1"
+        assert instance_ids == ["i-test2"]
+        # Marked as the post-facto track: this instance is already dying, so a
+        # handler must not assume it has the two minutes a warning would give.
+        assert event_details["Source"] == "ec2-state"
 
     @patch("threading.Thread")
     def test_process_interruption_events(self, mock_thread, monitor):
@@ -209,15 +247,15 @@ class TestSpotInterruptionMonitor:
         fleet_handler = MagicMock()
 
         monitor.register_instance("i-test1", instance_handler)
-        monitor.register_fleet("sfr-test1", fleet_handler)
+        monitor.register_fleet("fleet-test1", fleet_handler)
 
         # Add events to the queue
         instance_event = ("instance", "i-test1", {"InstanceId": "i-test1"})
         fleet_event = (
             "fleet",
-            "sfr-test1",
+            "fleet-test1",
             ["i-test1", "i-test2"],
-            {"FleetRequestId": "sfr-test1"},
+            {"FleetRequestId": "fleet-test1"},
         )
 
         monitor.event_queue.put(instance_event)
@@ -229,7 +267,7 @@ class TestSpotInterruptionMonitor:
         # Verify handlers were called
         instance_handler.assert_called_once_with("i-test1", {"InstanceId": "i-test1"})
         fleet_handler.assert_called_once_with(
-            "sfr-test1", ["i-test1", "i-test2"], {"FleetRequestId": "sfr-test1"}
+            "fleet-test1", ["i-test1", "i-test2"], {"FleetRequestId": "fleet-test1"}
         )
 
 
@@ -404,7 +442,7 @@ class TestSpotInterruptionHandler:
     def test_handle_fleet_interruption(self, handler):
         """Test the base implementation of handle_fleet_interruption."""
         # This is just a placeholder in the base class, so no real logic to test
-        fleet_id = "sfr-test1"
+        fleet_id = "fleet-test1"
         instance_ids = ["i-test1", "i-test2"]
         event = {"FleetRequestId": fleet_id, "InstanceAction": "terminate"}
 
@@ -513,7 +551,7 @@ class TestParslSpotInterruptionHandler:
         handler.handle_instance_interruption = MagicMock()
 
         # Handle fleet interruption
-        fleet_id = "sfr-test1"
+        fleet_id = "fleet-test1"
         instance_ids = ["i-test1", "i-test2"]
         event = {"FleetRequestId": fleet_id, "InstanceAction": "terminate"}
 

--- a/tests/unit/test_spot_warning_notifier.py
+++ b/tests/unit/test_spot_warning_notifier.py
@@ -1,0 +1,869 @@
+"""Unit tests for the EventBridge spot-interruption warning notifier (#86).
+
+The EC2-state poll that predated this could only ever report an interruption
+post-facto: an interrupted instance is first observable at ``shutting-down``,
+which is after the reclaim and far too late to checkpoint. An ``instant`` fleet
+gets no Capacity Rebalance either -- ``CreateFleet`` rejects
+``SpotOptions.MaintenanceStrategies`` for that type -- so an EventBridge rule
+delivering to SQS, polled by the driver, is what supplies the two-minute
+warning.
+
+The mechanism was verified end to end against real AWS with a Fault Injection
+Simulator experiment (``aws:ec2:send-spot-instance-interruptions``): the warning
+reached the queue 15.2s after the experiment started, with the instance still
+``running``. What these tests pin is the wiring around it -- the parts a live
+probe proves once but that silently rot afterwards:
+
+* the queue policy is set *before* the target is added, so no window exists in
+  which EventBridge has a target it cannot deliver to;
+* ``put_targets`` sends no ``RoleArn``, because SQS delivery is authorised by the
+  queue's own resource policy and passing a role is not how it works;
+* ``remove_targets`` precedes ``delete_rule``, because EventBridge refuses to
+  delete a rule that still has a target;
+* each message is deleted *before* it is parsed, since the rule matches every
+  spot interruption in the account and an unparseable or unowned message would
+  otherwise redeliver on every poll for the whole retention period.
+
+SPDX-License-Identifier: Apache-2.0
+SPDX-FileCopyrightText: 2025 Scott Friedman and Project Contributors
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+
+from parsl_ephemeral_aws.compute.spot_interruption import SpotInterruptionMonitor
+from parsl_ephemeral_aws.constants import (
+    SPOT_INTERRUPTION_EVENT_DETAIL_TYPE,
+    SPOT_INTERRUPTION_EVENT_SOURCE,
+    SPOT_INTERRUPTION_QUEUE_RETENTION_SECONDS,
+    SPOT_INTERRUPTION_QUEUE_WAIT_SECONDS,
+    SPOT_INTERRUPTION_RULE_NAME_PREFIX,
+    TAG_MANAGED,
+)
+from parsl_ephemeral_aws.exceptions import ResourceCreationError
+from parsl_ephemeral_aws.utils.aws import (
+    create_spot_interruption_notifier,
+    delete_spot_interruption_notifier,
+)
+
+pytestmark = pytest.mark.unit
+
+
+QUEUE_URL = "https://sqs.us-east-1.amazonaws.com/942542972736/parsl-spot-warning-abc"
+QUEUE_ARN = "arn:aws:sqs:us-east-1:942542972736:parsl-spot-warning-abc"
+RULE_ARN = "arn:aws:events:us-east-1:942542972736:rule/parsl-spot-warning-abc"
+
+
+def _clients():
+    """Return ``(recorder, events, sqs)`` sharing one call log.
+
+    Ordering is half of what this module tests, and it is ordering *between* two
+    clients -- the queue policy on SQS against the target on EventBridge. Two
+    independent mocks cannot express that, so both are attached to a parent whose
+    ``mock_calls`` interleaves them.
+    """
+    recorder = MagicMock()
+    events = MagicMock()
+    sqs = MagicMock()
+    recorder.attach_mock(events, "events")
+    recorder.attach_mock(sqs, "sqs")
+
+    sqs.create_queue.return_value = {"QueueUrl": QUEUE_URL}
+    sqs.get_queue_attributes.return_value = {"Attributes": {"QueueArn": QUEUE_ARN}}
+    sqs.set_queue_attributes.return_value = {}
+    events.put_rule.return_value = {"RuleArn": RULE_ARN}
+    events.put_targets.return_value = {"FailedEntryCount": 0}
+
+    return recorder, events, sqs
+
+
+def _call_names(recorder):
+    """The bare method names from *recorder*, in the order they were called."""
+    return [name for name, _, _ in recorder.mock_calls]
+
+
+class TestCreateSpotInterruptionNotifier:
+    """The rule, the queue, and the wiring between them."""
+
+    def test_returns_the_rule_name_queue_url_and_arn(self):
+        _, events, sqs = _clients()
+
+        result = create_spot_interruption_notifier(
+            events, sqs, "parsl-spot-warning-abc"
+        )
+
+        assert result == ("parsl-spot-warning-abc", QUEUE_URL, QUEUE_ARN)
+
+    def test_the_queue_policy_is_set_before_the_target_is_added(self):
+        """Otherwise EventBridge briefly has a target it cannot deliver to.
+
+        The window is short but it is exactly the window that matters: a warning
+        arriving in it is dropped by SQS as unauthorised, and a dropped warning
+        is not retried -- the two minutes elapse and the instance is gone. This
+        is also the ordering that cannot be caught by a live probe, which will
+        almost always create the rule long before any interruption fires.
+        """
+        recorder, events, sqs = _clients()
+
+        create_spot_interruption_notifier(events, sqs, "parsl-spot-warning-abc")
+
+        names = _call_names(recorder)
+        assert names.index("sqs.set_queue_attributes") < names.index(
+            "events.put_targets"
+        )
+
+    def test_the_queue_exists_before_the_rule_names_it(self):
+        """The policy needs the queue ARN and the rule ARN, so both come first."""
+        recorder, events, sqs = _clients()
+
+        create_spot_interruption_notifier(events, sqs, "parsl-spot-warning-abc")
+
+        names = _call_names(recorder)
+        assert names.index("sqs.create_queue") < names.index("sqs.get_queue_attributes")
+        assert names.index("events.put_rule") < names.index("sqs.set_queue_attributes")
+
+    def test_put_targets_sends_no_role_arn(self):
+        """SQS is authorised by the queue policy, not by a role EventBridge assumes.
+
+        Most target types take a ``RoleArn``; SQS does not, and supplying one
+        would be a role created, and leaked, for nothing.
+        """
+        _, events, sqs = _clients()
+
+        create_spot_interruption_notifier(events, sqs, "parsl-spot-warning-abc")
+
+        kwargs = events.put_targets.call_args.kwargs
+        assert "RoleArn" not in kwargs
+        assert kwargs["Rule"] == "parsl-spot-warning-abc"
+        assert kwargs["Targets"] == [
+            {"Id": "parsl-spot-warning-queue", "Arn": QUEUE_ARN}
+        ]
+
+    def test_the_event_pattern_matches_only_the_interruption_warning(self):
+        """A wider pattern would deliver unrelated EC2 events to be parsed."""
+        _, events, sqs = _clients()
+
+        create_spot_interruption_notifier(events, sqs, "parsl-spot-warning-abc")
+
+        pattern = json.loads(events.put_rule.call_args.kwargs["EventPattern"])
+        assert pattern == {
+            "source": [SPOT_INTERRUPTION_EVENT_SOURCE],
+            "detail-type": [SPOT_INTERRUPTION_EVENT_DETAIL_TYPE],
+        }
+        assert events.put_rule.call_args.kwargs["State"] == "ENABLED"
+
+    def test_the_queue_policy_is_scoped_to_this_rule(self):
+        """``aws:SourceArn`` is what stops any other rule posting to the queue.
+
+        Without the condition the policy grants ``events.amazonaws.com`` at
+        large, which is every EventBridge rule in every account -- a queue any
+        stranger can inject a fabricated interruption warning into, and this
+        monitor's handlers act on those warnings by checkpointing and
+        rescheduling.
+        """
+        _, events, sqs = _clients()
+
+        create_spot_interruption_notifier(events, sqs, "parsl-spot-warning-abc")
+
+        policy = json.loads(
+            sqs.set_queue_attributes.call_args.kwargs["Attributes"]["Policy"]
+        )
+        statement = policy["Statement"][0]
+        assert statement["Effect"] == "Allow"
+        assert statement["Principal"] == {"Service": "events.amazonaws.com"}
+        assert statement["Action"] == "sqs:SendMessage"
+        assert statement["Resource"] == QUEUE_ARN
+        assert statement["Condition"] == {"ArnEquals": {"aws:SourceArn": RULE_ARN}}
+
+    def test_the_queue_retention_is_short(self):
+        """A warning is worthless once its two minutes are up.
+
+        Default SQS retention is four days. Replaying a stale warning against a
+        long-dead instance would have the handler checkpoint and reschedule work
+        that already finished or already failed, so the retention is cut to the
+        window in which the message can still be acted on.
+        """
+        _, events, sqs = _clients()
+
+        create_spot_interruption_notifier(events, sqs, "parsl-spot-warning-abc")
+
+        attributes = sqs.create_queue.call_args.kwargs["Attributes"]
+        assert attributes["MessageRetentionPeriod"] == str(
+            SPOT_INTERRUPTION_QUEUE_RETENTION_SECONDS
+        )
+        assert SPOT_INTERRUPTION_QUEUE_RETENTION_SECONDS <= 3600
+
+    def test_tags_reach_the_rule_when_supplied(self):
+        _, events, sqs = _clients()
+
+        create_spot_interruption_notifier(
+            events,
+            sqs,
+            "parsl-spot-warning-abc",
+            tags=[{"Key": TAG_MANAGED, "Value": "true"}],
+        )
+
+        assert events.put_rule.call_args.kwargs["Tags"] == [
+            {"Key": TAG_MANAGED, "Value": "true"}
+        ]
+
+    def test_no_tags_key_is_sent_when_none_are_given(self):
+        """``Tags=[]`` is not the same as omitting it -- EventBridge rejects it.
+
+        ``put_rule`` declares ``Tags`` with a minimum length of 1, so an empty
+        list is a ``ValidationException`` rather than a no-op.
+        """
+        _, events, sqs = _clients()
+
+        create_spot_interruption_notifier(events, sqs, "parsl-spot-warning-abc")
+
+        assert "Tags" not in events.put_rule.call_args.kwargs
+
+    def test_a_refused_target_raises(self):
+        """``put_targets`` reports failure in the body, not by raising.
+
+        ``FailedEntryCount`` is the only signal, so an unchecked call returns
+        successfully having wired nothing -- the rule exists, the queue exists,
+        and no warning ever arrives. Nothing downstream would notice, because
+        the absence of interruption warnings is indistinguishable from the
+        absence of interruptions.
+        """
+        _, events, sqs = _clients()
+        events.put_targets.return_value = {
+            "FailedEntryCount": 1,
+            "FailedEntries": [
+                {
+                    "TargetId": "parsl-spot-warning-queue",
+                    "ErrorCode": "AccessDeniedException",
+                    "ErrorMessage": "not authorized",
+                }
+            ],
+        }
+
+        with pytest.raises(ResourceCreationError) as excinfo:
+            create_spot_interruption_notifier(events, sqs, "parsl-spot-warning-abc")
+
+        assert "AccessDeniedException" in str(excinfo.value)
+
+    def test_a_client_error_is_wrapped(self):
+        """The caller degrades on ``ResourceCreationError``, not on ClientError."""
+        _, events, sqs = _clients()
+        sqs.create_queue.side_effect = ClientError(
+            {
+                "Error": {
+                    "Code": "QueueDeletedRecently",
+                    "Message": "You must wait 60 seconds after deleting a queue",
+                }
+            },
+            "CreateQueue",
+        )
+
+        with pytest.raises(ResourceCreationError) as excinfo:
+            create_spot_interruption_notifier(events, sqs, "parsl-spot-warning-abc")
+
+        assert "QueueDeletedRecently" in str(excinfo.value)
+
+
+class TestDeleteSpotInterruptionNotifier:
+    """Cleanup, which runs from paths that must not be stopped by a failure."""
+
+    def test_targets_are_removed_before_the_rule_is_deleted(self):
+        """EventBridge refuses to delete a rule that still has a target.
+
+        Reversing these two leaves the rule behind on every teardown, still
+        matching every spot interruption in the account, and pointing at a queue
+        that is about to be deleted.
+        """
+        recorder, events, sqs = _clients()
+
+        delete_spot_interruption_notifier(
+            events, sqs, "parsl-spot-warning-abc", QUEUE_URL
+        )
+
+        names = _call_names(recorder)
+        assert names.index("events.remove_targets") < names.index("events.delete_rule")
+        assert events.remove_targets.call_args.kwargs["Ids"] == [
+            "parsl-spot-warning-queue"
+        ]
+
+    def test_everything_is_deleted(self):
+        _, events, sqs = _clients()
+
+        delete_spot_interruption_notifier(
+            events, sqs, "parsl-spot-warning-abc", QUEUE_URL
+        )
+
+        events.delete_rule.assert_called_once_with(Name="parsl-spot-warning-abc")
+        sqs.delete_queue.assert_called_once_with(QueueUrl=QUEUE_URL)
+
+    def test_a_failed_rule_deletion_does_not_strand_the_queue(self):
+        """Each step is independent; the queue costs nothing but leaks a name.
+
+        SQS refuses to recreate a queue for 60 seconds after deletion, so a
+        stranded queue also blocks the next provider that picks the same
+        provider-ID prefix.
+        """
+        _, events, sqs = _clients()
+        events.delete_rule.side_effect = ClientError(
+            {"Error": {"Code": "ResourceNotFoundException", "Message": "gone"}},
+            "DeleteRule",
+        )
+
+        delete_spot_interruption_notifier(
+            events, sqs, "parsl-spot-warning-abc", QUEUE_URL
+        )
+
+        sqs.delete_queue.assert_called_once_with(QueueUrl=QUEUE_URL)
+
+    def test_an_already_absent_rule_is_not_an_error(self):
+        """Cleanup runs from ``except`` handlers, where gone is the goal."""
+        _, events, sqs = _clients()
+        events.remove_targets.side_effect = ClientError(
+            {"Error": {"Code": "ResourceNotFoundException", "Message": "gone"}},
+            "RemoveTargets",
+        )
+        sqs.delete_queue.side_effect = ClientError(
+            {
+                "Error": {
+                    "Code": "AWS.SimpleQueueService.NonExistentQueue",
+                    "Message": "gone",
+                }
+            },
+            "DeleteQueue",
+        )
+
+        delete_spot_interruption_notifier(
+            events, sqs, "parsl-spot-warning-abc", QUEUE_URL
+        )
+
+    def test_nothing_is_called_for_a_notifier_that_was_never_created(self):
+        """The monitor degrades to the EC2 poll, leaving both names None."""
+        _, events, sqs = _clients()
+
+        delete_spot_interruption_notifier(events, sqs, None, None)
+
+        events.remove_targets.assert_not_called()
+        events.delete_rule.assert_not_called()
+        sqs.delete_queue.assert_not_called()
+
+
+class TestMonitorNotifierLifecycle:
+    """When the monitor creates and destroys the notifier."""
+
+    @pytest.fixture
+    def session(self):
+        """A session whose ``client()`` returns a distinct mock per service."""
+        clients = {
+            "events": MagicMock(name="events"),
+            "sqs": MagicMock(name="sqs"),
+            "ec2": MagicMock(name="ec2"),
+            "cloudwatch": MagicMock(name="cloudwatch"),
+        }
+        session = MagicMock()
+        session.client.side_effect = lambda service, **kw: clients.setdefault(
+            service, MagicMock(name=service)
+        )
+        session._clients = clients
+        return session
+
+    def test_construction_makes_no_aws_calls(self, session):
+        """Every mode builds a monitor in ``__init__``, before initialize().
+
+        Creating the rule there would mean a construction that can fail on an
+        IAM permission, and -- worse -- a rule and queue created by a provider
+        that then raises, with no ``stop_monitoring`` ever reached to remove
+        them.
+        """
+        monitor = SpotInterruptionMonitor(session, provider_id="abcdef123456")
+
+        session.client.assert_not_called()
+        assert monitor.warning_rule_name is None
+        assert monitor.warning_queue_url is None
+
+    def test_the_notifier_name_is_derived_from_the_provider_id(self, session):
+        """Two providers in one account must not share a queue.
+
+        They would each drain warnings the other needed: SQS delivers a message
+        to one consumer, and this poll deletes on receipt.
+        """
+        monitor = SpotInterruptionMonitor(session, provider_id="abcdef123456")
+
+        assert (
+            monitor._notifier_name == f"{SPOT_INTERRUPTION_RULE_NAME_PREFIX}-abcdef12"
+        )
+
+    def test_a_missing_provider_id_still_yields_a_unique_name(self, session):
+        first = SpotInterruptionMonitor(session)
+        second = SpotInterruptionMonitor(session)
+
+        assert first._notifier_name != second._notifier_name
+
+    @patch("threading.Thread")
+    def test_start_monitoring_creates_the_notifier(self, _thread, session):
+        monitor = SpotInterruptionMonitor(session, provider_id="abcdef123456")
+
+        with patch(
+            "parsl_ephemeral_aws.compute.spot_interruption."
+            "create_spot_interruption_notifier",
+            return_value=(monitor._notifier_name, QUEUE_URL, QUEUE_ARN),
+        ) as create:
+            monitor.start_monitoring()
+
+        create.assert_called_once()
+        assert create.call_args.args[2] == monitor._notifier_name
+        assert create.call_args.kwargs["tags"] == [
+            {"Key": TAG_MANAGED, "Value": "true"}
+        ]
+        assert monitor.warning_queue_url == QUEUE_URL
+
+    @patch("threading.Thread")
+    def test_a_failed_notifier_degrades_rather_than_failing_the_workflow(
+        self, _thread, session
+    ):
+        """Losing the advance warning is worse than the poll, not fatal.
+
+        A caller whose IAM policy grants no ``events``/``sqs`` still gets a
+        working provider; what it loses is the lead time to checkpoint. Raising
+        here would make the two new permissions mandatory for every spot
+        workflow, including ones that do no checkpointing at all.
+        """
+        monitor = SpotInterruptionMonitor(session, provider_id="abcdef123456")
+
+        with patch(
+            "parsl_ephemeral_aws.compute.spot_interruption."
+            "create_spot_interruption_notifier",
+            side_effect=ResourceCreationError("AccessDenied"),
+        ):
+            monitor.start_monitoring()
+
+        assert monitor.warning_queue_url is None
+        # The thread still started: the EC2-state poll is the fallback track.
+        assert monitor.monitoring_thread is not None
+
+    @patch("threading.Thread")
+    def test_the_notifier_can_be_disabled(self, _thread, session):
+        monitor = SpotInterruptionMonitor(
+            session, provider_id="abcdef123456", use_event_bridge=False
+        )
+
+        with patch(
+            "parsl_ephemeral_aws.compute.spot_interruption."
+            "create_spot_interruption_notifier",
+        ) as create:
+            monitor.start_monitoring()
+
+        create.assert_not_called()
+        assert monitor.warning_queue_url is None
+
+    @patch("threading.Thread")
+    def test_restarting_does_not_create_a_second_notifier(self, thread, session):
+        """A monitor whose thread died is restartable; its queue is not remade.
+
+        Creating a second one would leak the first, and it would leak it under a
+        name nothing tracks -- the attribute holding it has just been
+        overwritten.
+        """
+        thread.return_value.is_alive.return_value = False
+        monitor = SpotInterruptionMonitor(session, provider_id="abcdef123456")
+
+        with patch(
+            "parsl_ephemeral_aws.compute.spot_interruption."
+            "create_spot_interruption_notifier",
+            return_value=(monitor._notifier_name, QUEUE_URL, QUEUE_ARN),
+        ) as create:
+            monitor.start_monitoring()
+            monitor.start_monitoring()
+
+        assert create.call_count == 1
+
+    @patch("threading.Thread")
+    def test_stop_monitoring_deletes_the_notifier(self, _thread, session):
+        monitor = SpotInterruptionMonitor(session, provider_id="abcdef123456")
+        monitor.warning_rule_name = monitor._notifier_name
+        monitor.warning_queue_url = QUEUE_URL
+
+        with patch(
+            "parsl_ephemeral_aws.compute.spot_interruption."
+            "delete_spot_interruption_notifier",
+        ) as delete:
+            monitor.stop_monitoring()
+
+        delete.assert_called_once()
+        assert delete.call_args.args[2] == monitor._notifier_name
+        assert delete.call_args.args[3] == QUEUE_URL
+        assert monitor.warning_rule_name is None
+        assert monitor.warning_queue_url is None
+
+    def test_the_notifier_is_deleted_even_when_no_thread_was_running(self, session):
+        """The rule outlives the thread, so cleanup cannot be gated on it.
+
+        ``stop_monitoring`` returns early when there is no live thread. If the
+        teardown sat after that return, a monitor whose thread had already died
+        -- or one stopped twice -- would leave the rule and queue behind for
+        good: nothing else in the package deletes them.
+        """
+        monitor = SpotInterruptionMonitor(session, provider_id="abcdef123456")
+        monitor.warning_rule_name = monitor._notifier_name
+        monitor.warning_queue_url = QUEUE_URL
+        assert monitor.monitoring_thread is None
+
+        with patch(
+            "parsl_ephemeral_aws.compute.spot_interruption."
+            "delete_spot_interruption_notifier",
+        ) as delete:
+            monitor.stop_monitoring()
+
+        delete.assert_called_once()
+
+    def test_stopping_a_monitor_with_no_notifier_calls_nothing(self, session):
+        monitor = SpotInterruptionMonitor(session, provider_id="abcdef123456")
+
+        with patch(
+            "parsl_ephemeral_aws.compute.spot_interruption."
+            "delete_spot_interruption_notifier",
+        ) as delete:
+            monitor.stop_monitoring()
+
+        delete.assert_not_called()
+
+
+def _warning_message(instance_id="i-abc123", action="terminate", receipt="rh-1"):
+    """An EventBridge envelope in the shape a real warning arrived in.
+
+    Captured from the FIS probe rather than invented: ``detail`` carries
+    ``instance-id`` and ``instance-action``, and the envelope's own
+    ``detail-type`` is the string the rule pattern matches.
+    """
+    return {
+        "MessageId": "m-1",
+        "ReceiptHandle": receipt,
+        "Body": json.dumps(
+            {
+                "version": "0",
+                "source": SPOT_INTERRUPTION_EVENT_SOURCE,
+                "detail-type": SPOT_INTERRUPTION_EVENT_DETAIL_TYPE,
+                "detail": {"instance-id": instance_id, "instance-action": action},
+            }
+        ),
+    }
+
+
+class TestPollWarningQueue:
+    """Draining warnings, and routing them to whichever handler owns them."""
+
+    @pytest.fixture
+    def monitor(self):
+        monitor = SpotInterruptionMonitor(
+            MagicMock(), check_interval=1, provider_id="abcdef123456"
+        )
+        monitor.warning_queue_url = QUEUE_URL
+        return monitor
+
+    @pytest.fixture
+    def sqs(self):
+        client = MagicMock()
+        client.receive_message.return_value = {"Messages": [_warning_message()]}
+        return client
+
+    def test_a_warning_for_a_registered_instance_is_queued(self, monitor, sqs):
+        monitor.register_instance("i-abc123", MagicMock())
+
+        monitor._poll_warning_queue(sqs, MagicMock())
+
+        event_type, instance_id, details = monitor.event_queue.get_nowait()
+        assert event_type == "instance"
+        assert instance_id == "i-abc123"
+        assert details["InstanceId"] == "i-abc123"
+        assert details["InstanceAction"] == "terminate"
+
+    def test_the_source_marks_it_as_an_advance_warning(self, monitor, sqs):
+        """This is how a handler knows it has two minutes rather than none.
+
+        The EC2-state track stamps ``ec2-state`` and fires on an instance that
+        is already dying; a handler that cannot tell them apart must either
+        assume the worst and skip checkpointing entirely, or attempt a
+        checkpoint that cannot complete.
+        """
+        monitor.register_instance("i-abc123", MagicMock())
+
+        monitor._poll_warning_queue(sqs, MagicMock())
+
+        _, _, details = monitor.event_queue.get_nowait()
+        assert details["Source"] == "eventbridge"
+
+    def test_a_stop_action_is_preserved(self, monitor, sqs):
+        """``instance-action`` is one of terminate, stop, or hibernate.
+
+        A stopped or hibernated instance can come back, which is a different
+        recovery decision from a terminated one, so the value has to survive
+        rather than be flattened to the default.
+        """
+        sqs.receive_message.return_value = {
+            "Messages": [_warning_message(action="hibernate")]
+        }
+        monitor.register_instance("i-abc123", MagicMock())
+
+        monitor._poll_warning_queue(sqs, MagicMock())
+
+        _, _, details = monitor.event_queue.get_nowait()
+        assert details["InstanceAction"] == "hibernate"
+
+    def test_every_message_is_deleted_before_it_is_parsed(self, monitor, sqs):
+        """An unparseable message must not redeliver for the retention period.
+
+        Deleting after a successful parse looks equivalent and is not: the rule
+        matches every spot interruption in the account, so this queue receives
+        messages for instances the monitor does not own, and any message it
+        cannot use would be received again on every single poll -- crowding out,
+        via ``MaxNumberOfMessages``, the warnings it can.
+        """
+        sqs.receive_message.return_value = {
+            "Messages": [
+                {"MessageId": "m-1", "ReceiptHandle": "rh-junk", "Body": "not json"}
+            ]
+        }
+
+        monitor._poll_warning_queue(sqs, MagicMock())
+
+        sqs.delete_message.assert_called_once_with(
+            QueueUrl=QUEUE_URL, ReceiptHandle="rh-junk"
+        )
+
+    def test_a_message_with_no_body_is_survived(self, monitor, sqs):
+        """``Body`` is always present from SQS, but a mock or a proxy may drop it."""
+        sqs.receive_message.return_value = {
+            "Messages": [{"MessageId": "m-1", "ReceiptHandle": "rh-1"}]
+        }
+
+        monitor._poll_warning_queue(sqs, MagicMock())
+
+        assert monitor.event_queue.empty()
+
+    def test_a_failed_delete_does_not_lose_the_warning(self, monitor, sqs):
+        """The warning is still actionable even if the message will redeliver.
+
+        Dropping it here would trade a duplicate for a missed interruption, and
+        only one of those two loses work.
+        """
+        sqs.delete_message.side_effect = ClientError(
+            {"Error": {"Code": "ReceiptHandleIsInvalid", "Message": "expired"}},
+            "DeleteMessage",
+        )
+        monitor.register_instance("i-abc123", MagicMock())
+
+        monitor._poll_warning_queue(sqs, MagicMock())
+
+        assert not monitor.event_queue.empty()
+
+    def test_a_warning_for_an_unowned_instance_is_dropped_quietly(self, monitor, sqs):
+        """The rule is account-wide, so this is the common case, not an error.
+
+        The instances to watch are not known until the fleet launches, so the
+        pattern cannot be scoped to them. Every other spot instance in the
+        account and region delivers here too.
+        """
+        monitor.register_instance("i-somethingelse", MagicMock())
+
+        monitor._poll_warning_queue(sqs, MagicMock())
+
+        assert monitor.event_queue.empty()
+        # Still deleted, or it would redeliver until the retention expires.
+        sqs.delete_message.assert_called_once()
+
+    def test_a_warning_for_a_fleet_member_routes_to_the_fleet_handler(
+        self, monitor, sqs
+    ):
+        """An instance launched by a fleet is not registered under its own ID.
+
+        Only the fleet is registered, so the instance has to be attributed by
+        asking each registered fleet what it is running -- via the reserved
+        ``aws:ec2:fleet-id`` tag, the only route that works for an instant
+        fleet.
+        """
+        monitor.register_fleet("fleet-1", MagicMock())
+        ec2 = MagicMock()
+
+        with patch(
+            "parsl_ephemeral_aws.compute.spot_interruption.get_ec2_fleet_instance_ids",
+            return_value=["i-abc123", "i-other"],
+        ) as lookup:
+            monitor._poll_warning_queue(sqs, ec2)
+
+        lookup.assert_called_once_with(ec2, "fleet-1")
+        event_type, fleet_id, instance_ids, details = monitor.event_queue.get_nowait()
+        assert event_type == "fleet"
+        assert fleet_id == "fleet-1"
+        # Only the interrupted instance, not the whole fleet: the others are
+        # still running and their work must not be rescheduled.
+        assert instance_ids == ["i-abc123"]
+        assert details["FleetRequestId"] == "fleet-1"
+        assert details["Source"] == "eventbridge"
+
+    def test_a_directly_registered_instance_is_not_looked_up_by_fleet(
+        self, monitor, sqs
+    ):
+        """The instance handler is more specific, and the lookup costs an API call.
+
+        Falling through to the fleet scan would also mean a ``describe_instances``
+        page-walk per registered fleet on every warning -- including the account's
+        unrelated ones.
+        """
+        monitor.register_instance("i-abc123", MagicMock())
+        monitor.register_fleet("fleet-1", MagicMock())
+
+        with patch(
+            "parsl_ephemeral_aws.compute.spot_interruption.get_ec2_fleet_instance_ids",
+        ) as lookup:
+            monitor._poll_warning_queue(sqs, MagicMock())
+
+        lookup.assert_not_called()
+
+    def test_all_ten_messages_in_a_batch_are_handled(self, monitor, sqs):
+        """A batch arrives when several instances in a fleet go at once.
+
+        Handling only the first would leave the rest to redeliver, spending a
+        poll interval each -- and the whole lead time is two minutes.
+        """
+        sqs.receive_message.return_value = {
+            "Messages": [
+                _warning_message(instance_id=f"i-{n}", receipt=f"rh-{n}")
+                for n in range(10)
+            ]
+        }
+        for n in range(10):
+            monitor.register_instance(f"i-{n}", MagicMock())
+
+        monitor._poll_warning_queue(sqs, MagicMock())
+
+        assert monitor.event_queue.qsize() == 10
+        assert sqs.delete_message.call_count == 10
+
+    def test_the_poll_long_polls_within_the_check_interval(self, monitor, sqs):
+        """Long polling is what makes the warning arrive promptly.
+
+        With short polling the warning waits out the check interval, spending up
+        to a quarter of its two minutes idle. But the wait cannot exceed the
+        interval either, or a monitor configured to check often would block past
+        its own period and ignore ``stop_event`` for the difference.
+        """
+        monitor._poll_warning_queue(sqs, MagicMock())
+
+        kwargs = sqs.receive_message.call_args.kwargs
+        assert kwargs["QueueUrl"] == QUEUE_URL
+        assert kwargs["MaxNumberOfMessages"] == 10
+        assert kwargs["WaitTimeSeconds"] == 1  # check_interval, the smaller of the two
+
+    def test_a_long_check_interval_is_capped_by_the_sqs_maximum(self):
+        """SQS rejects ``WaitTimeSeconds`` above 20."""
+        monitor = SpotInterruptionMonitor(MagicMock(), check_interval=300)
+        monitor.warning_queue_url = QUEUE_URL
+        sqs = MagicMock()
+        sqs.receive_message.return_value = {}
+
+        monitor._poll_warning_queue(sqs, MagicMock())
+
+        assert (
+            sqs.receive_message.call_args.kwargs["WaitTimeSeconds"]
+            == SPOT_INTERRUPTION_QUEUE_WAIT_SECONDS
+        )
+        assert SPOT_INTERRUPTION_QUEUE_WAIT_SECONDS <= 20
+
+    def test_a_receive_failure_does_not_break_the_loop(self, monitor, sqs):
+        """The EC2-state poll runs in the same iteration and must still run.
+
+        ``_monitoring_loop`` catches broadly, so a raise here would also skip
+        ``_process_interruption_events`` and strand whatever is already queued.
+        """
+        sqs.receive_message.side_effect = ClientError(
+            {
+                "Error": {
+                    "Code": "AWS.SimpleQueueService.NonExistentQueue",
+                    "Message": "gone",
+                }
+            },
+            "ReceiveMessage",
+        )
+
+        monitor._poll_warning_queue(sqs, MagicMock())
+
+        assert monitor.event_queue.empty()
+
+    def test_an_empty_poll_does_nothing(self, monitor, sqs):
+        """SQS omits ``Messages`` entirely rather than returning an empty list."""
+        sqs.receive_message.return_value = {"ResponseMetadata": {}}
+
+        monitor._poll_warning_queue(sqs, MagicMock())
+
+        assert monitor.event_queue.empty()
+        sqs.delete_message.assert_not_called()
+
+    def test_a_queued_warning_reaches_the_handler(self, monitor, sqs):
+        """End to end within the monitor: message in, handler called.
+
+        The two halves are tested separately above; this pins that they compose,
+        since ``_poll_warning_queue`` enqueues a 3-tuple and
+        ``_process_interruption_events`` unpacks by arity.
+        """
+        handler = MagicMock()
+        monitor.register_instance("i-abc123", handler)
+
+        monitor._poll_warning_queue(sqs, MagicMock())
+        monitor._process_interruption_events()
+
+        handler.assert_called_once()
+        assert handler.call_args.args[0] == "i-abc123"
+        assert handler.call_args.args[1]["Source"] == "eventbridge"
+
+
+class TestMonitoringLoopWiring:
+    """The loop only polls SQS when a notifier exists."""
+
+    def _monitor(self, queue_url):
+        monitor = SpotInterruptionMonitor(MagicMock(), check_interval=1)
+        monitor.warning_queue_url = queue_url
+        # One iteration: the loop checks stop_event before and after the body.
+        monitor.stop_event.set()
+        return monitor
+
+    def test_the_queue_is_polled_when_a_notifier_exists(self):
+        monitor = self._monitor(QUEUE_URL)
+        monitor.stop_event.clear()
+
+        def stop_after_one(*args, **kwargs):
+            monitor.stop_event.set()
+
+        monitor._poll_warning_queue = MagicMock(side_effect=stop_after_one)
+        monitor._check_instance_interruptions = MagicMock()
+        monitor._check_fleet_interruptions = MagicMock()
+
+        monitor._monitoring_loop()
+
+        monitor._poll_warning_queue.assert_called_once()
+
+    def test_no_sqs_client_is_built_when_the_notifier_failed(self):
+        """Otherwise every iteration polls ``None`` as a queue URL.
+
+        SQS answers that with ``InvalidAddress``, once per check interval for
+        the life of the workflow, burying the real fallback path in errors.
+        """
+        monitor = SpotInterruptionMonitor(MagicMock(), check_interval=1)
+        assert monitor.warning_queue_url is None
+
+        def stop_after_one(*args, **kwargs):
+            monitor.stop_event.set()
+
+        monitor._poll_warning_queue = MagicMock()
+        monitor._check_instance_interruptions = MagicMock(side_effect=stop_after_one)
+        monitor._check_fleet_interruptions = MagicMock()
+
+        monitor._monitoring_loop()
+
+        monitor._poll_warning_queue.assert_not_called()
+        # The fallback track still ran.
+        monitor._check_instance_interruptions.assert_called_once()
+        assert "sqs" not in [
+            call.args[0] for call in monitor.session.client.call_args_list
+        ]


### PR DESCRIPTION
Phase 6 of the v0.7.0 repair plan. Closes #86, all three sub-parts: retire the
legacy Spot Fleet API, fix the warm pool's cost leak, and detect spot
interruption *before* the instance dies.

## 6.1 — Spot Fleet → EC2 Fleet

AWS: *"Spot Fleet … uses a legacy API with no planned investment."* Every
`request_spot_fleet` call is now `create_fleet`, in all three producers:
`SpotFleetManager`, `ServerlessMode`, and the detached mode's bastion manager
script. Backed by the launch template #85 introduced — that ordering was
mandatory, because `CreateFleet` has no `LaunchSpecifications` member at all.

Fleet type is **`instant`**, chosen because it returns its instance IDs
synchronously and so preserves the block → instance-ID mapping the rest of the
package is built on. The trade-off is deliberate: `instant` rejects
`ReplaceUnhealthyInstances`, `TerminateInstancesWithExpiration`, and
`SpotOptions.MaintenanceStrategies` outright — not ignores, *rejects*, verified
against real EC2 — so there is no Capacity Rebalance. That is what 6.3 replaces.

### Defects this fixed on the way

Four paths in the fleet code could never have worked:

| Defect | Why it never worked | Verified by |
|---|---|---|
| `ServerlessMode`'s fleet launched with no AMI | `ecs_worker.yml`'s `RegionMap` was never wired to a `FindInMap` → `Parameter 'amiIdList' cannot be empty` | real EC2, both fleet APIs |
| …and with duplicate pools | It padded `!Select` slots by repeating an instance type → `InvalidFleetConfig: duplicate instance pools`. **`DryRun` does not catch this** — it accepted the identical request | real EC2, with and without `DryRun` |
| Default bastion path always failed | `_create_bastion_stack()` sent 4 parameters `bastion.yml` does not declare; CFN rejects undeclared parameters outright | `ValidationError: Parameters: [UseSpotFleet] do not exist in the template` |
| No fleet was ever interruption-monitored | `StandardMode` iterated `block["fleet_requests"]`; the manager writes `block["fleet_request_id"]`. Loop body unreachable at both submit and state-load | code reading + unit test |
| Orphan sweep found neither fleet resource | Knew one of the two IAM role prefixes in use, and enumerated via `describe_spot_fleet_requests`, which cannot see an EC2 Fleet | real EC2 |
| Synthesised "similar instance types" were invalid | Slicing the first character assumes a single-char family: `m5a.large` → `mm5a.large` | code reading |

### No fleet is built by CloudFormation any more, on any path

The `Overrides` list is variable-length — one entry per instance type — and CFN
cannot build one. Three routes were tried against real AWS before giving up:

- `Fn::ForEach` (`AWS::LanguageExtensions`) expands to a **map**, not a list —
  confirmed by reading the processed template off a change set.
- A fixed set of `!Select` slots cannot be left partly filled: an out-of-range
  `!Select` fails validation **even inside the untaken branch of an `!If`**.
- Padding the slots by repeating a type is what the old template did, and EC2
  refuses it as duplicate instance pools.

`ServerlessMode` calls `CreateFleet` directly instead. That also stops it
deploying an ECS cluster, a task definition, two IAM roles, and a log group that
an EC2 fleet never touches — and makes the fleet ID available immediately rather
than after up to **three minutes** of polling stack outputs, during which an
interruption would have gone unhandled.

The spot bastion becomes an `AWS::EC2::Instance` referencing a launch template
carrying `InstanceMarketOptions`. `AWS::EC2::Instance` does not accept that
member directly, but a launch template does, and an instance referencing it
launches as spot. One template now serves both bastion variants, and the spot
bastion gains IMDSv2 with it.

### Compatibility

`use_spot_fleet`, the `SpotFleetManager` class name, and the `fleet_request_id`
state key are all unchanged, so existing configuration and state documents keep
working. The orphan sweep still cancels pre-upgrade Spot Fleet requests and
deletes the IAM roles they needed.

**New IAM:** `ec2:CreateFleet`, `ec2:DescribeFleets`, `ec2:DeleteFleets`.

## 6.2 — Warm pool: bound the cost, keep the design

A warm instance is left **Running**, not Stopped, so it bills at the full
instance rate for the whole TTL whether or not another job arrives. AWS is blunt
about this shape: keeping warm instances running is *"highly discouraged to avoid
incurring unnecessary charges."*

The native ASG warm pool AWS recommends holds instances **Stopped**, and a
Stopped instance runs no SSM agent — so it cannot receive the `SendCommand` this
package dispatches with. Moving to a pull model is **#130**, deferred to v0.8.0.

Until then the cost is bounded rather than eliminated:

- `warm_pool_ttl` default **600s → 120s** (an idle pool costs a fifth of what it did)
- `warm_pool_size` capped at `MAX_WARM_POOL_SIZE` (20), `ValueError` above it
- enabling a pool logs the instance count, the window, and the resulting idle
  instance-seconds — the kwarg name alone does not convey that it costs money
  while doing nothing

## 6.3 — The warning now arrives before the reclaim

An EventBridge rule on `EC2 Spot Instance Interruption Warning` delivers to an
SQS queue the driver long-polls, giving ~2 minutes of notice with the instance
still `running` — the only window in which checkpointing can succeed. The
pre-existing EC2-state poll cannot see anything until `shutting-down`, which is
after the reclaim.

Driver-side only, so it works for instances that are already running. Failing to
create the notifier is **logged, not raised**: detection degrades to the
post-facto poll, which is worse but functional, and is not a reason to fail the
workflow that was about to run.

**New IAM:** `events:PutRule`, `events:PutTargets`, `events:RemoveTargets`,
`events:DeleteRule`, `events:TagResource`, `sqs:CreateQueue`,
`sqs:GetQueueAttributes`, `sqs:SetQueueAttributes`, `sqs:ReceiveMessage`,
`sqs:DeleteMessage`, `sqs:DeleteQueue`. No IAM **role** is created — delivery to
SQS is authorised by the queue's own resource policy, unlike most target types,
and `put_targets` with no `RoleArn` returns `FailedEntryCount=0`.

Two design points worth stating:

- **The rule cannot be scoped to this provider.** The event's `detail` carries
  only `instance-id` and `instance-action`, and instance IDs are not known until
  the fleet launches, so the rule necessarily matches every spot interruption in
  the account and region. Each monitor discards warnings for instances it does
  not track.
- **`EC2 Instance Rebalance Recommendation` is deliberately not matched.** It
  signals elevated risk, not an impending reclaim; treating it as an interruption
  would checkpoint and tear down workers that were never going away.

## Verification

**832 unit + security tests pass** (up from 788), `ruff check` clean,
`ruff format` clean, `mypy` has **no new errors** against the 87-error baseline
(79 now). The mypy check was done by diffing error *identities* with line numbers
normalised, not counts — the net improvement would otherwise have masked one
genuinely new error, which is how the `serverless.py` subnet guard below was
found.

### Real AWS

`tests/aws/test_spot_warning_e2e.py` — **11/11 passed**, zero orphaned resources
after (`tools/cleanup_aws_resources.py` found no rules, queues, FIS templates,
instances, or launch templates).

Four load-bearing claims confirmed against live AWS:

1. EventBridge delivers to SQS with **no IAM role** — read back off the target.
2. A real FIS-driven interruption warning arrives **while the instance is still
   `running`** — 15.2s after the experiment started.
3. The provider's own monitor routes that warning to a registered handler with
   `Source: "eventbridge"`.
4. The rule and queue are **gone** after teardown — asserted inside the tests,
   not only in teardown, so a silent teardown failure cannot hide a leak.

A fake warning is not an option: `put_events` refuses any `aws.`-prefixed source
with `NotAuthorizedForSourceException`, which is why FIS is the only way to cause
an interruption on demand. Set `AWS_TEST_FIS_ROLE_ARN` to run those two tests;
the other nine need only the standard E2E network.

### New unit coverage

`tests/unit/test_spot_warning_notifier.py` — **43 tests**. The notifier had zero.
Four behaviours a live probe proves once and that then rot silently:

- **The queue policy is set before the target is added.** A warning arriving in
  that window is dropped by SQS as unauthorised and never retried — the two
  minutes elapse and the instance is gone. A live probe cannot catch this: it
  creates the rule long before any interruption fires.
- **`put_targets` reports refusal in `FailedEntryCount`, not by raising.** An
  unchecked call returns successfully having wired nothing, and the absence of
  warnings is indistinguishable from the absence of interruptions.
- **Every message is deleted before it is parsed.** The rule matches the whole
  account, so an unparseable body would be redelivered on every poll, crowding
  out usable warnings via `MaxNumberOfMessages`.
- **The notifier is torn down even when no thread was running.** Nothing else in
  the package deletes the rule and queue.

Ordering assertions span two clients (the queue policy on SQS against the target
on EventBridge), so both are attached to a shared parent mock whose `mock_calls`
interleaves them — two independent mocks cannot express that.

`moto` 5.1.21 supports `create_fleet(Type="instant")` but does **not** apply the
`aws:ec2:fleet-id` tag, so the tag lookup the orphan sweep depends on is
asserted against real AWS only. Noted in the code.

## Also in this PR

- `ServerlessMode._create_job_fleet()` gained an explicit subnet guard. The ECS
  network guard establishes `subnet_id`, but in a different method, so an unset
  one would have reached `CreateFleet` as a null and been refused there — *after*
  the launch template was created. The guard fails first, so no per-job template
  is leaked; unit-tested by asserting `create_launch_template` was never called.
