### PR TITLE
fix: emit every provider param into Globus endpoint configs (#138)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Generated Globus Compute endpoint configs could not start a worker, and
+  silently dropped most of the provider's configuration.** Three defects, one
+  cause: `_provider_params_yaml()` named the parameters to emit in a hand-written
+  list that covered 15 of 52.
+  - `worker_init` was not in the list, so the reconstructed provider fell back to
+    `EphemeralAWSProvider`'s default — which installs `parsl` and not
+    `globus-compute-endpoint`. A Globus worker's launch command is rewritten to
+    `globus-compute-endpoint python-exec parsl.executors.high_throughput.process_worker_pool`,
+    so every worker failed "command not found". `GlobusComputeProvider` now
+    defaults `worker_init` to a script installing both, and emits it
+    unconditionally so it travels with the config rather than being re-resolved on
+    load.
+  - `encrypted: true` was hardcoded and unreachable from the constructor.
+    `HighThroughputExecutor` writes CurveZMQ certificates under its own `run_dir`
+    on the endpoint host and hands that path to workers as `--cert_dir`, so an EC2
+    worker died `FileNotFoundError` before registering. It is now an `encrypted`
+    constructor parameter defaulting to `False`; `True` still needs certificate
+    distribution (#62), and High-Assurance endpoints — which reject `False` — need
+    that resolved rather than this default.
+  - The other 37 parameters, including `additional_tags`, the state-backend
+    selection, and every fleet, warm-pool, and AMI-baking option, never reached
+    the file. The emitted set is now derived from `inspect.signature`, so a
+    newly added parameter is covered without anyone updating the generator.
+
+  The emitter keys on what the caller passed rather than on what differs from the
+  default, which matters for `image_id`: it is resolved from SSM to the current
+  AL2023 AMI at construction (#84), and a differs-from-default rule would write
+  that day's AMI into the file and freeze it there. An `image_id` the caller chose
+  is still emitted. `provider_id` is never emitted, so an endpoint restart adopts
+  the persisted ID instead of the generating process's.
+
+  Every other test of this generator asserted on the *text* it produced, which is
+  how a config no worker could load kept passing — including one that asserted
+  `encrypted: true`. The new tests load the generated directory through
+  `globus_compute_endpoint`'s own `get_config()` and assert on the reconstructed
+  objects; that round-trip caught two bugs in the fix itself. It is possible now
+  because #125 removed the `globus`/`test` extra conflict along with LocalStack
+  (closes #138).
 - Two fixtures in `tests/unit/test_error_handling.py` wrote
   `ephemeral_aws_state.json` into the repository root on every run.
   `state_file_path` defaults to that *relative* filename, and both fixtures mock
@@ -20,6 +58,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   null-restore hazard reachable, so this was not merely untidy (refs #93).
 
 ### Added
+- `GlobusComputeProvider` accepts `encrypted` (default `False`), and defaults
+  `worker_init` to a script that installs `globus-compute-endpoint` rather than
+  inheriting the `parsl`-only default. Both are part of #138 above.
 - An autouse `tests/conftest.py` guard fails any test that leaves a
   default-named state file in the working directory or the repository root,
   naming the test and the fix. Gitignoring the path was the alternative and was

--- a/README.md
+++ b/README.md
@@ -169,35 +169,45 @@ parsl.clear()
 > **Full guide**: [docs/globus_compute.md](docs/globus_compute.md) — architecture,
 > IAM setup, spot/container examples, multi-region deployment, and troubleshooting.
 
-Deploy enterprise Function-as-a-Service endpoints using our AWS Provider:
+Run functions on ephemeral EC2 from any network — including behind a NAT, which
+standard mode cannot do.
 
 ### Endpoint Configuration
 
+Generate the endpoint directory from the provider rather than hand-writing YAML.
+It writes both files Globus Compute needs, and needs no edits to start:
+
 ```bash
-# Install Globus Compute
-pip install globus-compute-endpoint globus-compute-sdk
-
-# Configure endpoint
-globus-compute-endpoint configure aws_research_endpoint
+uv sync --extra globus
+uv run globus-compute-endpoint login
 ```
 
-Edit `~/.globus_compute/aws_research_endpoint/config.yaml`:
+```python
+from parsl_ephemeral_aws import GlobusComputeProvider
 
-```yaml
-display_name: "AWS Research Endpoint"
-engine:
-  type: GlobusComputeEngine
+provider = GlobusComputeProvider(
+    region="us-east-1",
+    vpc_id="vpc-0123456789abcdef0",
+    subnet_id="subnet-0123456789abcdef0",
+    security_group_id="sg-0123456789abcdef0",
+    instance_type="c5.large",
+    mode="standard",
+    auto_create_instance_profile=True,
+    min_blocks=0,
+    max_blocks=20,
+    display_name="AWS Research Endpoint",
+)
 
-  provider:
-    type: AWSProvider
-    region: us-east-1
-    instance_type: c5.large
-    enable_ssm_tunneling: true
-    init_blocks: 1
-    max_blocks: 20
-
-  max_workers_per_node: 1
+provider.generate_endpoint_config("~/.globus_compute/aws_research_endpoint")
 ```
+
+```bash
+uv run globus-compute-endpoint start aws_research_endpoint
+```
+
+The `config.py` shim written alongside `config.yaml` is what makes the config
+loadable at all — Globus Compute resolves a provider by attribute lookup on
+`parsl.providers`, which does not know this class until something imports it.
 
 ### Function Execution
 

--- a/docs/globus_compute.md
+++ b/docs/globus_compute.md
@@ -5,12 +5,13 @@ Run Python functions on ephemeral AWS EC2 instances through
 environment — including behind corporate firewalls, university networks, and home
 routers.
 
-```{warning}
-Read [Known limitations](#known-limitations) before deploying. The generated
-`config.yaml` currently drops `worker_init` and hardcodes `encrypted: true`, and
-both defects prevent workers from starting
-([#138](https://github.com/scttfrdmn/parsl-aws-provider/issues/138)). Two manual
-edits work around them, and are given below.
+```{note}
+Before v0.8.0 the generated `config.yaml` dropped `worker_init`, hardcoded
+`encrypted: true`, and omitted 37 of 52 provider parameters — so every endpoint
+needed two manual edits before a worker could start
+([#138](https://github.com/scttfrdmn/parsl-aws-provider/issues/138)). Generated
+configs are now complete and start unedited. Read
+[Known limitations](#known-limitations) before deploying.
 ```
 
 ## Why it is worth the trouble
@@ -129,54 +130,54 @@ Compute's own loader; `get_config()` prefers `config.py` when both are present,
 which is what makes the pair work
 ([#87](https://github.com/scttfrdmn/parsl-aws-provider/issues/87)).
 
-### 2. Apply the two required edits
+### 2. Read the two keys that are set for you
 
-Open `config.yaml` and make both changes. Without them the endpoint starts, EC2
-instances launch, and no worker ever registers
-([#138](https://github.com/scttfrdmn/parsl-aws-provider/issues/138)).
+No edits are required. Two generated keys are worth understanding, because both
+are the difference between a worker that registers and one that dies silently:
 
 ```yaml
 engine:
   type: GlobusComputeEngine
-  encrypted: false          # ← change from true; see below
+  # CurveZMQ certificates live in the endpoint host's run_dir, which an EC2
+  # worker cannot read -- see #62. Set true once that is distributed.
+  encrypted: false
   provider:
     type: GlobusComputeProvider
     region: us-east-1
-    # ... generated keys ...
-    # ← add this, replacing the default worker_init entirely:
-    worker_init: "dnf install -y python3.11 python3.11-pip\nln -sf /usr/bin/python3.11 /usr/bin/python3\npip3.11 install --quiet --upgrade globus-compute-endpoint\n"
+    worker_init: "dnf install -y python3.11 python3.11-pip\nln -sf /usr/bin/python3.11 /usr/bin/python3\npip3.11 install --quiet globus-compute-endpoint\n"
+    # ... every parameter you passed to the constructor ...
 ```
 
-**Why `worker_init`.** A Globus Compute worker is not launched with Parsl's
+**`worker_init`.** A Globus Compute worker is not launched with Parsl's
 `process_worker_pool.py`. The engine rewrites the command to:
 
 ```
 globus-compute-endpoint python-exec parsl.executors.high_throughput.process_worker_pool -a ...
 ```
 
-so `globus-compute-endpoint` must be on the worker's `PATH`. The provider's
-default `worker_init` installs `parsl` and not `globus-compute-endpoint`, and the
-generator drops any value you passed to the constructor — so the reconstructed
-provider always gets the default. The worker command is then `command not found`.
+so `globus-compute-endpoint` must be on the worker's `PATH`, and nothing but
+`worker_init` puts it there. `GlobusComputeProvider` therefore overrides the
+inherited default — which installs `parsl` alone — with one that installs both,
+and emits it unconditionally so it travels with the config. Pass your own
+`worker_init` to replace it; it must still install `globus-compute-endpoint`.
 
-**Why `encrypted: false`.** `GlobusComputeEngine` forwards `encrypted` to the
-wrapped `HighThroughputExecutor`, which generates CurveZMQ certificates in its
-`run_dir` **on the endpoint host** and passes that path to workers as
-`--cert_dir`. An EC2 worker has no such path and dies with `FileNotFoundError`
-before registering. Same-VPC deployments rely on VPC isolation instead;
-certificate distribution is
-[#62](https://github.com/scttfrdmn/parsl-aws-provider/issues/62).
+The install deliberately omits `--upgrade`: `globus-compute-endpoint` pins
+`parsl` exactly, so letting pip take a newer `parsl` breaks the pin it just
+resolved.
+
+**`encrypted: false`.** `GlobusComputeEngine` forwards `encrypted` to the wrapped
+`HighThroughputExecutor`, which generates CurveZMQ certificates in its `run_dir`
+**on the endpoint host** and passes that path to workers as `--cert_dir`. An EC2
+worker has no such path and dies with `FileNotFoundError` before registering.
+Same-VPC deployments rely on VPC isolation instead; certificate distribution is
+[#62](https://github.com/scttfrdmn/parsl-aws-provider/issues/62). Pass
+`encrypted=True` to override, once you have a way to distribute the certificates.
 
 ```{note}
 High-Assurance endpoints reject `encrypted: false`
-(`GlobusComputeEngine.assert_ha_compliant()`), so they need #62 resolved rather
-than this workaround.
+(`GlobusComputeEngine.assert_ha_compliant()`), so they need #62 resolved before
+they can use this provider at all.
 ```
-
-Anything else the generator dropped goes in the same place — `additional_tags`,
-`state_store_type`, `use_spot_fleet`, `warm_pool_size`, `image_id`, and 32 more.
-A hand-edited `config.yaml` accepts every `EphemeralAWSProvider` option; only the
-*generator* is selective.
 
 ### 3. Start the endpoint
 
@@ -221,7 +222,7 @@ uv run python tools/cleanup_aws_resources.py --dry-run --region us-east-1
 
 ## Configuration reference
 
-`GlobusComputeProvider` accepts every `EphemeralAWSProvider` parameter plus three
+`GlobusComputeProvider` accepts every `EphemeralAWSProvider` parameter plus four
 of its own:
 
 | Parameter | Type | Default | Description |
@@ -229,13 +230,30 @@ of its own:
 | `endpoint_id` | `str \| None` | `None` | Endpoint UUID. Emitted into `config.yaml` as a provider key and a trailing comment. |
 | `container_image` | `str \| None` | `None` | Image URI. Sets `container_type: docker` and `container_uri` under `engine`. |
 | `display_name` | `str` | `"Ephemeral AWS Endpoint"` | Label shown in the Globus Compute web console. |
+| `encrypted` | `bool` | `False` | CurveZMQ encryption on the engine. `True` needs [#62](https://github.com/scttfrdmn/parsl-aws-provider/issues/62) — see step 2. |
 
-Parameters that reach `config.yaml` today: `region`, `instance_type`, `mode`,
-`vpc_id`, `subnet_id`, `security_group_id`, `min_blocks`, `max_blocks`,
-`use_spot`, `spot_interruption_handling`, `auto_create_instance_profile`,
-`iam_instance_profile_arn`, `container_image`, `status_polling_interval`,
-`waiter_delay`, `waiter_max_attempts`, and `endpoint_id`. Everything else must be
-added to the YAML by hand until #138 lands.
+`worker_init` also differs from the base class: `GlobusComputeProvider` defaults
+it to a script that installs `globus-compute-endpoint`, not just `parsl`.
+
+**Which parameters reach `config.yaml`.** Every parameter you pass, plus
+`region`, `instance_type`, `mode`, `max_blocks`, and `worker_init` whether you
+pass them or not. The list comes from `inspect.signature`, so a parameter added to
+`EphemeralAWSProvider` is emitted without anyone updating the generator — the
+hand-maintained list that preceded it covered 15 of 52 (#138).
+
+Two parameters are deliberately never emitted:
+
+- **`provider_id`** — pinning it would tie every endpoint restart to the ID of the
+  process that generated the config, instead of adopting whatever is already
+  persisted at the state location.
+- **`image_id`, unless you passed it** — it is resolved from SSM to the current
+  Amazon Linux 2023 AMI at construction ([#84](https://github.com/scttfrdmn/parsl-aws-provider/issues/84)),
+  and writing that resolved value in would freeze the endpoint on whichever AMI
+  was current the day you generated the file. An `image_id` you chose is emitted.
+
+`nodes_per_block`, `cores_per_node`, `mem_per_node`, and `debug` are also left
+out: the first three are set by `GlobusComputeEngine` from its own config keys, so
+emitting them would put two writers on one value.
 
 Recommended values for a Globus Compute deployment:
 
@@ -253,8 +271,6 @@ Recommended values for a Globus Compute deployment:
 long-lived `globus-compute-endpoint` worker process the engine expects.
 
 ## Examples
-
-Each of these still needs the two edits from step 2.
 
 ### Spot endpoint
 
@@ -281,7 +297,7 @@ provider.generate_endpoint_config("~/.globus_compute/spot_aws")
 ```
 
 What actually protects your work is a retry policy on the engine, not the
-interruption handler:
+interruption handler. The generator already writes it:
 
 ```yaml
 engine:
@@ -296,9 +312,6 @@ Two limitations, both
 being constructed *at all* — without it you get one WARNING at startup and no
 detection — and what the warning triggers today is a log line, not task
 recovery. Treat it as observability.
-
-`checkpoint_bucket` is also one of the dropped parameters (#138), so add it to
-the YAML by hand.
 
 ### Container endpoint
 
@@ -315,6 +328,9 @@ provider = GlobusComputeProvider(
     max_blocks=5,
     auto_create_instance_profile=True,
     display_name="Python 3.11 Container Endpoint",
+    # Overriding the default is correct here: the host runs Docker, and the
+    # image is what needs globus-compute-endpoint.
+    worker_init="dnf install -y docker\nsystemctl start docker\n",
 )
 
 provider.generate_endpoint_config("~/.globus_compute/python311_aws")
@@ -322,14 +338,10 @@ provider.generate_endpoint_config("~/.globus_compute/python311_aws")
 
 `container_type: docker` means the engine wraps the worker command in
 `docker run`, so `worker_init` must install and start Docker *and* the image must
-contain `globus-compute-endpoint`:
+contain `globus-compute-endpoint`.
 
-```yaml
-    worker_init: "dnf install -y docker\nsystemctl start docker\n"
-```
-
-`python:3.11-slim` does not contain it, so build your own image or pass one that
-does. For a private ECR image, add the permissions from
+`python:3.11-slim` does not contain `globus-compute-endpoint`, so build your own
+image or pass one that does. For a private ECR image, add the permissions from
 `minimum_iam_policy(include_ecr=True)`.
 
 ### One endpoint per region
@@ -372,13 +384,10 @@ start`.
 
 ## Known limitations
 
-- **`worker_init` is dropped and `encrypted: true` is hardcoded** in the
-  generated config; both prevent workers from registering, and both need the
-  manual edits from step 2
-  ([#138](https://github.com/scttfrdmn/parsl-aws-provider/issues/138)).
-- **37 of 52 provider parameters are dropped** by the generator, including
-  `additional_tags`, the state-backend selection, and every fleet, warm-pool, and
-  AMI-baking option (#138). Add them to `config.yaml` by hand.
+- **CurveZMQ encryption cannot be enabled** for EC2 workers until certificate
+  distribution exists ([#62](https://github.com/scttfrdmn/parsl-aws-provider/issues/62)),
+  so `encrypted` defaults to `False` and High-Assurance endpoints — which reject
+  that — cannot use this provider.
 - **Multi-user (manager) endpoints are unsupported**
   ([#133](https://github.com/scttfrdmn/parsl-aws-provider/issues/133)). Those
   render `user_config_template.yaml.j2` to a string and the forked user-endpoint
@@ -413,13 +422,16 @@ uv run pytest tests/unit/test_globus_compute_provider.py --no-cov -v
 
 ### The endpoint starts, instances launch, no worker registers
 
-The two step-2 edits. In order of likelihood:
+In order of likelihood:
 
 1. **`globus-compute-endpoint` is not installed on the worker.** Reach the
    instance with `aws ssm start-session --target i-...` and read
-   `/var/log/cloud-init-output.log`; then run `which globus-compute-endpoint`.
-2. **`encrypted: true` is still set.** The worker dies with `FileNotFoundError`
-   on the `--cert_dir` path before it can log anything useful.
+   `/var/log/cloud-init-output.log`; then run `which globus-compute-endpoint`. If
+   you passed your own `worker_init`, this is usually it — the default installs
+   the binary and a custom one may not.
+2. **`encrypted: true`.** The worker dies with `FileNotFoundError` on the
+   `--cert_dir` path before it can log anything useful. Generated configs set
+   `false`; check whether the file was hand-edited or predates v0.8.0.
 3. **The daemon host is not reachable from the subnet.** Workers connect back to
    it over ZMQ. Check the daemon host's own security group, not the workers'.
 
@@ -438,9 +450,9 @@ It is waiting for a worker. Beyond the above:
 - **Egress**: a private subnet needs a NAT gateway or the `ssm`, `ssmmessages`,
   and `ec2messages` VPC endpoints, plus a route to whatever package index
   `worker_init` uses.
-- **AMI**: resolved from SSM for the region and architecture. A custom `image_id`
-  must exist in the target region — and note `image_id` is a dropped parameter
-  (#138), so confirm it actually reached the YAML.
+- **AMI**: resolved from SSM for the region and architecture, and only emitted
+  into `config.yaml` when you passed it explicitly. A custom `image_id` must exist
+  in the target region.
 
 ### `ResourceNotFoundException` on start
 

--- a/parsl_ephemeral_aws/globus_compute.py
+++ b/parsl_ephemeral_aws/globus_compute.py
@@ -109,8 +109,10 @@ SPDX-License-Identifier: Apache-2.0
 SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
 """
 
+import inspect
 import logging
 import os
+from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -136,6 +138,67 @@ _INDENT2 = "  "
 _INDENT4 = "    "
 _INDENT6 = "      "
 
+# Constructor parameters deliberately left out of the generated config.
+#
+# ``provider_id`` identifies one provider's state document. Emitting it would
+# pin every endpoint restart to the *generating* process's ID; leaving it out
+# lets the constructor adopt whatever is already persisted at the state location,
+# which is what _adopt_persisted_provider_id() exists to do.
+#
+# ``nodes_per_block``, ``cores_per_node`` and ``mem_per_node`` belong to Parsl's
+# own ExecutionProvider surface. GlobusComputeEngine sets them from its own
+# config keys, so emitting them here would put two writers on one value.
+#
+# ``debug`` is a local troubleshooting flag, not endpoint configuration.
+_SKIP_PARAMS = frozenset(
+    {
+        "provider_id",
+        "nodes_per_block",
+        "cores_per_node",
+        "mem_per_node",
+        "debug",
+    }
+)
+
+# Parameters whose name differs from the attribute holding the resolved value.
+# ``mode`` is the only one: the constructor normalises it into ``mode_type`` (an
+# OperatingModeType) and keeps no ``self.mode``.
+_ATTRIBUTE_OVERRIDES = {"mode": "mode_type"}
+
+# Emitted even when the caller did not pass them. The first four are what someone
+# reads the file to find out, and a config that states them is easier to trust
+# than one where their absence has to be interpreted.
+#
+# ``worker_init`` is here for a stronger reason: it is the only thing that puts
+# ``globus-compute-endpoint`` on a worker's PATH (see
+# DEFAULT_GLOBUS_WORKER_INIT). Leaving it out when unset would mean the
+# reconstructed provider falls back to EphemeralAWSProvider's parsl-only
+# DEFAULT_WORKER_INIT -- the #138 failure, reintroduced one level down. It is
+# always emitted, so the subclass default travels with the config.
+_ALWAYS_EMIT = frozenset(
+    {"region", "instance_type", "mode", "max_blocks", "worker_init"}
+)
+
+# A Globus Compute worker is not launched with Parsl's process_worker_pool.py.
+# GlobusComputeEngine._get_compute_launch_cmd() rewrites the template to
+#
+#     globus-compute-endpoint python-exec \
+#         parsl.executors.high_throughput.process_worker_pool ...
+#
+# so ``globus-compute-endpoint`` must be on the worker's PATH. Nothing but
+# worker_init puts it there, and EphemeralAWSProvider's DEFAULT_WORKER_INIT
+# installs ``parsl`` alone -- every worker launched with it fails "command not
+# found" (#138). This default installs both.
+#
+# The pip install carries no --upgrade: globus-compute-endpoint pins parsl
+# exactly, so letting pip take a newer parsl would break the pin it just
+# resolved.
+DEFAULT_GLOBUS_WORKER_INIT = (
+    "dnf install -y python3.11 python3.11-pip\n"
+    "ln -sf /usr/bin/python3.11 /usr/bin/python3\n"
+    "pip3.11 install --quiet globus-compute-endpoint\n"
+)
+
 
 def _yaml_str(value: str) -> str:
     """Quote a string value if it contains YAML-special characters.
@@ -143,7 +206,19 @@ def _yaml_str(value: str) -> str:
     A bare colon is only a YAML mapping indicator when followed by a space or
     at end of line (e.g. ``"key: value"`` or trailing ``":"``).  Simple values
     such as Docker image tags (``python:3.11-slim``) do not need quoting.
+
+    Strings holding a newline are emitted as a double-quoted scalar with the
+    escape left intact -- ``worker_init`` is multi-line shell script, and a raw
+    newline inside a plain scalar would end the line and corrupt the document.
     """
+    if "\n" in value or "\t" in value:
+        escaped = (
+            value.replace("\\", "\\\\")
+            .replace('"', '\\"')
+            .replace("\n", "\\n")
+            .replace("\t", "\\t")
+        )
+        return f'"{escaped}"'
     needs_quoting = (
         ": " in value
         or value.endswith(":")
@@ -160,8 +235,21 @@ def _yaml_line(key: str, value: Any, indent: str = "") -> str:
         return f"{indent}{key}: null"
     if isinstance(value, bool):
         return f"{indent}{key}: {str(value).lower()}"
+    # Before the str branch, not after: OperatingModeType and friends are
+    # ``(str, Enum)``, so an isinstance(value, str) test matches them and
+    # ``str(value)`` renders "OperatingModeType.STANDARD" -- which the provider
+    # constructor then rejects as an invalid mode. ``.value`` is what it accepts.
+    if isinstance(value, Enum):
+        return f"{indent}{key}: {_yaml_str(str(value.value))}"
     if isinstance(value, str):
         return f"{indent}{key}: {_yaml_str(value)}"
+    if isinstance(value, dict):
+        inner = ", ".join(
+            f"{_yaml_str(str(k))}: {_yaml_str(str(v))}" for k, v in value.items()
+        )
+        return f"{indent}{key}: {{{inner}}}"
+    if isinstance(value, (list, tuple)):
+        return f"{indent}{key}: [{', '.join(_yaml_str(str(v)) for v in value)}]"
     return f"{indent}{key}: {value}"
 
 
@@ -238,6 +326,20 @@ class GlobusComputeProvider(EphemeralAWSProvider):
     display_name : str, optional
         Human-readable name for the Globus Compute endpoint.
         Default is ``"Ephemeral AWS Endpoint"``.
+    encrypted : bool, optional
+        Whether the engine encrypts worker traffic with CurveZMQ. Default is
+        ``False``, and that default is deliberate: ``HighThroughputExecutor``
+        generates the certificates under its own ``run_dir`` on the *endpoint
+        host* and passes that path to workers as ``--cert_dir``, so an EC2
+        worker is handed a directory that does not exist on it and dies with
+        ``FileNotFoundError``. Until certificate distribution is implemented
+        (#62), ``True`` cannot work for remote workers and rely on VPC isolation
+        instead. This was hardcoded ``true`` before #138, which made every
+        generated config unusable.
+
+        High-Assurance endpoints are the exception -- ``assert_ha_compliant()``
+        rejects ``encrypted=False``, so those need #62 resolved rather than this
+        default.
     \\*\\*kwargs
         All keyword arguments accepted by ``EphemeralAWSProvider``.
     """
@@ -249,12 +351,26 @@ class GlobusComputeProvider(EphemeralAWSProvider):
         endpoint_id: Optional[str] = None,
         container_image: Optional[str] = None,
         display_name: str = "Ephemeral AWS Endpoint",
+        encrypted: bool = False,
         **kwargs: Any,
     ) -> None:
+        # A Globus worker needs globus-compute-endpoint on its PATH, which the
+        # inherited DEFAULT_WORKER_INIT does not install (#138). Only defaulted,
+        # never overridden: an explicit worker_init is the caller's business.
+        kwargs.setdefault("worker_init", DEFAULT_GLOBUS_WORKER_INIT)
+
+        # Recorded before super().__init__ because the parent normalises and
+        # resolves several of these in place. _provider_params_yaml() emits this
+        # set, so it is the caller's stated intent that reaches the config rather
+        # than whatever the attributes hold afterwards -- see that method for why
+        # the difference matters for image_id.
+        self._explicit_params: frozenset = frozenset(kwargs)
+
         super().__init__(**kwargs)
         self.endpoint_id: Optional[str] = endpoint_id
         self.container_image: Optional[str] = container_image
         self.display_name: str = display_name
+        self.encrypted: bool = encrypted
 
     # ------------------------------------------------------------------
     # Config generation
@@ -337,7 +453,16 @@ class GlobusComputeProvider(EphemeralAWSProvider):
         lines.append("")
         lines.append("engine:")
         lines.append(f"{_INDENT2}type: GlobusComputeEngine")
-        lines.append(f"{_INDENT2}encrypted: true")
+        if not self.encrypted:
+            lines.append(
+                f"{_INDENT2}# CurveZMQ certificates live in the endpoint host's run_dir,"
+                " which an EC2"
+            )
+            lines.append(
+                f"{_INDENT2}# worker cannot read -- see #62. Set true once that is"
+                " distributed."
+            )
+        lines.append(_yaml_line("encrypted", self.encrypted, indent=_INDENT2))
         lines.append(f"{_INDENT2}max_retries_on_system_failure: 3")
 
         # ---- container (optional) ----
@@ -369,82 +494,62 @@ class GlobusComputeProvider(EphemeralAWSProvider):
         return "\n".join(lines)
 
     def _provider_params_yaml(self) -> list[str]:
-        """Return YAML lines (with 4-space indent) for provider parameters."""
+        """Return YAML lines (with 4-space indent) for provider parameters.
+
+        The emitted set is every parameter the caller passed explicitly, plus
+        those in :data:`_ALWAYS_EMIT`, minus :data:`_SKIP_PARAMS`. Parameter
+        names come from ``inspect.signature`` rather than a hand-written list,
+        because the hand-written version covered 15 of 52 and silently dropped
+        the rest (#138) -- ``worker_init`` among them, without which the
+        reconstructed provider installs ``parsl`` but not
+        ``globus-compute-endpoint`` and every worker command is "command not
+        found". A signature-derived set cannot fall behind a new option.
+
+        Keyed on what the caller *passed*, not on what differs from the default,
+        because two attributes are resolved at runtime and would otherwise be
+        frozen into the config:
+
+        * ``image_id`` defaults to ``None`` and is then filled in from SSM with
+          the current Amazon Linux 2023 AMI (#84). Emitting the resolved value
+          would pin the endpoint to whatever AMI was current on the day the
+          config was generated, which is the staleness #84 removed.
+        * ``provider_id`` defaults to a fresh UUID; see :data:`_SKIP_PARAMS`.
+
+        A caller who passes a value equal to the default still gets it emitted.
+        That is intended -- it was a deliberate choice, and a default can change
+        between releases.
+        """
         lines: list[str] = []
+        signature = inspect.signature(EphemeralAWSProvider.__init__)
 
-        # Core compute parameters
-        lines.append(_yaml_line("region", self.region, indent=_INDENT4))
-        lines.append(_yaml_line("instance_type", self.instance_type, indent=_INDENT4))
-        lines.append(_yaml_line("mode", self.mode_type.value, indent=_INDENT4))
+        for name, parameter in signature.parameters.items():
+            if name in _SKIP_PARAMS or parameter.kind is parameter.VAR_KEYWORD:
+                continue
+            if name not in _ALWAYS_EMIT and name not in self._explicit_params:
+                continue
 
-        # Network. Required since #69, so the constructor has already rejected a
-        # provider that lacks them -- with one exception: serverless mode with
-        # Lambda workers, whose functions run in the Lambda-managed VPC and so
-        # have nothing to pre-provision. That exception is why these are emitted
-        # conditionally rather than unconditionally. Omitting them from the YAML
-        # would produce a config that parses and then fails in the constructor.
-        for key, value in (
-            ("vpc_id", self.vpc_id),
-            ("subnet_id", self.subnet_id),
-            ("security_group_id", self.security_group_id),
-        ):
-            if value:
-                lines.append(_yaml_line(key, value, indent=_INDENT4))
+            attribute = _ATTRIBUTE_OVERRIDES.get(name, name)
+            if not hasattr(self, attribute):  # pragma: no cover - defensive
+                continue
 
-        # Block sizing
-        lines.append(_yaml_line("min_blocks", self.min_blocks, indent=_INDENT4))
-        lines.append(_yaml_line("max_blocks", self.max_blocks, indent=_INDENT4))
+            lines.append(_yaml_line(name, getattr(self, attribute), indent=_INDENT4))
 
-        # Spot
-        lines.append(_yaml_line("use_spot", self.use_spot, indent=_INDENT4))
-        if self.use_spot:
-            lines.append(
-                _yaml_line(
-                    "spot_interruption_handling",
-                    self.spot_interruption_handling,
-                    indent=_INDENT4,
-                )
-            )
-
-        # IAM / connectivity
-        lines.append(
-            _yaml_line(
-                "auto_create_instance_profile",
-                self.auto_create_instance_profile,
-                indent=_INDENT4,
-            )
-        )
-        if self.iam_instance_profile_arn:
-            lines.append(
-                _yaml_line(
-                    "iam_instance_profile_arn",
-                    self.iam_instance_profile_arn,
-                    indent=_INDENT4,
-                )
-            )
-
-        # Container image forwarded to provider so workers can pull it
+        # These two are GlobusComputeProvider's own, so the signature loop above
+        # cannot see them -- it reads EphemeralAWSProvider.__init__. Both are real
+        # kwargs of this subclass, so they bind on the way back in.
+        #
+        # container_image is emitted here as well as as engine.container_uri: the
+        # engine key is what actually containerises the worker, while this one
+        # keeps the value on the reconstructed provider, so regenerating a config
+        # from a loaded one does not silently drop it. The other two subclass
+        # params live elsewhere in the document -- display_name is a top-level
+        # Globus key and encrypted belongs to the engine.
+        if self.endpoint_id:
+            lines.append(_yaml_line("endpoint_id", self.endpoint_id, indent=_INDENT4))
         if self.container_image:
             lines.append(
                 _yaml_line("container_image", self.container_image, indent=_INDENT4)
             )
-
-        # Tuning
-        lines.append(
-            _yaml_line(
-                "status_polling_interval",
-                self.status_polling_interval,
-                indent=_INDENT4,
-            )
-        )
-        lines.append(_yaml_line("waiter_delay", self.waiter_delay, indent=_INDENT4))
-        lines.append(
-            _yaml_line("waiter_max_attempts", self.waiter_max_attempts, indent=_INDENT4)
-        )
-
-        # Optional endpoint_id metadata
-        if self.endpoint_id:
-            lines.append(_yaml_line("endpoint_id", self.endpoint_id, indent=_INDENT4))
 
         return lines
 

--- a/tests/unit/test_docs_examples.py
+++ b/tests/unit/test_docs_examples.py
@@ -335,14 +335,20 @@ def test_documented_renames_do_not_resolve():
 
 
 def test_globus_only_options_are_globus_only():
-    """The three Globus-specific options are on the subclass, not the base.
+    """The Globus-specific options are on the subclass, not the base.
 
     docs/globus_compute.md documents them as the whole of what GlobusComputeProvider
-    adds.
+    adds. ``encrypted`` joined them in #138: it configures the engine rather than
+    the provider, which is why it does not belong on the base.
     """
     base = _accepted_kwargs(EphemeralAWSProvider)
     globus = _own_kwargs(GlobusComputeProvider)
-    assert globus - base == {"endpoint_id", "container_image", "display_name"}
+    assert globus - base == {
+        "endpoint_id",
+        "container_image",
+        "display_name",
+        "encrypted",
+    }
 
 
 def test_compute_type_has_no_auto() -> None:

--- a/tests/unit/test_globus_compute_provider.py
+++ b/tests/unit/test_globus_compute_provider.py
@@ -254,10 +254,20 @@ class TestGenerateEndpointConfig:
         assert "mode: standard" in content
 
     def test_config_encrypted_flag(self, tmp_path):
+        """False by default, and reflects the constructor argument (#138).
+
+        This asserted ``true`` while the value was hardcoded, which is how a
+        config no EC2 worker could load kept passing its own test: the worker is
+        handed a ``--cert_dir`` under the endpoint host's ``run_dir`` and dies
+        ``FileNotFoundError`` before registering (#62).
+        """
         provider = _make_provider(tmp_path)
         config_path = provider.generate_endpoint_config(str(tmp_path / "ep"))
-        content = Path(config_path).read_text()
-        assert "encrypted: true" in content
+        assert "encrypted: false" in Path(config_path).read_text()
+
+        explicit = _make_provider(tmp_path, encrypted=True)
+        config_path = explicit.generate_endpoint_config(str(tmp_path / "ep2"))
+        assert "encrypted: true" in Path(config_path).read_text()
 
     def test_existing_directory_is_ok(self, tmp_path):
         """Calling generate_endpoint_config twice does not raise."""

--- a/tests/unit/test_globus_config_loading.py
+++ b/tests/unit/test_globus_config_loading.py
@@ -208,3 +208,260 @@ class TestMultiUserLimitation:
                 load_config_yaml(rendered)
         finally:
             _register_with_parsl_providers()
+
+
+class TestEveryParameterSurvivesTheRoundTrip:
+    """#138: the generator emitted 15 of 52 parameters and dropped the rest.
+
+    `test_provider_params_round_trip` above checks four of them, which is how a
+    hand-picked emitter list stayed wrong for so long -- the four it checked were
+    all in the list. These tests assert on the parameters that were *missing*,
+    and the first one is the check the issue names as the one that would have
+    caught all three consequences.
+    """
+
+    def test_worker_init_survives(self, tmp_path):
+        """Consequence 1, the one that broke every endpoint.
+
+        A Globus worker's launch command is rewritten to
+        `globus-compute-endpoint python-exec ...`, so that binary must be on the
+        worker's PATH and only `worker_init` puts it there. The generator dropped
+        it, so the reconstructed provider fell back to
+        `EphemeralAWSProvider.DEFAULT_WORKER_INIT` -- which installs `parsl` and
+        not `globus-compute-endpoint`, making every worker command "command not
+        found".
+        """
+        worker_init = (
+            "dnf install -y python3.11\npip3.11 install globus-compute-endpoint\n"
+        )
+        provider = _make_provider(tmp_path, worker_init=worker_init)
+        provider.generate_endpoint_config(str(tmp_path / "ep"))
+
+        loaded = _load(tmp_path / "ep").engine.provider
+
+        assert loaded.worker_init == worker_init
+
+    def test_default_worker_init_installs_globus_compute_endpoint(self, tmp_path):
+        """A caller who sets nothing still gets a worker that can start.
+
+        The subclass overrides the inherited default, and the value is emitted
+        unconditionally so it travels with the config rather than being resolved
+        again on load. Asserting the *capability* (the binary is installed), not
+        the exact script, so tightening the script does not break this.
+        """
+        provider = _make_provider(tmp_path)
+        provider.generate_endpoint_config(str(tmp_path / "ep"))
+
+        loaded = _load(tmp_path / "ep").engine.provider
+
+        assert "globus-compute-endpoint" in loaded.worker_init
+
+    def test_encrypted_defaults_false_and_is_overridable(self, tmp_path):
+        """Consequence 2: `encrypted: true` was hardcoded and cannot work.
+
+        HighThroughputExecutor writes CurveZMQ certificates under its own
+        `run_dir` on the endpoint host and hands that path to workers as
+        `--cert_dir`; an EC2 worker has no such directory and dies
+        `FileNotFoundError` (#62). The capability existed -- a hand-edited
+        `encrypted: false` loads fine -- it was simply unreachable.
+        """
+        provider = _make_provider(tmp_path)
+        provider.generate_endpoint_config(str(tmp_path / "ep"))
+        assert _load(tmp_path / "ep").engine.encrypted is False
+
+        explicit = _make_provider(tmp_path, encrypted=True)
+        explicit.generate_endpoint_config(str(tmp_path / "ep2"))
+        assert _load(tmp_path / "ep2").engine.encrypted is True
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            pytest.param(
+                {"additional_tags": {"Project": "x", "Owner": "y"}}, id="tags"
+            ),
+            pytest.param(
+                {"state_store_type": "s3", "s3_bucket": "b"}, id="state-backend"
+            ),
+            pytest.param(
+                {"use_spot_fleet": True, "instance_types": ["t3.medium", "t3.large"]},
+                id="fleet",
+            ),
+            # auto_create_instance_profile is not decoration: the constructor
+            # rejects warm_pool_size > 0 without it, since SSM SendCommand needs
+            # IAM permissions on the instance.
+            pytest.param(
+                {
+                    "warm_pool_size": 2,
+                    "warm_pool_ttl": 300,
+                    "auto_create_instance_profile": True,
+                },
+                id="warm-pool",
+            ),
+            pytest.param({"baked_ami_id": "ami-0bakedbakedbaked0"}, id="baked-ami"),
+            pytest.param({"key_name": "mykey", "use_public_ips": False}, id="access"),
+            pytest.param({"auto_shutdown": False, "max_idle_time": 900}, id="idle"),
+            pytest.param({"checkpoint_bucket": "ckpt"}, id="checkpoint"),
+            pytest.param({"profile_name": "aws"}, id="profile"),
+        ],
+    )
+    def test_dropped_parameter_groups_survive(self, tmp_path, kwargs):
+        """Consequence 3: the 37 silently-dropped parameters, by group.
+
+        Each group is one thing a user could configure and then find missing --
+        no cost allocation, the wrong state backend, an unreachable fleet path.
+        A dict and a list are in here on purpose: those need real YAML rendering
+        rather than `str()`, which is where a naive emitter breaks.
+        """
+        provider = _make_provider(tmp_path, **kwargs)
+        provider.generate_endpoint_config(str(tmp_path / "ep"))
+
+        loaded = _load(tmp_path / "ep").engine.provider
+
+        for name, expected in kwargs.items():
+            actual = getattr(loaded, name)
+            # state_store_type normalises to an Enum whose .value is the string.
+            actual = getattr(actual, "value", actual)
+            assert actual == expected, f"{name}: {actual!r} != {expected!r}"
+
+    def test_subclass_own_params_survive(self, tmp_path):
+        """The four `GlobusComputeProvider` params, which the signature loop misses.
+
+        `_provider_params_yaml` walks `EphemeralAWSProvider.__init__`, so these
+        need naming individually -- and they land in three different places:
+        `display_name` at the top level, `encrypted` and `container_uri` on the
+        engine, `endpoint_id` and `container_image` on the provider. Asserting
+        after a real load is what proves each one reached a key its consumer
+        actually reads.
+        """
+        endpoint_id = str(uuid.uuid4())
+        provider = _make_provider(
+            tmp_path,
+            endpoint_id=endpoint_id,
+            container_image="python:3.11-slim",
+            display_name="Subclass Params",
+        )
+        provider.generate_endpoint_config(str(tmp_path / "ep"))
+
+        config = _load(tmp_path / "ep")
+
+        assert config.display_name == "Subclass Params"
+        assert config.engine.container_uri == "python:3.11-slim"
+        assert config.engine.provider.endpoint_id == endpoint_id
+        assert config.engine.provider.container_image == "python:3.11-slim"
+
+    def test_resolved_ami_is_not_pinned_into_the_config(self, tmp_path):
+        """The emitter keys on what the caller passed, not on what differs.
+
+        `image_id` defaults to None and is then filled from SSM with the current
+        Amazon Linux 2023 AMI (#84). A "differs from the default" rule would
+        write today's AMI into the file and freeze it there, which is the
+        staleness #84 removed. `_make_provider` passes `image_id`, so this builds
+        a provider without it.
+        """
+        provider_id = f"test-{uuid.uuid4().hex[:8]}"
+        with (
+            patch("parsl_ephemeral_aws.provider.create_session") as mock_session,
+            patch.object(
+                EphemeralAWSProvider,
+                "_initialize_state_store",
+                return_value=FileStateStore(
+                    file_path=str(tmp_path / f"{provider_id}.json"),
+                    provider_id=provider_id,
+                ),
+            ),
+            patch.object(
+                EphemeralAWSProvider,
+                "_initialize_operating_mode",
+                return_value=MagicMock(),
+            ),
+        ):
+            mock_session.return_value = MagicMock()
+            provider = GlobusComputeProvider(
+                provider_id=provider_id,
+                region="us-east-1",
+                mode="standard",
+                vpc_id=VPC_ID,
+                subnet_id=SUBNET_ID,
+                security_group_id=SG_ID,
+            )
+
+        assert "image_id" not in provider._build_config_yaml()
+
+    def test_explicit_image_id_is_emitted(self, tmp_path):
+        """The other half: an AMI the caller chose must survive.
+
+        Without this, "don't pin the resolved AMI" could be implemented by
+        dropping `image_id` altogether and still pass the test above.
+        """
+        provider = _make_provider(tmp_path)  # passes image_id
+        provider.generate_endpoint_config(str(tmp_path / "ep"))
+
+        loaded = _load(tmp_path / "ep").engine.provider
+
+        assert loaded.image_id == "ami-0123456789abcdef0"
+
+    def test_emitted_set_is_derived_from_the_signature(self, tmp_path):
+        """The property that keeps this fixed: no hand-maintained list.
+
+        #138 happened because the emitter named parameters one by one and fell
+        behind. Passing every parameter the constructor accepts and asserting
+        each appears is what makes a newly added option a passing case for free
+        rather than a silent omission.
+        """
+        import inspect
+
+        signature = inspect.signature(EphemeralAWSProvider.__init__)
+        from parsl_ephemeral_aws.globus_compute import _SKIP_PARAMS
+
+        # Values chosen only to be non-default and type-plausible; the assertion
+        # is about presence, not about what a sane configuration looks like.
+        # instance_type and image_id are absent because _make_provider passes
+        # them, and region/mode/network because they are its positional shape.
+        # one_shot is handled separately below -- the constructor rejects it
+        # alongside warm_pool_size, and both belong in the covered set.
+        sample = {
+            "max_blocks": 4,
+            "min_blocks": 1,
+            "init_blocks": 1,
+            "key_name": "k",
+            "profile_name": "aws",
+            "state_file_path": "s.json",
+            "s3_key": "k.json",
+            "parameter_store_path": "/p/x",
+            "spot_max_price": "0.05",
+            "spot_allocation_strategy": "capacity-optimized",
+            "spot_interruption_handling": True,
+            "checkpoint_prefix": "cp",
+            "checkpoint_interval": 30,
+            "auto_shutdown": False,
+            "max_idle_time": 900,
+            "bastion_instance_type": "t3.small",
+            "memory_size": 2048,
+            "timeout": 600,
+            "use_public_ips": False,
+            "custom_ami": True,
+            "iam_instance_profile_arn": "arn:aws:iam::1:instance-profile/p",
+            "auto_create_instance_profile": True,
+            "status_polling_interval": 30,
+            "waiter_delay": 10,
+            "waiter_max_attempts": 30,
+            "warm_pool_size": 1,
+            "warm_pool_ttl": 300,
+            "use_spot": True,
+        }
+        provider = _make_provider(tmp_path, **sample)
+        yaml_text = provider._build_config_yaml()
+
+        missing = [
+            name
+            for name in signature.parameters
+            if name in sample
+            and name not in _SKIP_PARAMS
+            and f"    {name}:" not in yaml_text
+        ]
+        assert not missing, f"passed but not emitted: {missing}"
+
+        one_shot = _make_provider(
+            tmp_path, one_shot=True, auto_create_instance_profile=True
+        )
+        assert "    one_shot:" in one_shot._build_config_yaml()


### PR DESCRIPTION
Closes #138.

## The defect

`_provider_params_yaml()` named the parameters to emit in a hand-written list
that covered **15 of 52**. Three consequences, all of which shipped:

1. **`worker_init` was not in the list.** A Globus worker is not launched with
   Parsl's `process_worker_pool.py` — `GlobusComputeEngine._get_compute_launch_cmd()`
   rewrites the command to `globus-compute-endpoint python-exec
   parsl.executors.high_throughput.process_worker_pool`, so that binary must be on
   the worker's PATH and only `worker_init` puts it there. Dropping it meant the
   reconstructed provider fell back to `EphemeralAWSProvider.DEFAULT_WORKER_INIT`,
   which installs `parsl` alone, and **every worker command was "command not
   found"**.
2. **`encrypted: true` was hardcoded** and unreachable from the constructor.
   `HighThroughputExecutor` generates CurveZMQ certificates under its own `run_dir`
   on the endpoint host and passes that path to workers as `--cert_dir`; an EC2
   worker has no such directory and dies `FileNotFoundError` before registering
   (#62). The capability existed — a hand-edited `encrypted: false` loads fine — it
   was simply unreachable.
3. **The remaining 37 parameters silently vanished**, including `additional_tags`,
   the state-backend selection, and every fleet, warm-pool, and AMI-baking option.

## The fix

- The emitted set is derived from `inspect.signature(EphemeralAWSProvider.__init__)`,
  so a newly added parameter is covered without anyone updating the generator. That
  property is what keeps this fixed; the list is what fell behind.
- `worker_init` defaults to a script installing `globus-compute-endpoint` (no
  `--upgrade`: it pins `parsl` exactly, so letting pip take a newer `parsl` would
  break the pin it just resolved) and is emitted unconditionally, so the default
  travels with the config instead of being re-resolved on load.
- `encrypted` is a constructor parameter defaulting to `False`, with the reason
  in a generated comment.
- Two subclass-only params — `endpoint_id` and `container_image` — are named
  explicitly, since the signature loop reads the *base* class.

**Keyed on what the caller passed, not on what differs from the default.**
`image_id` defaults to `None` and is then resolved from SSM to the current AL2023
AMI (#84); a differs-from-default rule would write that day's AMI into the file and
freeze it there, reintroducing the staleness #84 removed. An `image_id` the caller
chose is still emitted. `provider_id` is never emitted, so a restart adopts the
persisted ID rather than the generating process's.

## Verification

Every prior test of this generator asserted on the **text** it produced, which is
exactly how a config no worker could load kept passing its own suite — one of them
asserted `encrypted: true`. The new tests hand the generated directory to
`globus_compute_endpoint`'s own `get_config()` and assert on the reconstructed
objects. That round-trip is possible in `tests/unit/` because #125 removed the
`globus`/`test` extra conflict along with LocalStack, and it **caught two bugs in
this fix**:

- `mode: OperatingModeType.STANDARD` reached the YAML. `OperatingModeType` is
  `(str, Enum)`, so the `isinstance(value, str)` branch matched before the Enum
  branch and `str(value)` rendered the repr — which the constructor then rejects.
- `image_id: <MagicMock ...>` was emitted, which is what prompted the redesign
  around caller intent rather than default-divergence.

| Gate | Result |
|---|---|
| `pytest tests/unit tests/security` | 1082 passed, 2 skipped |
| `pytest tests/unit tests/security -m unit` | same count — no test hidden from the marked run |
| `ruff check parsl_ephemeral_aws tests` | clean |
| `mypy parsl_ephemeral_aws` | 79 errors, identical to `main`; none in `globus_compute.py` |
| `sphinx-build -W` | build succeeded |

Also verified by hand against a live load: `display_name`, `encrypted`,
`container_uri`, `endpoint_id`, `container_image`, `additional_tags`,
`warm_pool_size`, and `worker_init` all round-trip, the provider reconstructs as
`GlobusComputeProvider`, and `image_id` is absent from the file. The
`display_name`/`container_image`/`endpoint_id` half of that is now a test rather
than a script.

## Docs

`docs/globus_compute.md` was written *around* these defects being open — step 2
was "Apply the two required edits", and the config reference listed which
parameters reach the file and told the reader to hand-add the other 37. Rewritten:
step 2 now explains the two keys that are set for you and why, and the reference
documents which parameters are deliberately *not* emitted.

The README's Globus section was worse and unrelated to #138: it told the reader to
hand-write a `config.yaml` with `type: AWSProvider` and `enable_ssm_tunneling:
true` — neither of which exists in this package or in Parsl. It predates
`generate_endpoint_config()` entirely. Replaced with the generator call.