### PR TITLE
test: keep the default state file out of the repo root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Two fixtures in `tests/unit/test_error_handling.py` wrote
+  `ephemeral_aws_state.json` into the repository root on every run.
+  `state_file_path` defaults to that *relative* filename, and both fixtures mock
+  only `boto3.Session` — so the state store is a real `FileStateStore` pointed at
+  the working directory, and each construction that succeeded left a file behind.
+  The 11 affected tests now pass a `tmp_path` path. The file had been mistaken for
+  a leftover from a manual run; its `launch_template_id` was a `MagicMock` repr,
+  which is what identified a test rather than a real session as the writer. A
+  stale state document in the root is also what makes the `load_state()`
+  null-restore hazard reachable, so this was not merely untidy (refs #93).
+
+### Added
+- An autouse `tests/conftest.py` guard fails any test that leaves a
+  default-named state file in the working directory or the repository root,
+  naming the test and the fix. Gitignoring the path was the alternative and was
+  rejected: it would have silenced the symptom while tests kept writing outside
+  their sandbox. The watched filename is read from the `state_file_path` signature
+  default rather than hardcoded, so renaming the default cannot quietly disable
+  the check (refs #93).
+
 ## [0.7.0] - 2026-07-31
 
 ### Security

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,14 +4,17 @@ SPDX-License-Identifier: Apache-2.0
 SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
 """
 
+import inspect
 import os
 import pytest
 import boto3
 import logging
 import requests
+from pathlib import Path
 from unittest.mock import MagicMock
 from typing import Generator
 
+from parsl_ephemeral_aws.provider import EphemeralAWSProvider
 from tests.substrate_support import (
     create_substrate_session,
     get_substrate_endpoint,
@@ -24,6 +27,16 @@ logging.basicConfig(level=logging.INFO)
 # Test configuration
 AWS_TEST_REGION = os.environ.get("AWS_TEST_REGION", "us-west-2")
 AWS_TEST_PROFILE = os.environ.get("AWS_TEST_PROFILE", "aws")
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Read from the signature rather than hardcoded, so the guard below keeps working
+# if the default is ever renamed. Kept out of the fixture to pay the import once.
+DEFAULT_STATE_FILENAME = (
+    inspect.signature(EphemeralAWSProvider.__init__)
+    .parameters["state_file_path"]
+    .default
+)
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -89,6 +102,43 @@ def _neutralize_aws_credentials(request, monkeypatch):
         monkeypatch.setenv(*marker.args)
     monkeypatch.delenv("AWS_PROFILE", raising=False)
     monkeypatch.delenv("AWS_DEFAULT_PROFILE", raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _no_default_state_file_left_behind(request):
+    """Fail the test that drops a default-path state file outside its sandbox.
+
+    ``state_file_path`` defaults to the *relative* ``ephemeral_aws_state.json``
+    (provider.py), so any test that constructs a provider successfully without
+    overriding it writes into whatever the working directory happens to be --
+    normally the checkout. Two fixtures in ``test_error_handling.py`` did exactly
+    that for several releases; the file went unnoticed because it is not
+    gitignored and reads as a leftover from a manual run (#93).
+
+    Ignoring the path would have hidden it. Failing here instead names the
+    offending test, and the fix is a one-line ``state_file_path`` pointing at
+    ``tmp_path``. That matters beyond tidiness: a stale state document in the
+    repo root is what makes the ``load_state()`` null-restore hazard reachable,
+    so a test leaving one behind is not harmless.
+
+    Both the working directory and the repo root are checked, because the write
+    lands in the former while the latter is what gets committed by accident, and
+    a test is free to ``chdir`` between the two. Scoped to the default filename:
+    a state file at an explicit path is the caller's business.
+    """
+    watched = {Path.cwd() / DEFAULT_STATE_FILENAME, REPO_ROOT / DEFAULT_STATE_FILENAME}
+    preexisting = {p for p in watched if p.exists()}
+    yield
+    leaked = sorted(p for p in watched if p.exists() and p not in preexisting)
+    if leaked:
+        for path in leaked:
+            path.unlink()
+        pytest.fail(
+            f"{request.node.nodeid} wrote {DEFAULT_STATE_FILENAME} outside its "
+            f"sandbox ({', '.join(str(p) for p in leaked)}). Pass "
+            "state_file_path=str(tmp_path / 'state.json') when constructing the "
+            "provider, or patch _initialize_state_store."
+        )
 
 
 @pytest.fixture

--- a/tests/unit/test_error_handling.py
+++ b/tests/unit/test_error_handling.py
@@ -54,7 +54,7 @@ class TestAWSConnectionErrors:
     """Tests for AWS connection and authentication errors."""
 
     @pytest.fixture
-    def provider_config(self):
+    def provider_config(self, tmp_path):
         """Create a basic provider configuration."""
         return {
             "region": "us-east-1",
@@ -65,6 +65,11 @@ class TestAWSConnectionErrors:
             "vpc_id": "vpc-12345",
             "subnet_id": "subnet-12345",
             "security_group_id": "sg-12345",
+            # Only boto3.Session is mocked here, so the state store is a real
+            # FileStateStore. Without this it defaults to the relative
+            # 'ephemeral_aws_state.json' and every construction that *succeeds*
+            # drops one in the repository root (#93).
+            "state_file_path": str(tmp_path / "state.json"),
         }
 
     def _provider_with_failing_sts(self, provider_config, error_code):
@@ -987,7 +992,7 @@ class TestProviderConfigurationErrors:
     """
 
     @pytest.fixture
-    def provider_config(self):
+    def provider_config(self, tmp_path):
         """Minimum config that constructs, for tests to perturb one field of."""
         return {
             "region": "us-east-1",
@@ -997,6 +1002,9 @@ class TestProviderConfigurationErrors:
             "vpc_id": "vpc-12345",
             "subnet_id": "subnet-12345",
             "security_group_id": "sg-12345",
+            # Keeps the real FileStateStore inside the sandbox -- see the note on
+            # TestAWSConnectionErrors.provider_config.
+            "state_file_path": str(tmp_path / "state.json"),
         }
 
     @staticmethod


### PR DESCRIPTION
Follow-up to the v0.7.0 release. The stray `ephemeral_aws_state.json` in the
repository root was filed on #93 as root clutter; this identifies the writer and
fixes it rather than gitignoring the path.

## The defect

`state_file_path` defaults to the *relative* `ephemeral_aws_state.json`. Two
`provider_config` fixtures in `tests/unit/test_error_handling.py`
(`TestAWSConnectionErrors`, `TestProviderConfigurationErrors`) mock only
`boto3.Session`, so the provider builds a **real** `FileStateStore` at that
default — pointed at whatever the working directory happens to be. Every
construction that *succeeded* left a file behind; the ones asserting a raise did
not, which is why it looked intermittent.

Eleven tests were affected. Sibling files don't leak because they patch
`_initialize_state_store` with a `tmp_path`-backed store; `tests/aws/` and
`tests/integration/` either do the same or use S3/Parameter Store. I checked all
of them.

The file had been read as a leftover from a manual run. What identified a test as
the writer was its `launch_template_id`, which held a literal
`<MagicMock name='mock.client().create_launch_template()...'>` — mock output, so
no real AWS resources were ever involved.

## The fix

Both fixtures take `tmp_path` and pass `state_file_path`.

## The guard

An autouse `tests/conftest.py` fixture fails any test that leaves a
default-named state file in the working directory or the repo root, naming the
test and the one-line fix.

Gitignoring the path was the alternative and was rejected deliberately: it
silences the symptom while tests keep writing outside their sandbox. That matters
beyond tidiness — a stale state document in the repo root is exactly what makes
the `load_state()` null-restore hazard reachable, so a test dropping one there is
not harmless.

Two details worth noting:
- Both CWD and repo root are watched. The write lands in the former; the latter
  is what gets committed by accident; a test is free to `chdir` between them.
- The watched filename is read from the `state_file_path` signature default
  rather than hardcoded, so renaming the default cannot quietly disable the
  check.

## Verification

- **Bisected** the writer: per-file sweep → `test_error_handling.py`; per-class
  sweep → the two classes above; per-test → confirmed that successful
  constructions write and failing ones do not.
- **Mutation-checked the guard.** Reverting one fixture's `state_file_path` makes
  it fail all 11 tests with the actionable message, rather than passing
  vacuously.
- `uv run pytest tests/unit tests/security --no-cov -q` → **1062 passed, 3
  skipped**, no file in the root.
- Marked run (`-m unit`) gives an identical count, so the guard didn't shift
  collection.
- `ruff check` / `ruff format --check` clean; bandit clean via pre-commit.

Stays open against #93 — the rest of that issue (root clutter, `tools/` prune) is
still v0.8.0 work.

refs #93