### PR TITLE
fix: make spot interruption handling actually work (closes #137)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+- **The spot task-recovery API, which could not work at this layer and never
+  ran.** `SpotInterruptionHandler`, `ParslSpotInterruptionHandler`, the
+  `checkpointable` decorator, and the `checkpoint_bucket`, `checkpoint_prefix`,
+  and `checkpoint_interval` provider parameters are gone. This is a **breaking
+  config-schema change**: those three keywords now raise
+  `ProviderConfigurationError` rather than being accepted and ignored.
+
+  The entry point was `register_task(task_id, instance_id)`, and a Parsl provider
+  is never told a task ID — `submit(command, tasks_per_node, job_name)` is the
+  whole contract, because providers manage *blocks* while the executor manages
+  tasks. So nothing in the package could populate `task_mapping`; it was always
+  empty, every interruption logged "No registered tasks found", and
+  `save_checkpoint`/`recover_tasks`/`queue_task_for_recovery` were unreachable
+  alongside it. The `checkpointable` decorator's own source said "in a real
+  implementation, we would save to S3 here" and saved nothing.
+
+  Being documented as working made it worse than absent: `checkpoint_bucket` also
+  gated whether the interruption monitor was constructed at all, so a caller who
+  asked for `spot_interruption_handling=True` without a bucket got one startup
+  WARNING and no detection. Detection is unchanged and no longer gated on any
+  bucket. Recovery is Parsl's `retries` (or `max_retries_on_system_failure` on a
+  Globus Compute engine), which is now what the docs say (refs #137).
+- `CheckpointError`, `CheckpointNotFoundError`, and `TaskRecoveryError` from
+  `exceptions.py`, plus `DEFAULT_SPOT_CHECKPOINT_INTERVAL` and
+  `DEFAULT_SPOT_MAX_RECOVERY_ATTEMPTS` from `constants.py` — raised and read by
+  the removed API only, and never exported from the package root (refs #137).
+
 ### Fixed
+- **A reclaimed spot instance reported its work as successful.** An interrupted
+  instance goes to `shutting-down`, which `EC2_STATUS_MAPPING` renders
+  `COMPLETED` — so Parsl saw a block that finished normally, and `retries` never
+  fired for the tasks that died with it. A detected interruption now marks the
+  affected resource `STATUS_INTERRUPTED`, which the provider maps to
+  `JobState.FAILED`. That, not any checkpointing, is what makes the executor stop
+  dispatching into a doomed block and re-run its tasks (refs #137).
+- The interruption marker is now sticky. All three modes' `get_job_status()`
+  re-derive status from live AWS state on every poll, so the mark was overwritten
+  on the next call — an instance AWS is taking back still reports itself
+  `running`. Each mode now short-circuits a resource already marked
+  `STATUS_INTERRUPTED`, and the marker survives a save/load round trip (refs
+  #137).
+- A fleet interruption reached no block. `handle_fleet_interruption()` looked the
+  fleet ID up as a key in `resources`, but the resources dict is keyed by block ID
+  (standard mode) or `serverless-<job_id>`, carrying the fleet as a
+  `fleet_request_id` *field*. Every fleet reclaim therefore found nothing and
+  logged a miss. `OperatingMode._resource_ids_for_fleet()` now searches that
+  field, and `StandardMode` records `fleet_request_id` on the block record so
+  there is something to find (refs #137).
 - **Generated Globus Compute endpoint configs could not start a worker, and
   silently dropped most of the provider's configuration.** Three defects, one
   cause: `_provider_params_yaml()` named the parameters to emit in a hand-written
@@ -58,6 +106,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   null-restore hazard reachable, so this was not merely untidy (refs #93).
 
 ### Added
+- `ServerlessMode` accepts `lambda_code_bucket`, an existing S3 bucket to stage
+  Lambda deployment packages in. This is the surviving half of `checkpoint_bucket`
+  removed above: alongside gating the interruption monitor, it also overrode the
+  code-staging bucket, and that half was real. A caller-supplied bucket is reused
+  as-is and never deleted (`_owns_lambda_code_bucket` stays `False`, which is what
+  protects it); omit it and a provider-scoped bucket is created on first use and
+  removed by `cleanup_infrastructure()` (refs #137).
 - `GlobusComputeProvider` accepts `encrypted` (default `False`), and defaults
   `worker_init` to a script that installs `globus-compute-endpoint` rather than
   inheriting the `parsl`-only default. Both are part of #138 above.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -202,7 +202,6 @@ provider = EphemeralAWSProvider(
     spot_max_price="0.05",  # a string: dollars per hour
     spot_allocation_strategy="price-capacity-optimized",
     spot_interruption_handling=True,
-    checkpoint_bucket="my-parsl-checkpoints",  # required today, see #137
     worker_init="pip3 install --quiet --upgrade parsl scikit-learn\n",
 )
 
@@ -250,11 +249,13 @@ provider.shutdown()
 EventBridge rule and SQS queue so the provider learns of the reclaim about two
 minutes ahead rather than noticing the instance already `shutting-down`.
 
-Two caveats, both [#137](https://github.com/scttfrdmn/parsl-aws-provider/issues/137):
-without a `checkpoint_bucket` the monitor is not constructed at all — you get one
-WARNING at startup and no detection — and what the warning currently triggers is a
-log line, not task recovery. So **`retries` on the Parsl `Config` is what actually
-saves your work**; treat the warning as observability for now.
+What a detected reclaim does is mark the block `FAILED`, which is what makes Parsl
+stop dispatching to it and re-run its tasks elsewhere. **`retries` on the Parsl
+`Config` is therefore what actually saves your work** — the provider cannot
+checkpoint a task, because it is never told which tasks a block is running
+([#137](https://github.com/scttfrdmn/parsl-aws-provider/issues/137)). Set
+`retries` to at least 1 whenever `use_spot=True`; without it a reclaim fails the
+app instead of retrying it.
 
 ## Diversified instance types via EC2 Fleet
 

--- a/docs/globus_compute.md
+++ b/docs/globus_compute.md
@@ -286,7 +286,6 @@ provider = GlobusComputeProvider(
     mode="standard",
     use_spot=True,
     spot_interruption_handling=True,
-    checkpoint_bucket="my-parsl-checkpoints",  # gates detection, see below
     min_blocks=0,
     max_blocks=10,
     auto_create_instance_profile=True,
@@ -306,12 +305,11 @@ engine:
   max_retries_on_system_failure: 3    # this is what re-runs reclaimed functions
 ```
 
-Two limitations, both
-[#137](https://github.com/scttfrdmn/parsl-aws-provider/issues/137):
-`checkpoint_bucket` is an accidental prerequisite for the interruption monitor
-being constructed *at all* — without it you get one WARNING at startup and no
-detection — and what the warning triggers today is a log line, not task
-recovery. Treat it as observability.
+This is not a limitation to work around; it is the division of labour. A detected
+reclaim marks the block failed, and re-running the functions that were on it is
+the engine's job — the provider is never told which functions a block is running
+([#137](https://github.com/scttfrdmn/parsl-aws-provider/issues/137)). So leave
+`max_retries_on_system_failure` at a non-zero value whenever `use_spot=True`.
 
 ### Container endpoint
 

--- a/docs/spot_fleet.md
+++ b/docs/spot_fleet.md
@@ -121,7 +121,6 @@ provider = EphemeralAWSProvider(
     use_spot_fleet=True,
     instance_types=["m5.large", "m5a.large"],
     spot_interruption_handling=True,
-    checkpoint_bucket="my-parsl-checkpoints",  # required today, see #137
 )
 ```
 
@@ -134,15 +133,17 @@ time it is far too late to react.
 *Rebalance Recommendation* is deliberately not matched: it signals elevated risk,
 not an impending reclaim, and treating it as one would tear down healthy workers.
 
-Two limitations, both
-[#137](https://github.com/scttfrdmn/parsl-aws-provider/issues/137):
+A detected reclaim marks the affected block `FAILED`. That is the whole response,
+and it is the correct one: Parsl stops dispatching to a failed block and re-runs
+its tasks elsewhere under `retries`. **Set `retries` on the Parsl `Config`** — the
+provider cannot checkpoint a task itself, because a Parsl provider is never told
+which tasks a block is running; it is handed a command and returns a block ID
+([#137](https://github.com/scttfrdmn/parsl-aws-provider/issues/137)).
 
-- **`checkpoint_bucket` is required to get any detection at all.** Without it the
-  monitor is never constructed — one WARNING at startup, then silence. The bucket
-  is not otherwise used on this path.
-- **The warning currently produces a log line, not recovery.** The task-recovery
-  API exists but nothing in the package feeds it. Set `retries` on the Parsl
-  `Config`; that is what actually re-runs work lost to a reclaim.
+The block is marked for the *whole fleet*, not just the reclaimed instance, since
+the fleet is what carries a Parsl job ID. Note the marker is deliberately sticky:
+a fleet whose instances AWS is taking back still reports itself active, so
+re-deriving status would overwrite it on the next poll.
 
 ## Resource tracking
 

--- a/examples/spot_fleet_example.py
+++ b/examples/spot_fleet_example.py
@@ -103,11 +103,9 @@ def main() -> int:
         nodes_per_block=2,
         spot_max_price_percentage=80,  # cap at 80% of on-demand
         spot_allocation_strategy="price-capacity-optimized",  # the default
-        # Interruption detection needs a checkpoint bucket today (#137); it gates
-        # whether the monitor is constructed at all. Omit it and you get one
-        # WARNING at startup and no detection.
+        # A detected reclaim marks the fleet's block FAILED, which is what makes
+        # Parsl re-run its tasks under `retries` (#137).
         spot_interruption_handling=True,
-        checkpoint_bucket=os.environ.get("AWS_TEST_CHECKPOINT_BUCKET"),
         min_blocks=0,
         max_blocks=4,
         init_blocks=1,
@@ -132,8 +130,9 @@ def main() -> int:
                 encrypted=False,  # see #62
             )
         ],
-        # What actually protects work from a reclaim: the interruption warning
-        # currently produces a log line, not task recovery (#137).
+        # What actually protects work from a reclaim. The provider marks the block
+        # FAILED; re-running its tasks is Parsl's job, because a provider is never
+        # told which tasks a block is running (#137).
         retries=3,
         run_dir="runinfo_spot_fleet",
     )

--- a/examples/spot_interruption_example.py
+++ b/examples/spot_interruption_example.py
@@ -1,29 +1,25 @@
 #!/usr/bin/env python3
 """Spot interruption handling: seeing a reclaim coming, and surviving it.
 
-Two separate things, and only one of them is implemented today.
+Two separate jobs, split between the provider and Parsl.
 
-**Detection works.** With `spot_interruption_handling=True` the provider creates an
+**The provider detects.** With `spot_interruption_handling=True` it creates an
 EventBridge rule matching the *EC2 Spot Instance Interruption Warning* event with an
 SQS target, and polls it. That gives the full two-minute notice — verified against
 real EC2 with a Fault Injection Simulator experiment, where the warning reached the
 queue 15.2 s in with the instance still `running`. Polling instance state cannot
 see anything until `shutting-down`, far too late to react.
 
-**Recovery does not.** The warning currently produces a log line. There is a
-task-recovery API (`ParslSpotInterruptionHandler.handle_instance_interruption`) but
-nothing in the package feeds it the task mapping it needs, and the `checkpointable`
-decorator's own source says "in a real implementation, we would save to S3 here" —
-it saves nothing. Tracked as
-https://github.com/scttfrdmn/parsl-aws-provider/issues/137.
+A detected reclaim marks the block `FAILED`, and the marker is deliberately sticky:
+an instance AWS is taking back still reports itself `running`, so re-deriving status
+on the next poll would overwrite it.
 
-So what actually re-runs work lost to a reclaim is `retries` on the Parsl `Config`.
-This example sets it, keeps tasks short enough that losing one is cheap, and shows
-how to trigger a real interruption to watch the detection fire.
-
-Note `checkpoint_bucket` is required to get detection at all: without it the monitor
-is never constructed and you get one WARNING at startup, then silence (also #137).
-The bucket is not otherwise written to on this path.
+**Parsl recovers.** `retries` on the `Config` is what re-runs the tasks that were on
+the lost block. The provider cannot do it: a Parsl provider is handed a command and
+returns a block ID, and is never told which tasks a block is running
+(https://github.com/scttfrdmn/parsl-aws-provider/issues/137). So this example sets
+`retries`, keeps chunks small enough that losing one is cheap, and shows how to
+trigger a real interruption to watch the detection fire.
 
 Usage
 -----
@@ -32,7 +28,6 @@ Usage
     export AWS_TEST_VPC_ID=vpc-...
     export AWS_TEST_SUBNET_ID=subnet-...
     export AWS_TEST_SG_ID=sg-...
-    export AWS_TEST_CHECKPOINT_BUCKET=my-parsl-checkpoints
 
     uv run python examples/spot_interruption_example.py
 
@@ -142,8 +137,6 @@ def main() -> int:
             spot_max_price_percentage=70,
             spot_allocation_strategy="price-capacity-optimized",  # the default
             spot_interruption_handling=True,
-            # Required for the monitor to be constructed at all (#137).
-            checkpoint_bucket=os.environ["AWS_TEST_CHECKPOINT_BUCKET"],
             nodes_per_block=2,
             init_blocks=1,
             min_blocks=0,

--- a/parsl_ephemeral_aws/compute/spot_interruption.py
+++ b/parsl_ephemeral_aws/compute/spot_interruption.py
@@ -1,7 +1,9 @@
-"""Utilities for handling AWS spot instance interruptions.
+"""Detection of AWS spot instance interruptions.
 
-This module provides functionality for detecting and responding to AWS spot instance
-interruption notices, allowing Parsl tasks to be checkpointed and recovered.
+This module detects that AWS is reclaiming a spot instance and calls the
+handlers registered for it. It does not decide what to do about it: the
+response lives on :class:`~parsl_ephemeral_aws.modes.base.OperatingMode`, which
+marks the doomed block interrupted so Parsl re-runs its tasks.
 
 SPDX-License-Identifier: Apache-2.0
 SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
@@ -17,7 +19,6 @@ import boto3
 from typing import Dict, List, Optional, Callable, Any
 from botocore.exceptions import ClientError
 
-from parsl_ephemeral_aws.exceptions import SpotInstanceError
 from parsl_ephemeral_aws.constants import (
     DEFAULT_SPOT_INTERRUPTION_CHECK_INTERVAL,
     DEFAULT_SPOT_INTERRUPTION_LEAD_TIME,
@@ -43,11 +44,13 @@ class SpotInterruptionMonitor:
 
     Detection runs on two tracks. The EventBridge warning is the one that
     matters: it arrives roughly two minutes *before* the reclaim, with the
-    instance still running, which is the only point at which checkpointing can
-    succeed. The EC2-state poll is kept as a fallback for when the notifier
-    could not be created (missing ``events``/``sqs`` permissions, say), but it
-    can only ever report an interruption post-facto, once the instance has
-    already reached ``shutting-down``.
+    instance still running, so the block can be marked ``STATUS_INTERRUPTED``
+    while the executor still has time to stop dispatching into it. The EC2-state
+    poll is kept as a fallback for when the notifier could not be created
+    (missing ``events``/``sqs`` permissions, say), but it can only ever report an
+    interruption post-facto, once the instance has already reached
+    ``shutting-down`` -- by which time work has been dispatched to a worker that
+    is already gone.
 
     Attributes
     ----------
@@ -247,7 +250,7 @@ class SpotInterruptionMonitor:
         except Exception as e:
             # Degrade to the EC2-state poll rather than failing the workflow.
             # The poll cannot see a warning in advance, so log loudly enough that
-            # the loss of checkpointing lead time is visible.
+            # the loss of the two-minute lead time is visible.
             logger.warning(
                 "Could not create the spot interruption notifier, falling back "
                 "to post-facto EC2 state polling -- interruptions will be "
@@ -309,8 +312,8 @@ class SpotInterruptionMonitor:
         Each message is an EventBridge envelope whose ``detail`` carries
         ``instance-id`` and ``instance-action``. Confirmed against a real
         FIS-driven interruption; the arriving instance was still ``running``,
-        which is what makes this usable for checkpointing where the EC2-state
-        poll is not.
+        which is what makes this track actionable where the EC2-state poll is
+        not.
 
         The rule cannot be scoped to specific instances -- their IDs are not
         known until the fleet launches -- so it matches every spot interruption
@@ -358,7 +361,7 @@ class SpotInterruptionMonitor:
                 "InstanceAction": detail.get("instance-action", "terminate"),
                 "NoticeTime": time.time(),
                 # Distinguishes an advance warning from the post-facto poll, so a
-                # handler can tell whether it has time to checkpoint.
+                # handler can tell whether the instance is still alive.
                 "Source": "eventbridge",
             }
             self._queue_warning(instance_id, event_details, ec2_client)
@@ -400,10 +403,10 @@ class SpotInterruptionMonitor:
         """Detect already-interrupted instances from their EC2 state.
 
         The fallback track. It reports an interruption only once the instance has
-        reached ``shutting-down`` or ``stopping`` -- after the reclaim, too late
-        to checkpoint -- so it exists to catch what the EventBridge notifier
-        misses, or to cover the case where the notifier could not be created at
-        all. :meth:`_poll_warning_queue` is the one that gives advance notice.
+        reached ``shutting-down`` or ``stopping`` -- after the reclaim -- so it
+        exists to catch what the EventBridge notifier misses, or to cover the case
+        where the notifier could not be created at all.
+        :meth:`_poll_warning_queue` is the one that gives advance notice.
         """
         if not self.instance_handlers:
             return
@@ -428,9 +431,9 @@ class SpotInterruptionMonitor:
                                 "InstanceId": instance_id,
                                 "InstanceAction": "terminate",
                                 "NoticeTime": time.time(),
-                                # No lead time left on this track; a handler can
-                                # skip checkpointing rather than attempt it
-                                # against an instance that is already going.
+                                # No lead time left on this track: the instance is
+                                # already going, so a handler knows the marker is
+                                # after the fact rather than ahead of it.
                                 "Source": "ec2-state",
                             }
                             self.event_queue.put(
@@ -530,491 +533,19 @@ class SpotInterruptionMonitor:
             pass
 
 
-class SpotInterruptionHandler:
-    """Handler for spot instance interruptions.
-
-    This class provides utilities for implementing recovery actions when spot
-    instances are interrupted. It includes functionality for saving and loading
-    checkpoint data, redirecting tasks to other instances, and prioritizing
-    task recovery.
-
-    Attributes
-    ----------
-    session : boto3.Session
-        AWS session for making API calls
-    checkpoint_bucket : Optional[str]
-        S3 bucket name for storing checkpoint data
-    checkpoint_prefix : str
-        S3 key prefix for checkpoint data
-    recovery_queue : queue.PriorityQueue
-        Queue for prioritizing recovery tasks
-    """
-
-    def __init__(
-        self,
-        session: boto3.Session,
-        checkpoint_bucket: Optional[str] = None,
-        checkpoint_prefix: str = "parsl/checkpoints",
-    ) -> None:
-        """Initialize the SpotInterruptionHandler.
-
-        Parameters
-        ----------
-        session : boto3.Session
-            AWS session for making API calls
-        checkpoint_bucket : Optional[str], optional
-            S3 bucket name for storing checkpoint data, by default None
-        checkpoint_prefix : str, optional
-            S3 key prefix for checkpoint data, by default "parsl/checkpoints"
-        """
-        self.session = session
-        self.checkpoint_bucket = checkpoint_bucket
-        self.checkpoint_prefix = checkpoint_prefix
-        self.recovery_queue = queue.PriorityQueue()
-
-        # Ensure S3 bucket exists if specified
-        if self.checkpoint_bucket:
-            self._ensure_bucket_exists()
-
-    def _ensure_bucket_exists(self) -> None:
-        """Ensure the checkpoint S3 bucket exists."""
-        s3 = self.session.client("s3")
-
-        try:
-            s3.head_bucket(Bucket=self.checkpoint_bucket)
-        except ClientError as e:
-            error_code = e.response["Error"]["Code"]
-            if error_code == "404":
-                # Bucket doesn't exist, create it
-                try:
-                    s3.create_bucket(Bucket=self.checkpoint_bucket)
-                    logger.info(f"Created checkpoint bucket {self.checkpoint_bucket}")
-                except Exception as e:
-                    logger.error(f"Failed to create checkpoint bucket: {e}")
-                    raise
-            else:
-                logger.error(f"Error checking checkpoint bucket: {e}")
-                raise
-
-    def save_checkpoint(
-        self, task_id: str, data: Dict[str, Any], priority: int = 1
-    ) -> str:
-        """Save checkpoint data to S3.
-
-        Parameters
-        ----------
-        task_id : str
-            Unique identifier for the task
-        data : Dict[str, Any]
-            Checkpoint data to save
-        priority : int, optional
-            Recovery priority (lower is higher priority), by default 1
-
-        Returns
-        -------
-        str
-            S3 URI for the saved checkpoint
-
-        Raises
-        ------
-        SpotInstanceError
-            If checkpoint cannot be saved
-        """
-        if not self.checkpoint_bucket:
-            raise SpotInstanceError("No checkpoint bucket specified")
-
-        s3 = self.session.client("s3")
-        key = f"{self.checkpoint_prefix}/{task_id}.json"
-
-        try:
-            s3.put_object(
-                Bucket=self.checkpoint_bucket,
-                Key=key,
-                Body=json.dumps(data),
-                ServerSideEncryption="AES256",
-                Metadata={
-                    "Priority": str(priority),
-                    "Timestamp": str(int(time.time())),
-                },
-            )
-            return f"s3://{self.checkpoint_bucket}/{key}"
-        except Exception as e:
-            logger.error(f"Failed to save checkpoint for task {task_id}: {e}")
-            raise SpotInstanceError(f"Failed to save checkpoint: {e}")
-
-    def load_checkpoint(self, task_id: str) -> Optional[Dict[str, Any]]:
-        """Load checkpoint data from S3.
-
-        Parameters
-        ----------
-        task_id : str
-            Unique identifier for the task
-
-        Returns
-        -------
-        Optional[Dict[str, Any]]
-            Checkpoint data or None if not found
-
-        Raises
-        ------
-        SpotInstanceError
-            If checkpoint cannot be loaded
-        """
-        if not self.checkpoint_bucket:
-            raise SpotInstanceError("No checkpoint bucket specified")
-
-        s3 = self.session.client("s3")
-        key = f"{self.checkpoint_prefix}/{task_id}.json"
-
-        try:
-            response = s3.get_object(Bucket=self.checkpoint_bucket, Key=key)
-            return json.loads(response["Body"].read())
-        except ClientError as e:
-            if e.response["Error"]["Code"] == "NoSuchKey":
-                return None
-            logger.error(f"Failed to load checkpoint for task {task_id}: {e}")
-            raise SpotInstanceError(f"Failed to load checkpoint: {e}")
-        except Exception as e:
-            logger.error(f"Failed to load checkpoint for task {task_id}: {e}")
-            raise SpotInstanceError(f"Failed to load checkpoint: {e}")
-
-    def queue_task_for_recovery(
-        self, task_id: str, checkpoint_uri: str, priority: int = 1
-    ) -> None:
-        """Queue a task for recovery.
-
-        Parameters
-        ----------
-        task_id : str
-            Unique identifier for the task
-        checkpoint_uri : str
-            URI for the checkpoint data
-        priority : int, optional
-            Recovery priority (lower is higher priority), by default 1
-        """
-        self.recovery_queue.put((priority, time.time(), task_id, checkpoint_uri))
-        logger.info(f"Queued task {task_id} for recovery with priority {priority}")
-
-    def get_next_recovery_task(self) -> Optional[Dict[str, Any]]:
-        """Get the next task to recover.
-
-        Returns
-        -------
-        Optional[Dict[str, Any]]
-            Task recovery information or None if queue is empty
-        """
-        try:
-            (
-                priority,
-                timestamp,
-                task_id,
-                checkpoint_uri,
-            ) = self.recovery_queue.get_nowait()
-            return {
-                "task_id": task_id,
-                "checkpoint_uri": checkpoint_uri,
-                "priority": priority,
-                "timestamp": timestamp,
-            }
-        except queue.Empty:
-            return None
-
-    def handle_instance_interruption(
-        self, instance_id: str, event: Dict[str, Any]
-    ) -> None:
-        """Handle spot instance interruption.
-
-        This method should be implemented by subclasses to provide specific
-        recovery actions for the application.
-
-        Parameters
-        ----------
-        instance_id : str
-            ID of the interrupted instance
-        event : Dict[str, Any]
-            Interruption event details
-        """
-        # This is a placeholder that should be overridden by subclasses
-        logger.warning(f"Spot instance {instance_id} is being interrupted: {event}")
-
-    def handle_fleet_interruption(
-        self, fleet_id: str, instance_ids: List[str], event: Dict[str, Any]
-    ) -> None:
-        """Handle spot fleet interruption.
-
-        This method should be implemented by subclasses to provide specific
-        recovery actions for the application.
-
-        Parameters
-        ----------
-        fleet_id : str
-            ID of the spot fleet
-        instance_ids : List[str]
-            IDs of the interrupted instances
-        event : Dict[str, Any]
-            Interruption event details
-        """
-        # This is a placeholder that should be overridden by subclasses
-        logger.warning(
-            f"Spot fleet {fleet_id} instances {instance_ids} are being interrupted: {event}"
-        )
-
-
-class ParslSpotInterruptionHandler(SpotInterruptionHandler):
-    """Parsl-specific handler for spot instance interruptions.
-
-    This class extends SpotInterruptionHandler to provide Parsl-specific
-    functionality for task recovery.
-
-    Attributes
-    ----------
-    session : boto3.Session
-        AWS session for making API calls
-    checkpoint_bucket : Optional[str]
-        S3 bucket name for storing checkpoint data
-    checkpoint_prefix : str
-        S3 key prefix for checkpoint data
-    executor : Any
-        Parsl executor for submitting recovery tasks
-    executor_label : str
-        Label of the executor for task submission
-    """
-
-    def __init__(
-        self,
-        session: boto3.Session,
-        checkpoint_bucket: Optional[str] = None,
-        checkpoint_prefix: str = "parsl/checkpoints",
-        executor=None,
-        executor_label: str = "default",
-    ) -> None:
-        """Initialize the ParslSpotInterruptionHandler.
-
-        Parameters
-        ----------
-        session : boto3.Session
-            AWS session for making API calls
-        checkpoint_bucket : Optional[str], optional
-            S3 bucket name for storing checkpoint data, by default None
-        checkpoint_prefix : str, optional
-            S3 key prefix for checkpoint data, by default "parsl/checkpoints"
-        executor : Any, optional
-            Parsl executor for submitting recovery tasks, by default None
-        executor_label : str, optional
-            Label of the executor for task submission, by default "default"
-        """
-        super().__init__(session, checkpoint_bucket, checkpoint_prefix)
-        self.executor = executor
-        self.executor_label = executor_label
-        self.task_mapping = {}  # instance_id -> list of task_ids
-
-    def register_task(self, task_id: str, instance_id: str) -> None:
-        """Register a task running on a specific instance.
-
-        Parameters
-        ----------
-        task_id : str
-            Unique identifier for the task
-        instance_id : str
-            ID of the instance running the task
-        """
-        if instance_id not in self.task_mapping:
-            self.task_mapping[instance_id] = []
-
-        self.task_mapping[instance_id].append(task_id)
-        logger.debug(f"Registered task {task_id} on instance {instance_id}")
-
-    def handle_instance_interruption(
-        self, instance_id: str, event: Dict[str, Any]
-    ) -> None:
-        """Handle spot instance interruption for Parsl tasks.
-
-        Parameters
-        ----------
-        instance_id : str
-            ID of the interrupted instance
-        event : Dict[str, Any]
-            Interruption event details
-        """
-        logger.warning(f"Spot instance {instance_id} is being interrupted: {event}")
-
-        # Get tasks running on this instance
-        tasks = self.task_mapping.get(instance_id, [])
-        if not tasks:
-            logger.info(f"No registered tasks found for instance {instance_id}")
-            return
-
-        logger.info(
-            f"Found {len(tasks)} tasks to recover from interrupted instance {instance_id}"
-        )
-
-        # Queue tasks for recovery
-        for task_id in tasks:
-            try:
-                # Attempt to load checkpoint data for this task
-                checkpoint_data = self.load_checkpoint(task_id)
-                if checkpoint_data:
-                    self.queue_task_for_recovery(
-                        task_id,
-                        f"s3://{self.checkpoint_bucket}/{self.checkpoint_prefix}/{task_id}.json",
-                    )
-                else:
-                    logger.warning(f"No checkpoint data found for task {task_id}")
-            except Exception as e:
-                logger.error(f"Error processing task {task_id} for recovery: {e}")
-
-        # Clean up task mapping
-        if instance_id in self.task_mapping:
-            del self.task_mapping[instance_id]
-
-    def handle_fleet_interruption(
-        self, fleet_id: str, instance_ids: List[str], event: Dict[str, Any]
-    ) -> None:
-        """Handle spot fleet interruption for Parsl tasks.
-
-        Parameters
-        ----------
-        fleet_id : str
-            ID of the spot fleet
-        instance_ids : List[str]
-            IDs of the interrupted instances
-        event : Dict[str, Any]
-            Interruption event details
-        """
-        logger.warning(
-            f"Spot fleet {fleet_id} instances {instance_ids} are being interrupted: {event}"
-        )
-
-        # Process each interrupted instance
-        for instance_id in instance_ids:
-            self.handle_instance_interruption(instance_id, event)
-
-    def recover_tasks(self) -> None:
-        """Process the recovery queue and resubmit tasks."""
-        if not self.executor:
-            logger.warning("No executor provided for task recovery")
-            return
-
-        tasks_recovered = 0
-
-        # Process recovery queue
-        while True:
-            task_info = self.get_next_recovery_task()
-            if not task_info:
-                break
-
-            task_id = task_info["task_id"]
-            checkpoint_uri = task_info["checkpoint_uri"]
-
-            try:
-                # Here we would use the Parsl executor to resubmit the task
-                # The actual implementation would depend on how tasks are represented in Parsl
-                logger.info(
-                    f"Recovering task {task_id} using checkpoint {checkpoint_uri}"
-                )
-
-                # In a real implementation, we would:
-                # 1. Load the checkpoint data
-                # 2. Create a new Parsl future
-                # 3. Submit the task to the executor
-                # 4. Update any dependent tasks
-
-                tasks_recovered += 1
-
-            except Exception as e:
-                logger.error(f"Failed to recover task {task_id}: {e}")
-
-        logger.info(f"Recovered {tasks_recovered} tasks")
-
-
-# Decorator function for making functions checkpointable
-def checkpointable(
-    checkpoint_bucket: Optional[str] = None,
-    checkpoint_prefix: str = "parsl/checkpoints",
-    checkpoint_interval: int = 60,  # seconds
-):
-    """Decorator to make a function checkpointable for spot interruption recovery.
-
-    This decorator adds checkpointing capabilities to a function, allowing it
-    to be recovered if interrupted by a spot instance termination.
-
-    Parameters
-    ----------
-    checkpoint_bucket : Optional[str], optional
-        S3 bucket for storing checkpoints, by default None
-    checkpoint_prefix : str, optional
-        S3 key prefix for checkpoints, by default "parsl/checkpoints"
-    checkpoint_interval : int, optional
-        Interval between checkpoints in seconds, by default 60
-
-    Returns
-    -------
-    Callable
-        Decorated function with checkpointing
-
-    Example
-    -------
-    >>> @checkpointable(checkpoint_bucket="my-bucket")
-    >>> def my_function(x, y, checkpoint_data=None):
-    >>>     # Initialize from checkpoint if available
-    >>>     if checkpoint_data:
-    >>>         state = checkpoint_data
-    >>>     else:
-    >>>         state = {"iteration": 0, "result": 0}
-    >>>
-    >>>     # Simulate work with checkpointing
-    >>>     for i in range(state["iteration"], 100):
-    >>>         state["result"] += x * y
-    >>>         state["iteration"] = i + 1
-    >>>
-    >>>         # Return checkpoint at intervals
-    >>>         if (i + 1) % 10 == 0:
-    >>>             yield state
-    >>>
-    >>>     return state["result"]
-    """
-
-    def decorator(func):
-        def wrapper(*args, **kwargs):
-            # Parse any checkpoint data provided
-            checkpoint_data = kwargs.pop("checkpoint_data", None)
-
-            # Create a generator from the function
-            gen = func(*args, checkpoint_data=checkpoint_data, **kwargs)
-
-            # If function is not a generator, make it one
-            if not hasattr(gen, "__iter__") and not hasattr(gen, "__next__"):
-                return gen
-
-            # Process generator, capturing checkpoints
-            last_checkpoint = time.time()
-            result = None
-
-            try:
-                while True:
-                    # Get next checkpoint or result
-                    try:
-                        checkpoint = next(gen)
-
-                        # Save checkpoint if interval has passed
-                        current_time = time.time()
-                        if current_time - last_checkpoint >= checkpoint_interval:
-                            # In a real implementation, we would save to S3 here
-                            # For now, just update the last checkpoint time
-                            last_checkpoint = current_time
-
-                    except StopIteration as e:
-                        result = e.value
-                        break
-
-                return result
-
-            except Exception as e:
-                # In case of exception, try to save a final checkpoint
-                # This could be triggered by a spot interruption
-                logger.error(f"Error in checkpointable function: {e}")
-                raise
-
-        return wrapper
-
-    return decorator
+# The interruption *response* is not here: it lives on
+# ``modes.base.OperatingMode.handle_instance_interruption``, which marks the
+# doomed block ``STATUS_INTERRUPTED`` so the provider reports
+# ``JobState.FAILED`` and Parsl re-runs the lost tasks under the executor's own
+# ``retries``.
+#
+# This module used to also carry ``SpotInterruptionHandler`` and
+# ``ParslSpotInterruptionHandler``, a checkpoint/recovery API that could not
+# work at this layer and never ran (#137). Its entry point was
+# ``register_task(task_id, instance_id)``, and a Parsl provider is never told a
+# task ID -- ``submit(command, tasks_per_node, job_name)`` is the whole
+# contract, because providers manage *blocks* while the executor manages tasks.
+# Nothing in the package could call it, so ``task_mapping`` was always empty,
+# every interruption logged "No registered tasks found", and
+# ``save_checkpoint``/``recover_tasks``/``checkpointable`` were dead alongside
+# it. Being documented as working made it worse than absent.

--- a/parsl_ephemeral_aws/constants.py
+++ b/parsl_ephemeral_aws/constants.py
@@ -292,13 +292,14 @@ EC2_FLEET_ALLOCATION_STRATEGIES = frozenset(
 # (``aws:ec2:send-spot-instance-interruptions``) -- the warning reached the queue
 # 15.2s after the experiment started, with the instance still ``running``. That
 # is the whole point: the EC2-state poll this supplements cannot see anything
-# until ``shutting-down``, by which time checkpointing is already too late.
+# until ``shutting-down``, by which time the executor has already dispatched work
+# to a worker that is gone.
 #
 # ``EC2 Instance Rebalance Recommendation`` is deliberately *not* matched. It is
 # a separate detail-type that signals elevated interruption risk, not an
 # impending reclaim, and confirmed via ``test_event_pattern`` not to match this
-# pattern. Treating it as an interruption would checkpoint and tear down workers
-# that were never going away.
+# pattern. Treating it as an interruption would fail the blocks of healthy
+# workers that were never going away.
 SPOT_INTERRUPTION_EVENT_SOURCE = "aws.ec2"
 SPOT_INTERRUPTION_EVENT_DETAIL_TYPE = "EC2 Spot Instance Interruption Warning"
 
@@ -328,8 +329,6 @@ DEFAULT_SPOT_ALLOCATION_STRATEGY = "price-capacity-optimized"
 DEFAULT_SPOT_INSTANCE_INTERRUPTION_BEHAVIOR = "terminate"
 DEFAULT_SPOT_INTERRUPTION_CHECK_INTERVAL = 30  # seconds
 DEFAULT_SPOT_INTERRUPTION_LEAD_TIME = 120  # seconds
-DEFAULT_SPOT_CHECKPOINT_INTERVAL = 60  # seconds
-DEFAULT_SPOT_MAX_RECOVERY_ATTEMPTS = 3
 
 # Tag defaults
 DEFAULT_TAG_PREFIX = "parsl-ephemeral"
@@ -387,6 +386,18 @@ STATUS_CANCELLED = "CANCELED"  # British spelling alias
 STATUS_UNKNOWN = "UNKNOWN"
 STATUS_SUCCEEDED = "COMPLETED"  # Alias for compatibility
 STATUS_WARM = "WARM"  # instance running, job done, ready for reuse
+
+# A spot instance AWS has issued a two-minute reclaim warning for (#137).
+#
+# Distinct from STATUS_FAILED so logs and state files say why the block died,
+# but it maps to JobState.FAILED in the provider: from Parsl's side a reclaimed
+# block did not finish its work, and FAILED is what makes the executor stop
+# dispatching to it and re-run the lost tasks under its own `retries`.
+#
+# Without this the interruption is invisible. An interrupted instance goes to
+# "shutting-down", which EC2_STATUS_MAPPING renders COMPLETED -- so a reclaimed
+# block reported success and its tasks were silently dropped.
+STATUS_INTERRUPTED = "INTERRUPTED"
 
 # Warm pool defaults.
 #

--- a/parsl_ephemeral_aws/exceptions.py
+++ b/parsl_ephemeral_aws/exceptions.py
@@ -225,24 +225,6 @@ class SpotInterruptionError(SpotInstanceError):
     pass
 
 
-class CheckpointError(EphemeralAWSError):
-    """Error saving or loading checkpoint data."""
-
-    pass
-
-
-class CheckpointNotFoundError(CheckpointError):
-    """No checkpoint found for the given task."""
-
-    pass
-
-
-class TaskRecoveryError(EphemeralAWSError):
-    """Error recovering a task after spot interruption."""
-
-    pass
-
-
 class InvalidStateError(ProviderError):
     """Provider is in an invalid state for the requested operation."""
 

--- a/parsl_ephemeral_aws/modes/base.py
+++ b/parsl_ephemeral_aws/modes/base.py
@@ -13,7 +13,10 @@ import boto3
 
 from botocore.exceptions import ClientError
 
-from parsl_ephemeral_aws.constants import DEFAULT_SPOT_ALLOCATION_STRATEGY
+from parsl_ephemeral_aws.constants import (
+    DEFAULT_SPOT_ALLOCATION_STRATEGY,
+    STATUS_INTERRUPTED,
+)
 from parsl_ephemeral_aws.exceptions import OperatingModeError, ResourceNotFoundError
 from parsl_ephemeral_aws.state.base import STATE_KEY_MODE, StateStore
 
@@ -57,13 +60,7 @@ class OperatingMode(abc.ABC):
     spot_allocation_strategy : str
         Allocation strategy for spot instances
     spot_interruption_handling : bool
-        Whether to enable spot interruption handling
-    checkpoint_bucket : Optional[str]
-        S3 bucket name for storing task checkpoints
-    checkpoint_prefix : str
-        S3 key prefix for checkpoint data
-    checkpoint_interval : int
-        Interval between checkpoints in seconds
+        Whether to detect spot interruptions and mark the affected block failed
     additional_tags : Dict[str, str]
         Tags to apply to created resources
     auto_shutdown : bool
@@ -94,9 +91,6 @@ class OperatingMode(abc.ABC):
         spot_max_price: Optional[str] = None,
         spot_allocation_strategy: str = DEFAULT_SPOT_ALLOCATION_STRATEGY,
         spot_interruption_handling: bool = False,
-        checkpoint_bucket: Optional[str] = None,
-        checkpoint_prefix: str = "parsl/checkpoints",
-        checkpoint_interval: int = 60,
         additional_tags: Optional[Dict[str, str]] = None,
         auto_shutdown: bool = True,
         max_idle_time: int = 300,
@@ -139,13 +133,9 @@ class OperatingMode(abc.ABC):
             Allocation strategy for spot instances, in kebab-case, by default
             "price-capacity-optimized"
         spot_interruption_handling : bool, optional
-            Whether to enable spot interruption handling, by default False
-        checkpoint_bucket : Optional[str], optional
-            S3 bucket name for storing task checkpoints, by default None
-        checkpoint_prefix : str, optional
-            S3 key prefix for checkpoint data, by default "parsl/checkpoints"
-        checkpoint_interval : int, optional
-            Interval between checkpoints in seconds, by default 60
+            Whether to detect spot interruptions, by default False. Detection
+            marks the affected block STATUS_INTERRUPTED, which the provider
+            reports to Parsl as FAILED so it re-runs the lost tasks.
         additional_tags : Optional[Dict[str, str]], optional
             Tags to apply to created resources, by default None
         auto_shutdown : bool, optional
@@ -177,9 +167,6 @@ class OperatingMode(abc.ABC):
         self.spot_max_price = spot_max_price
         self.spot_allocation_strategy = spot_allocation_strategy
         self.spot_interruption_handling = spot_interruption_handling
-        self.checkpoint_bucket = checkpoint_bucket
-        self.checkpoint_prefix = checkpoint_prefix
-        self.checkpoint_interval = checkpoint_interval
         self.additional_tags = additional_tags or {}
         self.auto_shutdown = auto_shutdown
         self.max_idle_time = max_idle_time
@@ -339,6 +326,106 @@ class OperatingMode(abc.ABC):
             except Exception as e:
                 logger.error(f"Initialization failed: {e}")
                 raise OperatingModeError(f"Initialization failed: {e}") from e
+
+    # ------------------------------------------------------------------
+    # Spot interruption
+    # ------------------------------------------------------------------
+
+    def handle_instance_interruption(
+        self, instance_id: str, event: Dict[str, Any]
+    ) -> None:
+        """Mark *instance_id* interrupted so the block stops being dispatched to.
+
+        Registered with ``SpotInterruptionMonitor`` as the per-instance callback
+        and invoked on the two-minute reclaim warning, roughly 15 s after AWS
+        issues it.
+
+        Marking the resource is the whole response, and it is the useful one:
+        ``get_job_status`` reports ``STATUS_INTERRUPTED``, the provider maps that
+        to ``JobState.FAILED``, and Parsl stops dispatching to the block and
+        re-runs its tasks under the executor's own ``retries``. Nothing here
+        needs S3.
+
+        Without this the interruption was invisible rather than merely
+        unhandled: the instance moves to ``shutting-down``, which
+        ``EC2_STATUS_MAPPING`` renders ``COMPLETED``, so a reclaimed block
+        reported success and its tasks were dropped silently (#137).
+
+        Parameters
+        ----------
+        instance_id : str
+            The instance AWS has warned about.
+        event : Dict[str, Any]
+            The interruption event, logged for diagnosis.
+        """
+        logger.warning(
+            "Spot instance %s is being reclaimed by AWS; marking its block failed "
+            "so Parsl re-runs the affected tasks: %s",
+            instance_id,
+            event,
+        )
+        resource = self.resources.get(instance_id)
+        if resource is None:
+            # Already cleaned up, or belongs to a fleet tracked under its own ID.
+            logger.debug("No tracked resource for interrupted instance %s", instance_id)
+            return
+        resource["status"] = STATUS_INTERRUPTED
+        resource["interruption_event"] = event
+
+    def handle_fleet_interruption(
+        self, fleet_id: str, instance_ids: List[str], event: Dict[str, Any]
+    ) -> None:
+        """Mark a fleet's block, and each warned instance, interrupted.
+
+        Both are marked: the block is what Parsl holds a job ID for, while the
+        instances are what the monitor names, and either may be the tracked
+        resource depending on the launch path.
+
+        A fleet ID is almost never a resource key. ``resources`` is keyed by
+        block ID in StandardMode and by ``serverless-<job_id>`` in the other two,
+        with the fleet recorded as a ``fleet_request_id`` *field* on the record --
+        so a direct ``resources[fleet_id]`` lookup misses every time and the
+        block would keep reporting healthy while AWS took its capacity away. The
+        field is searched instead.
+
+        Parameters
+        ----------
+        fleet_id : str
+            The fleet AWS has warned about.
+        instance_ids : List[str]
+            Instances within the fleet being reclaimed.
+        event : Dict[str, Any]
+            The interruption event, logged for diagnosis.
+        """
+        logger.warning(
+            "Spot fleet %s instances %s are being reclaimed by AWS: %s",
+            fleet_id,
+            instance_ids,
+            event,
+        )
+        for resource_id in self._resource_ids_for_fleet(fleet_id):
+            resource = self.resources[resource_id]
+            resource["status"] = STATUS_INTERRUPTED
+            resource["interruption_event"] = event
+        for instance_id in instance_ids:
+            self.handle_instance_interruption(instance_id, event)
+
+    def _resource_ids_for_fleet(self, fleet_id: str) -> List[str]:
+        """Return the tracked resource IDs backed by *fleet_id*.
+
+        Matches a record keyed by the fleet ID directly, and any record carrying
+        it as ``fleet_request_id`` -- the latter is the shape every mode that
+        launches fleets actually writes.
+        """
+        matches = []
+        if fleet_id in self.resources:
+            matches.append(fleet_id)
+        for resource_id, resource in self.resources.items():
+            if resource_id == fleet_id:
+                continue
+            if resource.get("fleet_request_id") == fleet_id:
+                matches.append(resource_id)
+        return matches
 
     def save_state(self) -> None:
         """Save the current state under the mode's own state key.

--- a/parsl_ephemeral_aws/modes/detached.py
+++ b/parsl_ephemeral_aws/modes/detached.py
@@ -26,6 +26,7 @@ from parsl_ephemeral_aws.constants import (
     RESOURCE_TYPE_CLOUDFORMATION,
     RESOURCE_TYPE_SPOT_FLEET,
     STATUS_CANCELED,
+    STATUS_INTERRUPTED,
     STATUS_PENDING,
     STATUS_RUNNING,
     STATUS_UNKNOWN,
@@ -47,10 +48,7 @@ from parsl_ephemeral_aws.utils.aws import (
 from parsl_ephemeral_aws.compute.spot_fleet_cleanup import (
     cleanup_all_spot_fleet_resources,
 )
-from parsl_ephemeral_aws.compute.spot_interruption import (
-    SpotInterruptionMonitor,
-    ParslSpotInterruptionHandler,
-)
+from parsl_ephemeral_aws.compute.spot_interruption import SpotInterruptionMonitor
 
 
 logger = logging.getLogger(__name__)
@@ -146,28 +144,17 @@ class DetachedMode(OperatingMode):
         self.nodes_per_block = nodes_per_block
         self.spot_max_price_percentage = spot_max_price_percentage
 
-        # Initialize spot interruption handling if enabled
+        # Initialize spot interruption handling if enabled. use_spot_fleet is
+        # included because a fleet is only ever requested for spot capacity, and
+        # a bucket is no longer a prerequisite -- detection needs no S3 (#137).
         self.spot_interruption_monitor = None
-        self.spot_interruption_handler = None
 
-        if self.use_spot and self.spot_interruption_handling:
-            if not self.checkpoint_bucket and self.spot_interruption_handling:
-                logger.warning(
-                    "Spot interruption handling is enabled but no checkpoint bucket specified"
-                )
-            else:
-                logger.debug(
-                    "Initializing SpotInterruptionMonitor and Handler for DetachedMode"
-                )
-                self.spot_interruption_monitor = SpotInterruptionMonitor(
-                    self.session, provider_id=self.provider_id
-                )
-                self.spot_interruption_handler = ParslSpotInterruptionHandler(
-                    session=self.session,
-                    checkpoint_bucket=self.checkpoint_bucket,
-                    checkpoint_prefix=self.checkpoint_prefix,
-                )
-                self.spot_interruption_monitor.start_monitoring()
+        if (self.use_spot or self.use_spot_fleet) and self.spot_interruption_handling:
+            logger.debug("Initializing SpotInterruptionMonitor for DetachedMode")
+            self.spot_interruption_monitor = SpotInterruptionMonitor(
+                self.session, provider_id=self.provider_id
+            )
+            self.spot_interruption_monitor.start_monitoring()
 
         # Update resources dict to include bastion host
         self.resources = self.resources or {}
@@ -1612,6 +1599,14 @@ if __name__ == '__main__':
                 status_map[resource_id] = STATUS_UNKNOWN
                 continue
 
+            # An interruption is sticky: the bastion's status document is
+            # written by the reclaimed instance itself, so it cannot report its
+            # own reclaim, and re-reading it would overwrite the marker set by
+            # handle_instance_interruption on the very next poll (#137).
+            if resource.get("status") == STATUS_INTERRUPTED:
+                status_map[resource_id] = STATUS_INTERRUPTED
+                continue
+
             job_id = resource.get("job_id")
             if not job_id:
                 status_map[resource_id] = STATUS_UNKNOWN
@@ -1909,7 +1904,6 @@ if __name__ == '__main__':
                             f"Failed to stop spot interruption monitoring: {e}"
                         )
                     self.spot_interruption_monitor = None
-                    self.spot_interruption_handler = None
 
                 # Clear initialization flag only if we're cleaning up everything
                 self.initialized = False
@@ -2088,21 +2082,16 @@ if __name__ == '__main__':
                     )
 
                     # Initialize or clean up spot interruption handling based on new setting
-                    if self.spot_interruption_handling and self.use_spot:
+                    if self.spot_interruption_handling and (
+                        self.use_spot or self.use_spot_fleet
+                    ):
                         if not self.spot_interruption_monitor:
                             logger.debug(
-                                "Initializing SpotInterruptionMonitor and Handler after state load"
+                                "Initializing SpotInterruptionMonitor after state load"
                             )
                             self.spot_interruption_monitor = SpotInterruptionMonitor(
                                 self.session,
                                 provider_id=self.provider_id,
-                            )
-                            self.spot_interruption_handler = (
-                                ParslSpotInterruptionHandler(
-                                    session=self.session,
-                                    checkpoint_bucket=self.checkpoint_bucket,
-                                    checkpoint_prefix=self.checkpoint_prefix,
-                                )
                             )
                             self.spot_interruption_monitor.start_monitoring()
                     elif (
@@ -2114,21 +2103,16 @@ if __name__ == '__main__':
                         )
                         self.spot_interruption_monitor.stop_monitoring()
                         self.spot_interruption_monitor = None
-                        self.spot_interruption_handler = None
 
                 # Re-register existing spot instances with interruption monitor if needed
-                if (
-                    self.spot_interruption_handling
-                    and self.spot_interruption_monitor
-                    and self.spot_interruption_handler
-                ):
+                if self.spot_interruption_handling and self.spot_interruption_monitor:
                     for resource_id, resource in self.resources.items():
                         if resource.get("type") == RESOURCE_TYPE_EC2 and resource.get(
                             "is_spot", False
                         ):
                             self.spot_interruption_monitor.register_instance(
                                 resource_id,
-                                self.spot_interruption_handler.handle_instance_interruption,
+                                self.handle_instance_interruption,
                             )
                             logger.info(
                                 f"Re-registered spot instance {resource_id} for interruption handling"
@@ -2141,7 +2125,7 @@ if __name__ == '__main__':
                             fleet_request_id = resource.get("fleet_request_id")
                             self.spot_interruption_monitor.register_fleet(
                                 fleet_request_id,
-                                self.spot_interruption_handler.handle_fleet_interruption,
+                                self.handle_fleet_interruption,
                             )
                             logger.info(
                                 f"Re-registered spot fleet {fleet_request_id} for interruption handling"

--- a/parsl_ephemeral_aws/modes/serverless.py
+++ b/parsl_ephemeral_aws/modes/serverless.py
@@ -30,6 +30,7 @@ from parsl_ephemeral_aws.constants import (
     STATUS_FAILED,
     STATUS_CANCELLED,
     STATUS_COMPLETED,
+    STATUS_INTERRUPTED,
     STATUS_UNKNOWN,
     DEFAULT_LAMBDA_TIMEOUT,
     DEFAULT_LAMBDA_MEMORY,
@@ -49,10 +50,7 @@ from parsl_ephemeral_aws.modes.base import OperatingMode
 from parsl_ephemeral_aws.state.base import STATE_KEY_MODE
 from parsl_ephemeral_aws.compute.lambda_func import LambdaManager
 from parsl_ephemeral_aws.compute.ecs import ECSManager
-from parsl_ephemeral_aws.compute.spot_interruption import (
-    SpotInterruptionMonitor,
-    ParslSpotInterruptionHandler,
-)
+from parsl_ephemeral_aws.compute.spot_interruption import SpotInterruptionMonitor
 from parsl_ephemeral_aws.utils.aws import (
     architecture_for_instance_type,
     build_fleet_launch_template_configs,
@@ -103,6 +101,8 @@ class ServerlessMode(OperatingMode):
         Number of nodes per block for Spot Fleet
     spot_max_price_percentage : Optional[float]
         Maximum spot price as percentage of on-demand price
+    lambda_code_bucket : Optional[str]
+        Caller-supplied S3 bucket for staging Lambda deployment packages
     lambda_manager : LambdaManager
         Manager for Lambda functions
     ecs_manager : ECSManager
@@ -135,6 +135,7 @@ class ServerlessMode(OperatingMode):
         compute_type: Optional[str] = None,
         memory_size: Optional[int] = None,
         timeout: Optional[int] = None,
+        lambda_code_bucket: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
         """Initialize the serverless mode.
@@ -198,6 +199,16 @@ class ServerlessMode(OperatingMode):
         timeout : Optional[int], optional
             Lambda timeout in seconds, forwarded by ``EphemeralAWSProvider``.
             Overrides ``lambda_timeout`` when supplied.
+        lambda_code_bucket : Optional[str], optional
+            Existing S3 bucket to stage Lambda deployment packages in. A
+            caller-supplied bucket is reused as-is and never deleted; when
+            omitted, a provider-scoped bucket is created on first use and removed
+            by ``cleanup_infrastructure()``.
+
+            This is the surviving half of the old ``checkpoint_bucket``
+            parameter. Its checkpointing purpose was removed in #137 along with
+            the unimplementable task-recovery API, but the staging override was
+            real and is kept under a name that says what it does.
         """
         # compute_type is the provider-facing name for worker_type. Map it before
         # validating so an invalid value is reported against the real input.
@@ -284,34 +295,24 @@ class ServerlessMode(OperatingMode):
         self.ecs_manager: Optional[ECSManager] = None
         self.cf_client = self.session.client("cloudformation")
 
-        # Bucket that stages Lambda deployment packages, resolved on first use.
-        # _owns_lambda_code_bucket records whether we created it, so a
-        # caller-supplied checkpoint_bucket is never deleted on cleanup.
-        self._lambda_code_bucket: Optional[str] = None
+        # Bucket that stages Lambda deployment packages. A caller-supplied one is
+        # adopted here; otherwise it is created on first use.
+        # _owns_lambda_code_bucket records that we created it, so cleanup only
+        # ever deletes a bucket of our own making.
+        self._lambda_code_bucket: Optional[str] = lambda_code_bucket
         self._owns_lambda_code_bucket = False
 
-        # Initialize spot interruption handling if enabled
+        # Initialize spot interruption handling if enabled. Detection needs no
+        # S3 bucket -- requiring one meant a caller who asked for interruption
+        # handling and gave no bucket silently got none at all (#137).
         self.spot_interruption_monitor = None
-        self.spot_interruption_handler = None
 
         if (self.use_spot or self.use_spot_fleet) and self.spot_interruption_handling:
-            if not self.checkpoint_bucket and self.spot_interruption_handling:
-                logger.warning(
-                    "Spot interruption handling is enabled but no checkpoint bucket specified"
-                )
-            else:
-                logger.debug(
-                    "Initializing SpotInterruptionMonitor and Handler for ServerlessMode"
-                )
-                self.spot_interruption_monitor = SpotInterruptionMonitor(
-                    self.session, provider_id=self.provider_id
-                )
-                self.spot_interruption_handler = ParslSpotInterruptionHandler(
-                    session=self.session,
-                    checkpoint_bucket=self.checkpoint_bucket,
-                    checkpoint_prefix=self.checkpoint_prefix,
-                )
-                self.spot_interruption_monitor.start_monitoring()
+            logger.debug("Initializing SpotInterruptionMonitor for ServerlessMode")
+            self.spot_interruption_monitor = SpotInterruptionMonitor(
+                self.session, provider_id=self.provider_id
+            )
+            self.spot_interruption_monitor.start_monitoring()
 
     def initialize(self) -> None:
         """Initialize serverless mode.
@@ -626,10 +627,10 @@ class ServerlessMode(OperatingMode):
     def _ensure_lambda_code_bucket(self) -> str:
         """Return the S3 bucket used to stage Lambda deployment packages.
 
-        Prefers ``checkpoint_bucket`` when the caller supplied one, so a
-        configured bucket is reused rather than a second one created. Otherwise a
-        provider-scoped bucket is created on first use and removed by
-        ``cleanup_infrastructure()``.
+        A provider-scoped bucket is created on first use and removed by
+        ``cleanup_infrastructure()``. A ``lambda_code_bucket`` supplied by the
+        caller is returned unchanged and left alone at cleanup --
+        ``_owns_lambda_code_bucket`` stays False, which is what protects it.
 
         Returns
         -------
@@ -637,10 +638,6 @@ class ServerlessMode(OperatingMode):
             Name of the bucket to stage deployment packages in.
         """
         if self._lambda_code_bucket:
-            return self._lambda_code_bucket
-
-        if self.checkpoint_bucket:
-            self._lambda_code_bucket = self.checkpoint_bucket
             return self._lambda_code_bucket
 
         s3 = self.session.client("s3")
@@ -819,6 +816,15 @@ class ServerlessMode(OperatingMode):
             resource = self.resources.get(resource_id)
             if not resource:
                 status_map[resource_id] = STATUS_UNKNOWN
+                continue
+
+            # An interruption is sticky. The fleet and stack lookups below both
+            # re-derive status, and neither can see a reclaim -- a fleet whose
+            # instances AWS is taking back still reports itself active -- so
+            # without this the marker set by handle_fleet_interruption is
+            # overwritten on the very next poll (#137).
+            if resource.get("status") == STATUS_INTERRUPTED:
+                status_map[resource_id] = STATUS_INTERRUPTED
                 continue
 
             # A fleet-backed job has no stack: the fleet is created directly, so
@@ -1093,14 +1099,10 @@ class ServerlessMode(OperatingMode):
         # Registration is immediate now: the fleet ID comes back from CreateFleet
         # itself. It used to require polling stack outputs for up to 3 minutes,
         # during which an interruption would have gone unhandled.
-        if (
-            self.spot_interruption_handling
-            and self.spot_interruption_monitor
-            and self.spot_interruption_handler
-        ):
+        if self.spot_interruption_handling and self.spot_interruption_monitor:
             self.spot_interruption_monitor.register_fleet(
                 fleet_id,
-                self.spot_interruption_handler.handle_fleet_interruption,
+                self.handle_fleet_interruption,
             )
             logger.info(f"Registered EC2 Fleet {fleet_id} for interruption handling")
 
@@ -1587,8 +1589,8 @@ class ServerlessMode(OperatingMode):
     def _delete_lambda_code_bucket(self) -> None:
         """Delete the Lambda code bucket, but only if this mode created it.
 
-        A caller-supplied ``checkpoint_bucket`` is left alone: it belongs to the
-        caller and may hold checkpoints.
+        ``_owns_lambda_code_bucket`` is the guard: a bucket this mode merely
+        found and reused is left alone.
         """
         if not self._owns_lambda_code_bucket or not self._lambda_code_bucket:
             return
@@ -1634,7 +1636,6 @@ class ServerlessMode(OperatingMode):
             except Exception as e:
                 logger.error(f"Failed to stop spot interruption monitoring: {e}")
             self.spot_interruption_monitor = None
-            self.spot_interruption_handler = None
 
         # Clean up compute managers
         if self.lambda_manager:
@@ -1864,18 +1865,11 @@ class ServerlessMode(OperatingMode):
                     ):
                         if not self.spot_interruption_monitor:
                             logger.debug(
-                                "Initializing SpotInterruptionMonitor and Handler after state load"
+                                "Initializing SpotInterruptionMonitor after state load"
                             )
                             self.spot_interruption_monitor = SpotInterruptionMonitor(
                                 self.session,
                                 provider_id=self.provider_id,
-                            )
-                            self.spot_interruption_handler = (
-                                ParslSpotInterruptionHandler(
-                                    session=self.session,
-                                    checkpoint_bucket=self.checkpoint_bucket,
-                                    checkpoint_prefix=self.checkpoint_prefix,
-                                )
                             )
                             self.spot_interruption_monitor.start_monitoring()
                     elif (
@@ -1887,14 +1881,9 @@ class ServerlessMode(OperatingMode):
                         )
                         self.spot_interruption_monitor.stop_monitoring()
                         self.spot_interruption_monitor = None
-                        self.spot_interruption_handler = None
 
                 # Re-register existing spot fleet resources with interruption monitor if needed
-                if (
-                    self.spot_interruption_handling
-                    and self.spot_interruption_monitor
-                    and self.spot_interruption_handler
-                ):
+                if self.spot_interruption_handling and self.spot_interruption_monitor:
                     for resource_id, resource in self.resources.items():
                         from parsl_ephemeral_aws.constants import (
                             RESOURCE_TYPE_SPOT_FLEET,
@@ -1908,7 +1897,7 @@ class ServerlessMode(OperatingMode):
                             fleet_request_id = resource.get("fleet_request_id")
                             self.spot_interruption_monitor.register_fleet(
                                 fleet_request_id,
-                                self.spot_interruption_handler.handle_fleet_interruption,
+                                self.handle_fleet_interruption,
                             )
                             logger.info(
                                 f"Re-registered spot fleet {fleet_request_id} for interruption handling"

--- a/parsl_ephemeral_aws/modes/standard.py
+++ b/parsl_ephemeral_aws/modes/standard.py
@@ -27,6 +27,7 @@ from parsl_ephemeral_aws.constants import (
     STATUS_CANCELED,
     STATUS_COMPLETED,
     STATUS_FAILED,
+    STATUS_INTERRUPTED,
     STATUS_PENDING,
     STATUS_RUNNING,
     STATUS_UNKNOWN,
@@ -40,10 +41,7 @@ from parsl_ephemeral_aws.exceptions import (
 from parsl_ephemeral_aws.modes.base import OperatingMode
 from parsl_ephemeral_aws.state.base import STATE_KEY_MODE
 from parsl_ephemeral_aws.compute.spot_fleet import SpotFleetManager
-from parsl_ephemeral_aws.compute.spot_interruption import (
-    SpotInterruptionMonitor,
-    ParslSpotInterruptionHandler,
-)
+from parsl_ephemeral_aws.compute.spot_interruption import SpotInterruptionMonitor
 from parsl_ephemeral_aws.utils.aws import (
     architecture_for_instance_type,
     build_launch_template_data,
@@ -228,9 +226,12 @@ class StandardMode(OperatingMode):
         # Initialize SpotFleetManager if using spot fleet
         self.spot_fleet_manager = None
         self.spot_interruption_monitor = None
-        self.spot_interruption_handler = None
 
-        if self.use_spot and self.use_spot_fleet:
+        # use_spot_fleet alone is enough, and use_spot alone is not: every
+        # consumer of this manager gates on use_spot_fleet, so requiring
+        # `use_spot and use_spot_fleet` left the manager None for a fleet caller
+        # and silently degraded the launch to a single on-demand instance (#137).
+        if self.use_spot_fleet:
             # Create a simplified provider object for the SpotFleetManager
             # The SpotFleetManager expects a provider object with certain attributes
             provider = type(
@@ -269,21 +270,11 @@ class StandardMode(OperatingMode):
         # monitoring thread is only started after infrastructure is fully set up.
         # This prevents the monitor thread from leaking if __init__ succeeds but
         # a later call (e.g. initialize()) raises before cleanup can run.
-        if self.use_spot and self.spot_interruption_handling:
-            if not self.checkpoint_bucket and self.spot_interruption_handling:
-                logger.warning(
-                    "Spot interruption handling is enabled but no checkpoint bucket specified"
-                )
-            else:
-                logger.debug("Initializing SpotInterruptionMonitor and Handler")
-                self.spot_interruption_monitor = SpotInterruptionMonitor(
-                    self.session, provider_id=self.provider_id
-                )
-                self.spot_interruption_handler = ParslSpotInterruptionHandler(
-                    session=self.session,
-                    checkpoint_bucket=self.checkpoint_bucket,
-                    checkpoint_prefix=self.checkpoint_prefix,
-                )
+        if (self.use_spot or self.use_spot_fleet) and self.spot_interruption_handling:
+            logger.debug("Initializing SpotInterruptionMonitor")
+            self.spot_interruption_monitor = SpotInterruptionMonitor(
+                self.session, provider_id=self.provider_id
+            )
 
     # ------------------------------------------------------------------
     # AMI baking helpers
@@ -666,21 +657,16 @@ class StandardMode(OperatingMode):
                     )
 
                     # Initialize or clean up spot interruption handling based on new setting
-                    if self.spot_interruption_handling and self.use_spot:
+                    if self.spot_interruption_handling and (
+                        self.use_spot or self.use_spot_fleet
+                    ):
                         if not self.spot_interruption_monitor:
                             logger.debug(
-                                "Initializing SpotInterruptionMonitor and Handler after state load"
+                                "Initializing SpotInterruptionMonitor after state load"
                             )
                             self.spot_interruption_monitor = SpotInterruptionMonitor(
                                 self.session,
                                 provider_id=self.provider_id,
-                            )
-                            self.spot_interruption_handler = (
-                                ParslSpotInterruptionHandler(
-                                    session=self.session,
-                                    checkpoint_bucket=self.checkpoint_bucket,
-                                    checkpoint_prefix=self.checkpoint_prefix,
-                                )
                             )
                             self.spot_interruption_monitor.start_monitoring()
                     elif (
@@ -692,7 +678,6 @@ class StandardMode(OperatingMode):
                         )
                         self.spot_interruption_monitor.stop_monitoring()
                         self.spot_interruption_monitor = None
-                        self.spot_interruption_handler = None
 
                 # Load SpotFleetManager state if available
                 if (
@@ -728,7 +713,6 @@ class StandardMode(OperatingMode):
                     if (
                         self.spot_interruption_handling
                         and self.spot_interruption_monitor
-                        and self.spot_interruption_handler
                     ):
                         for block_data in self.spot_fleet_manager.blocks.values():
                             fleet_id = block_data.get("fleet_request_id")
@@ -736,7 +720,7 @@ class StandardMode(OperatingMode):
                                 continue
                             self.spot_interruption_monitor.register_fleet(
                                 fleet_id,
-                                self.spot_interruption_handler.handle_fleet_interruption,
+                                self.handle_fleet_interruption,
                             )
                             logger.info(
                                 f"Re-registered EC2 Fleet {fleet_id} for "
@@ -967,12 +951,16 @@ class StandardMode(OperatingMode):
 
             # Track the resource
             resource_type = RESOURCE_TYPE_EC2
+            fleet_request_id = None
             if (
                 self.use_spot_fleet
                 and self.spot_fleet_manager
                 and instance_id in self.spot_fleet_manager.blocks
             ):
                 resource_type = RESOURCE_TYPE_SPOT_FLEET
+                fleet_request_id = self.spot_fleet_manager.blocks[instance_id].get(
+                    "fleet_request_id"
+                )
 
             resource_data: Dict[str, Any] = {
                 "type": resource_type,
@@ -983,6 +971,14 @@ class StandardMode(OperatingMode):
                 "command": command,
                 "tasks_per_node": tasks_per_node,
             }
+
+            if fleet_request_id:
+                # The monitor registers the *fleet* ID, but this record is keyed
+                # by block ID, so without this field handle_fleet_interruption
+                # has no way back to the block it must mark (#137). The manager's
+                # own blocks dict is not enough: it is not persisted in state, so
+                # a resumed provider would lose the link.
+                resource_data["fleet_request_id"] = fleet_request_id
 
             if self._uses_ssm_dispatch():
                 # Cold start for the SSM paths: wait for SSM, then dispatch. The
@@ -1361,8 +1357,11 @@ class StandardMode(OperatingMode):
             if self.iam_instance_profile_arn:
                 run_args["IamInstanceProfile"] = {"Arn": self.iam_instance_profile_arn}
 
-        # Use spot instances if requested
-        if self.use_spot:
+        # Use spot instances if requested. use_spot_fleet implies spot: a fleet
+        # request is only ever placed for spot capacity, and testing use_spot
+        # alone here sent a use_spot_fleet=True caller down the on-demand path
+        # so the fleet was never requested (#137).
+        if self.use_spot or self.use_spot_fleet:
             return self._create_spot_instance(run_args)
         else:
             # Create on-demand instance
@@ -1546,14 +1545,10 @@ class StandardMode(OperatingMode):
 
     def _register_spot_instance(self, instance_id: str) -> None:
         """Register *instance_id* with the interruption monitor, if enabled."""
-        if (
-            self.spot_interruption_handling
-            and self.spot_interruption_monitor
-            and self.spot_interruption_handler
-        ):
+        if self.spot_interruption_handling and self.spot_interruption_monitor:
             self.spot_interruption_monitor.register_instance(
                 instance_id,
-                self.spot_interruption_handler.handle_instance_interruption,
+                self.handle_instance_interruption,
             )
             logger.info(
                 f"Registered spot instance {instance_id} for interruption handling"
@@ -1656,18 +1651,14 @@ class StandardMode(OperatingMode):
             # The block records a single "fleet_request_id"; this used to read a
             # "fleet_requests" list that no code has ever written, so no fleet
             # was ever actually registered.
-            if (
-                self.spot_interruption_handling
-                and self.spot_interruption_monitor
-                and self.spot_interruption_handler
-            ):
+            if self.spot_interruption_handling and self.spot_interruption_monitor:
                 fleet_id = self.spot_fleet_manager.blocks.get(block_id, {}).get(
                     "fleet_request_id"
                 )
                 if fleet_id:
                     self.spot_interruption_monitor.register_fleet(
                         fleet_id,
-                        self.spot_interruption_handler.handle_fleet_interruption,
+                        self.handle_fleet_interruption,
                     )
                     logger.info(
                         f"Registered EC2 Fleet {fleet_id} for interruption handling"
@@ -1732,6 +1723,15 @@ class StandardMode(OperatingMode):
             resource = self.resources.get(resource_id)
             if not resource:
                 status_map[resource_id] = STATUS_UNKNOWN
+                continue
+
+            # An interruption is sticky. Everything below re-derives status from
+            # AWS, and a reclaimed instance goes to "shutting-down", which
+            # EC2_STATUS_MAPPING renders COMPLETED -- so without this the marker
+            # set by handle_instance_interruption is overwritten on the very next
+            # poll and the reclaim is reported as success again (#137).
+            if resource.get("status") == STATUS_INTERRUPTED:
+                status_map[resource_id] = STATUS_INTERRUPTED
                 continue
 
             # Any resource carrying an SSM command ID — warm pool or one-shot —
@@ -2048,7 +2048,6 @@ class StandardMode(OperatingMode):
                 except Exception as e:
                     logger.error(f"Failed to stop spot interruption monitoring: {e}")
                 self.spot_interruption_monitor = None
-                self.spot_interruption_handler = None
 
             # Deregister baked AMI if this provider created it
             if self._baked_ami_id and getattr(self, "_owns_baked_ami", False):

--- a/parsl_ephemeral_aws/provider.py
+++ b/parsl_ephemeral_aws/provider.py
@@ -35,6 +35,7 @@ from parsl_ephemeral_aws.constants import (
     DEFAULT_WARM_POOL_TTL,
     DEFAULT_WORKER_INIT,
     MAX_WARM_POOL_SIZE,
+    STATUS_INTERRUPTED,
     STATUS_WARM,
 )
 from parsl_ephemeral_aws.exceptions import (
@@ -76,11 +77,17 @@ _STRING_TO_JOB_STATE: Dict[str, JobState] = {
     # WARM = instance idle in warm pool; the JOB is done so Parsl sees RUNNING
     # (prevents premature cancellation while we reuse the instance).
     "WARM": JobState.RUNNING,
+    # INTERRUPTED = AWS has issued the two-minute spot reclaim warning. FAILED
+    # rather than COMPLETED because the block did not finish its work: FAILED is
+    # what stops the executor dispatching to it and lets Parsl's own `retries`
+    # re-run the lost tasks (#137). Kept distinct as a string so state files and
+    # logs record the cause.
+    "INTERRUPTED": JobState.FAILED,
 }
 
 # Job states that are terminal (Parsl will not re-submit once in these states)
 _TERMINAL_STATES: frozenset = frozenset(
-    {"COMPLETED", "FAILED", "CANCELED", "CANCELLED"}
+    {"COMPLETED", "FAILED", "CANCELED", "CANCELLED", "INTERRUPTED"}
 )
 
 
@@ -168,13 +175,12 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
         or 'lowest-price'. Converted to the camelCase spelling Spot Fleet
         requires at the API boundary.
     spot_interruption_handling : bool, optional
-        Whether to enable spot interruption handling. Default is False.
-    checkpoint_bucket : Optional[str], optional
-        S3 bucket name for storing task checkpoints, required if spot_interruption_handling is True.
-    checkpoint_prefix : str, optional
-        S3 key prefix for checkpoint data. Default is 'parsl/checkpoints'.
-    checkpoint_interval : int, optional
-        Interval between checkpoints in seconds. Default is 60.
+        Whether to detect spot interruptions. Default is False. When enabled, an
+        interrupted block is reported to Parsl as FAILED rather than COMPLETED,
+        so the executor stops dispatching to it and re-runs the lost tasks under
+        its own ``retries`` setting. No checkpointing is performed: a provider
+        never sees task state, so re-running is the only recovery available at
+        this layer. Set ``retries`` on your Parsl config to make use of it.
     additional_tags : Dict[str, str], optional
         Additional tags to apply to AWS resources.
     auto_shutdown : bool, optional
@@ -286,9 +292,6 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
         use_spot_fleet: bool = False,
         instance_types: Optional[List[str]] = None,
         spot_max_price_percentage: Optional[int] = None,
-        checkpoint_bucket: Optional[str] = None,
-        checkpoint_prefix: str = "parsl/checkpoints",
-        checkpoint_interval: int = 60,
         additional_tags: Optional[Dict[str, str]] = None,
         auto_shutdown: bool = True,
         max_idle_time: int = DEFAULT_MAX_IDLE_TIME,
@@ -385,9 +388,6 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
         self.use_spot_fleet = use_spot_fleet
         self.instance_types = instance_types or []
         self.spot_max_price_percentage = spot_max_price_percentage
-        self.checkpoint_bucket = checkpoint_bucket
-        self.checkpoint_prefix = checkpoint_prefix
-        self.checkpoint_interval = checkpoint_interval
         self.additional_tags = additional_tags or {}
         self.auto_shutdown = auto_shutdown
         self.max_idle_time = max_idle_time
@@ -850,9 +850,6 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
             "instance_types": self.instance_types,
             "spot_max_price_percentage": self.spot_max_price_percentage,
             "nodes_per_block": self.nodes_per_block,
-            "checkpoint_bucket": self.checkpoint_bucket,
-            "checkpoint_prefix": self.checkpoint_prefix,
-            "checkpoint_interval": self.checkpoint_interval,
             "additional_tags": self.additional_tags,
             "auto_shutdown": self.auto_shutdown,
             "max_idle_time": self.max_idle_time,
@@ -1256,15 +1253,21 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
                         warm_transitions.append(resource_id)
                         continue  # decision made below
 
-                    elif status in ("FAILED", "CANCELED"):
+                    # STATUS_INTERRUPTED is here rather than in the WARM branch
+                    # above on purpose: a reclaimed instance is being taken by
+                    # AWS, so it must never be recycled into the pool (#137).
+                    elif status in ("FAILED", "CANCELED", STATUS_INTERRUPTED):
                         resources_to_cleanup.append(resource_id)
                         continue
 
                     else:
                         continue  # PENDING/RUNNING — leave alone
 
-                # Normal (non-warm-pool) lifecycle
-                if status in ["COMPLETED", "FAILED", "CANCELED"]:
+                # Normal (non-warm-pool) lifecycle. STATUS_INTERRUPTED terminates
+                # like any other terminal state -- omitting it leaked the
+                # instance, trading a silently-successful reclaim for a silent
+                # cost leak (#137).
+                if status in ["COMPLETED", "FAILED", "CANCELED", STATUS_INTERRUPTED]:
                     resources_to_cleanup.append(resource_id)
                 elif (
                     self.auto_shutdown

--- a/parsl_ephemeral_aws/utils/aws.py
+++ b/parsl_ephemeral_aws/utils/aws.py
@@ -674,7 +674,8 @@ def create_spot_interruption_notifier(
 
     This is what supplies the two-minute advance warning. Polling EC2 state
     cannot: an interrupted instance is only observable once it reaches
-    ``shutting-down``, which is after the reclaim, far too late to checkpoint.
+    ``shutting-down``, which is after the reclaim, far too late to stop
+    dispatching into it.
     An ``instant`` fleet also gets no Capacity Rebalance -- ``CreateFleet``
     rejects ``SpotOptions.MaintenanceStrategies`` for the type -- so EventBridge
     is the mechanism, and it has the further advantage of working for instances

--- a/tests/aws/test_spot_e2e.py
+++ b/tests/aws/test_spot_e2e.py
@@ -298,13 +298,15 @@ class TestSpotComputeLifecycle:
 class TestSpotInterruptionMonitor:
     """Verify spot interruption monitoring behaviour.
 
-    These tests require a provider with ``spot_interruption_handling=True`` and
-    a real S3 bucket for checkpoints.  Each test creates its own provider so
-    that the S3 bucket lifecycle matches the test lifetime.
+    ``spot_interruption_handling=True`` is the only requirement. It used to also
+    need an S3 bucket, because the monitor was built only when a
+    ``checkpoint_bucket`` was configured -- so a caller who asked for
+    interruption handling and gave no bucket silently got none at all. #137
+    removed both that gate and the checkpointing API behind it.
     """
 
     def _make_interruption_provider(
-        self, tmp_path, aws_session, test_run_id, aws_region, checkpoint_bucket: str
+        self, tmp_path, aws_session, test_run_id, aws_region
     ) -> EphemeralAWSProvider:
         """Helper: create a provider with interruption handling enabled."""
         state_file = str(tmp_path / f"state-int-{test_run_id}.json")
@@ -314,7 +316,6 @@ class TestSpotInterruptionMonitor:
             mode="standard",
             use_spot=True,
             spot_interruption_handling=True,
-            checkpoint_bucket=checkpoint_bucket,
             state_store_type="file",
             state_file_path=state_file,
             auto_shutdown=True,
@@ -333,33 +334,17 @@ class TestSpotInterruptionMonitor:
     def test_interruption_monitor_starts_after_initialize(
         self, tmp_path, aws_session, test_run_id, aws_region
     ):
-        """After initialize() the spot interruption monitor thread is running.
-
-        Creates a temporary S3 bucket for checkpoints, initialises the provider,
-        and asserts that ``spot_interruption_monitor.monitoring_thread.is_alive()``
-        is True.
-        """
-        s3 = aws_session.client("s3", region_name=aws_region)
-        bucket_name = f"parsl-e2e-cp-{test_run_id}"
-
-        if aws_region == "us-east-1":
-            s3.create_bucket(Bucket=bucket_name)
-        else:
-            s3.create_bucket(
-                Bucket=bucket_name,
-                CreateBucketConfiguration={"LocationConstraint": aws_region},
-            )
-
+        """After initialize() the spot interruption monitor thread is running."""
         provider = self._make_interruption_provider(
-            tmp_path, aws_session, test_run_id, aws_region, bucket_name
+            tmp_path, aws_session, test_run_id, aws_region
         )
         try:
             provider.operating_mode.initialize()
 
             monitor = provider.operating_mode.spot_interruption_monitor
             assert monitor is not None, (
-                "spot_interruption_monitor should be set when "
-                "spot_interruption_handling=True and a checkpoint_bucket is given"
+                "spot_interruption_monitor should be set whenever "
+                "spot_interruption_handling=True"
             )
             assert (
                 monitor.monitoring_thread is not None
@@ -370,19 +355,6 @@ class TestSpotInterruptionMonitor:
                 provider.shutdown()
             except Exception as exc:
                 logger.warning("interruption provider shutdown: %s", exc)
-            # Delete checkpoint bucket
-            try:
-                paginator = s3.get_paginator("list_objects_v2")
-                for page in paginator.paginate(Bucket=bucket_name):
-                    objects = page.get("Contents", [])
-                    if objects:
-                        s3.delete_objects(
-                            Bucket=bucket_name,
-                            Delete={"Objects": [{"Key": o["Key"]} for o in objects]},
-                        )
-                s3.delete_bucket(Bucket=bucket_name)
-            except Exception as exc:
-                logger.warning("checkpoint bucket cleanup: %s (ignored)", exc)
 
     def test_forced_termination_transitions_out_of_running(
         self, spot_provider, aws_session, aws_region

--- a/tests/aws/test_spot_warning_e2e.py
+++ b/tests/aws/test_spot_warning_e2e.py
@@ -11,7 +11,8 @@ Only AWS can prove the three claims that actually matter here:
   no interruptions.
 * **The warning arrives while the instance is still running.** That is the entire
   point: the EC2-state poll it replaces can only see ``shutting-down``, after the
-  reclaim, too late to checkpoint. A previous manual probe measured 15.2s from
+  reclaim and after work has gone to a dead worker. A previous manual probe
+  measured 15.2s from
   the Fault Injection Simulator experiment starting to the message landing in
   SQS, with the instance still ``running``.
 * **The rule and queue are deleted on shutdown.** EventBridge caps rules per
@@ -386,7 +387,7 @@ class TestFISInterruption:
         instance reaches ``shutting-down``. If the warning arrived no earlier
         than that, the EventBridge machinery would be pure cost -- so the
         assertion is not just that a message arrives, but that the instance is
-        still ``running`` when it does, with time left to checkpoint.
+        still ``running`` when it does, leaving time to stop dispatching into it.
 
         Uses its own provider rather than ``spot_provider`` so the E2E run tag
         FIS targets is the only thing selected: ``selectionMode: ALL`` would
@@ -458,8 +459,8 @@ class TestFISInterruption:
             )
             assert state == "running", (
                 f"the warning arrived at {elapsed:.1f}s but {instance_id} was "
-                f"already {state}; there is no lead time to checkpoint in and "
-                "the EventBridge notifier buys nothing over the EC2-state poll"
+                f"already {state}; there is no lead time left and the "
+                "EventBridge notifier buys nothing over the EC2-state poll"
             )
 
             assert warning["detail-type"] == SPOT_INTERRUPTION_EVENT_DETAIL_TYPE
@@ -494,25 +495,18 @@ class TestFISInterruption:
         provider builds for itself carries it the rest of the way: mode
         initialisation creates the notifier, ``_create_spot_instance`` registers
         the instance, the background thread polls, and the registered handler is
-        called with ``Source: eventbridge`` -- the flag telling a checkpointing
-        handler it still has time.
+        called with ``Source: eventbridge`` -- the flag saying the instance is
+        still alive.
 
-        The handler is swapped for a recorder rather than left as the real
-        S3-checkpointing one, so the assertion is about delivery and not about
-        whether a checkpoint happened to succeed. ``checkpoint_bucket`` is still
-        required, because it is what makes the mode build a monitor at all.
+        The handler is swapped for a recorder rather than left as the mode's own
+        ``handle_instance_interruption``, so the assertion is about delivery
+        rather than about what the mode then does with it (covered by the unit
+        and substrate suites). No S3 bucket is involved: the monitor used to be
+        built only when a ``checkpoint_bucket`` was configured, which #137
+        removed along with the unimplementable recovery API behind it.
         """
         fis = aws_session.client("fis", region_name=aws_region)
         ec2 = aws_session.client("ec2", region_name=aws_region)
-        s3 = aws_session.client("s3", region_name=aws_region)
-        bucket = f"parsl-e2e-warn-{test_run_id}"
-        if aws_region == "us-east-1":
-            s3.create_bucket(Bucket=bucket)
-        else:
-            s3.create_bucket(
-                Bucket=bucket,
-                CreateBucketConfiguration={"LocationConstraint": aws_region},
-            )
 
         provider = EphemeralAWSProvider(
             region=aws_region,
@@ -520,7 +514,6 @@ class TestFISInterruption:
             mode="standard",
             use_spot=True,
             spot_interruption_handling=True,
-            checkpoint_bucket=bucket,
             state_store_type="file",
             state_file_path=str(tmp_path / f"state-hdl-{test_run_id}.json"),
             auto_shutdown=True,
@@ -540,7 +533,7 @@ class TestFISInterruption:
             monitor = mode.spot_interruption_monitor
             assert monitor is not None, (
                 "no interruption monitor was built despite "
-                "spot_interruption_handling=True and a checkpoint bucket"
+                "spot_interruption_handling=True"
             )
 
             received = []
@@ -548,7 +541,7 @@ class TestFISInterruption:
             instance_id = provider.job_map[job_id]["resource_id"]
 
             # Registered by _create_spot_instance during submit; replaced here so
-            # the assertion is about delivery rather than about S3.
+            # the assertion is about delivery rather than about the response.
             assert instance_id in monitor.instance_handlers, (
                 f"{instance_id} was never registered with the monitor, so no "
                 "warning for it can ever be routed"
@@ -576,7 +569,7 @@ class TestFISInterruption:
             assert handled_id == instance_id
             assert details["Source"] == "eventbridge", (
                 "the warning was attributed to the post-facto EC2-state poll, "
-                "so a handler would skip checkpointing"
+                "so the block was marked after the reclaim rather than ahead of it"
             )
         finally:
             if job_id:
@@ -593,15 +586,3 @@ class TestFISInterruption:
                     fis.delete_experiment_template(id=template_id)
                 except Exception as exc:
                     logger.warning("FIS template cleanup: %s (ignored)", exc)
-            try:
-                paginator = s3.get_paginator("list_objects_v2")
-                for page in paginator.paginate(Bucket=bucket):
-                    objects = page.get("Contents", [])
-                    if objects:
-                        s3.delete_objects(
-                            Bucket=bucket,
-                            Delete={"Objects": [{"Key": o["Key"]} for o in objects]},
-                        )
-                s3.delete_bucket(Bucket=bucket)
-            except Exception as exc:
-                logger.warning("checkpoint bucket cleanup: %s (ignored)", exc)

--- a/tests/integration/test_serverless_mode_spot_fleet_integration.py
+++ b/tests/integration/test_serverless_mode_spot_fleet_integration.py
@@ -228,14 +228,19 @@ class TestServerlessModeSpotFleetIntegration:
         assert bucket not in [b["Name"] for b in s3.list_buckets()["Buckets"]]
 
     def test_a_caller_supplied_bucket_is_reused_and_kept(self, aws_session):
-        """A configured checkpoint_bucket is staged into, never deleted."""
+        """A configured lambda_code_bucket is staged into, never deleted.
+
+        The parameter used to be ``checkpoint_bucket``, whose checkpointing half
+        #137 removed; the staging override it also carried is real, so it kept the
+        behaviour under a name that describes it.
+        """
         s3 = aws_session.client("s3")
         s3.create_bucket(Bucket="parsl-test-caller-bucket")
 
         mode = self._mode(
             aws_session,
             worker_type=WORKER_TYPE_LAMBDA,
-            checkpoint_bucket="parsl-test-caller-bucket",
+            lambda_code_bucket="parsl-test-caller-bucket",
         )
         mode.initialize()
         resource_id = mode.submit_job("test-job-lambda-3", "echo hi", 1)

--- a/tests/integration/test_spot_interruption_integration.py
+++ b/tests/integration/test_spot_interruption_integration.py
@@ -1,518 +1,304 @@
-"""Integration tests for spot interruption handling using substrate.
+"""Integration tests for the spot interruption response, across all three modes.
 
-These tests verify that spot interruption handling works correctly across
-all operating modes, including detection, checkpointing, and recovery.
+Detection is covered in ``test_spot_interruption_substrate.py``; this file covers
+what happens *after* a reclaim is detected — the mode marking the block so the
+provider reports FAILED and Parsl re-runs its tasks. That path is per-mode, and
+the wiring differs in each: StandardMode registers each spot instance as it is
+created, DetachedMode re-registers them from state after a restart, and
+ServerlessMode registers a fleet whose ID is not its own resource key.
+
+Interruptions are driven by putting an event on ``monitor.event_queue`` and
+calling ``_process_interruption_events()``. That is the seam the monitoring thread
+itself uses, and it is the only workable one here: substrate does not emulate
+``events``, and it never sets ``InstanceLifecycle``, so neither the EventBridge
+warning nor the EC2-state poll can originate an interruption against the
+emulator. Everything downstream of the queue is the real code.
+
+The checkpoint/recovery API the previous version of this file tested was deleted
+in #137. It could not work at this layer: its entry point was
+``register_task(task_id, instance_id)``, and a Parsl provider is never told a
+task ID — it is handed a command and returns a block ID.
 
 SPDX-License-Identifier: Apache-2.0
 SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
 """
 
-import pytest
 import time
 import uuid
-from unittest.mock import patch
 
-from parsl_ephemeral_aws.modes.standard import StandardMode
+import pytest
+
+from parsl_ephemeral_aws.compute.spot_interruption import SpotInterruptionMonitor
+from parsl_ephemeral_aws.constants import (
+    RESOURCE_TYPE_EC2,
+    RESOURCE_TYPE_SPOT_FLEET,
+    STATUS_INTERRUPTED,
+    STATUS_RUNNING,
+)
 from parsl_ephemeral_aws.modes.detached import DetachedMode
 from parsl_ephemeral_aws.modes.serverless import ServerlessMode
-from parsl_ephemeral_aws.compute.spot_interruption import (
-    SpotInterruptionMonitor,
-    SpotInterruptionHandler,
-    ParslSpotInterruptionHandler,
-)
+from parsl_ephemeral_aws.modes.standard import StandardMode
 from parsl_ephemeral_aws.state.file import FileStateStore
-from tests.substrate_support import (
-    get_substrate_session,
-    is_substrate_available,
-)
+from tests.substrate_support import cleanup_substrate_vpc, setup_substrate_vpc
 
-
-@pytest.fixture(scope="session")
-def substrate_available():
-    """Check if substrate is available for testing."""
-    if not is_substrate_available():
-        pytest.skip("substrate not available - start with 'make substrate-up'")
-    return True
-
-
-@pytest.fixture(scope="session")
-def substrate_session(substrate_available):
-    """Create a session connected to substrate."""
-    return get_substrate_session()
-
-
-@pytest.fixture
-def temp_state_store(tmpdir):
-    """Create a temporary state store for testing."""
-    state_file = tmpdir.join("state.json")
-    return FileStateStore(file_path=str(state_file))
+pytestmark = [pytest.mark.integration, pytest.mark.substrate]
 
 
 @pytest.fixture
 def provider_id():
-    """Generate a unique provider ID for tests."""
+    """A unique provider ID, so concurrent runs cannot collide on state keys."""
     return f"test-provider-{uuid.uuid4().hex[:8]}"
 
 
 @pytest.fixture
-def checkpoint_bucket(substrate_session, provider_id):
-    """Create a temporary S3 bucket for checkpoints."""
-    bucket_name = f"test-checkpoint-bucket-{provider_id.split('-')[-1]}"
-    s3_client = substrate_session.client("s3")
-
-    try:
-        s3_client.create_bucket(Bucket=bucket_name)
-    except Exception as e:
-        pytest.skip(f"Failed to create S3 bucket: {e}")
-
-    yield bucket_name
-
-    # Cleanup
-    try:
-        # Delete all objects in the bucket
-        objects = s3_client.list_objects_v2(Bucket=bucket_name)
-        if "Contents" in objects:
-            delete_keys = {
-                "Objects": [{"Key": obj["Key"]} for obj in objects["Contents"]]
-            }
-            s3_client.delete_objects(Bucket=bucket_name, Delete=delete_keys)
-
-        # Delete the bucket
-        s3_client.delete_bucket(Bucket=bucket_name)
-    except Exception as e:
-        print(f"Error cleaning up bucket {bucket_name}: {e}")
+def state_store(tmp_path, provider_id):
+    """A file-backed store, which is what makes the restart test possible."""
+    return FileStateStore(
+        file_path=str(tmp_path / "state.json"), provider_id=provider_id
+    )
 
 
 @pytest.fixture
-def mock_spot_instance_id(substrate_session):
-    """Create a spot instance ID for testing."""
-    return f"i-spot-{uuid.uuid4().hex[:8]}"
+def network(substrate_session):
+    """Pre-provisioned VPC/subnet/SG — required of every mode since #69."""
+    ids = setup_substrate_vpc()
+    yield ids
+    cleanup_substrate_vpc(ids["vpc_id"])
 
 
-@pytest.fixture
-def mock_spot_fleet_id(substrate_session):
-    """Create a spot fleet ID for testing."""
-    return f"sfr-{uuid.uuid4().hex[:8]}"
-
-
-@pytest.mark.integration
-class TestSpotInterruptionHandlingSubstrate:
-    """Integration tests for spot interruption handling using substrate."""
-
-    @pytest.mark.substrate
-    def test_spot_interruption_monitor_creation(self, substrate_session):
-        """Test that SpotInterruptionMonitor can be initialized."""
-        monitor = SpotInterruptionMonitor(session=substrate_session)
-        assert monitor is not None
-        assert monitor.session == substrate_session
-        assert monitor.instance_handlers == {}
-        assert monitor.fleet_handlers == {}
-
-        # Start monitoring
-        monitor.start_monitoring()
-        assert monitor.monitoring_thread is not None
-        assert monitor.monitoring_thread.is_alive()
-
-        # Stop monitoring
-        monitor.stop_monitoring()
-        time.sleep(0.5)  # Let thread terminate
-        assert not monitor.monitoring_thread.is_alive()
-
-    @pytest.mark.substrate
-    def test_spot_interruption_handler_with_s3(
-        self, substrate_session, checkpoint_bucket
-    ):
-        """Test that SpotInterruptionHandler can use S3 for checkpoints."""
-        handler = SpotInterruptionHandler(
-            session=substrate_session,
-            checkpoint_bucket=checkpoint_bucket,
-            checkpoint_prefix="test-checkpoints",
+def _interrupt_instance(monitor, instance_id):
+    """Deliver an instance reclaim through the queue the monitor thread drains."""
+    monitor.event_queue.put(
+        (
+            "instance",
+            instance_id,
+            {
+                "InstanceId": instance_id,
+                "InstanceAction": "terminate",
+                "NoticeTime": time.time(),
+                "Source": "eventbridge",
+            },
         )
+    )
+    monitor._process_interruption_events()
 
-        assert handler is not None
-        assert handler.checkpoint_bucket == checkpoint_bucket
 
-        # Test saving a checkpoint
-        task_id = f"task-{uuid.uuid4().hex[:8]}"
-        test_data = {"state": "running", "progress": 50, "timestamp": time.time()}
-
-        uri = handler.save_checkpoint(task_id, test_data)
-        assert uri == f"s3://{checkpoint_bucket}/test-checkpoints/{task_id}.json"
-
-        # Test loading the checkpoint
-        loaded_data = handler.load_checkpoint(task_id)
-        assert loaded_data is not None
-        assert loaded_data["state"] == "running"
-        assert loaded_data["progress"] == 50
-
-    @pytest.mark.substrate
-    def test_parsl_handler_task_registration(
-        self, substrate_session, checkpoint_bucket, mock_spot_instance_id
-    ):
-        """Test that tasks can be registered with the ParslSpotInterruptionHandler."""
-        handler = ParslSpotInterruptionHandler(
-            session=substrate_session,
-            checkpoint_bucket=checkpoint_bucket,
-            checkpoint_prefix="test-checkpoints",
+def _interrupt_fleet(monitor, fleet_id, instance_ids):
+    """Deliver a fleet reclaim through the queue the monitor thread drains."""
+    monitor.event_queue.put(
+        (
+            "fleet",
+            fleet_id,
+            instance_ids,
+            {
+                "FleetRequestId": fleet_id,
+                "InstanceAction": "terminate",
+                "NoticeTime": time.time(),
+                "Source": "eventbridge",
+            },
         )
+    )
+    monitor._process_interruption_events()
 
-        # Register tasks
-        task_ids = [f"task-{uuid.uuid4().hex[:8]}" for _ in range(3)]
-        for task_id in task_ids:
-            handler.register_task(task_id, mock_spot_instance_id)
 
-        # Verify tasks were registered
-        assert mock_spot_instance_id in handler.task_mapping
-        assert len(handler.task_mapping[mock_spot_instance_id]) == 3
-        for task_id in task_ids:
-            assert task_id in handler.task_mapping[mock_spot_instance_id]
+class TestStandardModeInterruption:
+    """StandardMode registers each spot instance as it creates it."""
 
-    @pytest.mark.substrate
-    def test_standard_mode_with_spot_interruption(
-        self,
-        substrate_session,
-        temp_state_store,
-        provider_id,
-        checkpoint_bucket,
-        mock_spot_instance_id,
-    ):
-        """Test that StandardMode can handle spot interruptions."""
-        # Create StandardMode instance with spot interruption handling
+    @pytest.fixture
+    def mode(self, substrate_session, state_store, provider_id, network):
         mode = StandardMode(
             provider_id=provider_id,
             session=substrate_session,
-            state_store=temp_state_store,
+            state_store=state_store,
             region="us-east-1",
-            instance_type="t2.micro",
-            image_id="ami-12345678",  # Dummy AMI ID for testing
+            instance_type="t3.micro",
+            image_id="ami-12345678",
+            vpc_id=network["vpc_id"],
+            subnet_id=network["subnet_id"],
+            security_group_id=network["security_group_id"],
             use_spot=True,
             spot_interruption_handling=True,
-            checkpoint_bucket=checkpoint_bucket,
-            checkpoint_prefix="test/checkpoints",
         )
+        yield mode
+        if mode.spot_interruption_monitor:
+            mode.spot_interruption_monitor.stop_monitoring()
 
-        try:
-            # Initialize mode
-            mode.initialize()
+    def test_a_reclaim_marks_the_block_the_provider_reports_on(self, mode):
+        """The whole point of #137, through a real mode rather than a stub.
 
-            # Verify spot interruption monitor was created
-            assert mode.spot_interruption_monitor is not None
-            assert mode.spot_interruption_handler is not None
+        Before this, the reclaim was *invisible* rather than merely unhandled:
+        EC2 reports a reclaimed instance as ``shutting-down``, which
+        ``EC2_STATUS_MAPPING`` renders COMPLETED, so the block reported success
+        and its tasks were silently dropped instead of being re-run.
+        """
+        instance_id = f"i-{uuid.uuid4().hex[:16]}"
+        mode.resources[instance_id] = {
+            "type": RESOURCE_TYPE_EC2,
+            "job_id": "job-1",
+            "status": STATUS_RUNNING,
+            "is_spot": True,
+        }
 
-            # Mock instance creation response
-            with patch.object(mode, "_create_ec2_instance") as mock_create_instance:
-                mock_create_instance.return_value = {
-                    "instance_id": mock_spot_instance_id,
-                    "private_ip": "10.0.0.5",
-                    "public_ip": "54.123.456.789",
-                    "dns_name": "ec2-54-123-456-789.compute-1.amazonaws.com",
-                }
+        # The real registration call, made by _create_spot_instance on every
+        # spot launch — not a hand-wired handler.
+        mode._register_spot_instance(instance_id)
+        assert instance_id in mode.spot_interruption_monitor.instance_handlers
 
-                # Submit a job
-                job_id = f"test-job-{uuid.uuid4().hex[:8]}"
-                command = "echo hello"
-                resource_id = mode.submit_job(job_id, command, 1)
+        _interrupt_instance(mode.spot_interruption_monitor, instance_id)
 
-            # Verify spot instance was registered with monitor
-            assert (
-                mock_spot_instance_id
-                in mode.spot_interruption_monitor.instance_handlers
-            )
+        assert mode.resources[instance_id]["status"] == STATUS_INTERRUPTED
+        # And it survives the next poll, which is what makes the marker mean
+        # anything: get_job_status must not re-derive COMPLETED from the
+        # shutting-down instance.
+        assert mode.get_job_status([instance_id])[instance_id] == STATUS_INTERRUPTED
 
-            # Mock a spot interruption event
-            event = {
-                "detail-type": "EC2 Spot Instance Interruption Warning",
-                "source": "aws.ec2",
-                "detail": {
-                    "instance-id": mock_spot_instance_id,
-                    "instance-action": "terminate",
-                },
-            }
+    def test_an_untracked_instance_does_not_break_the_monitor(self, mode):
+        """A warning can arrive for an instance the mode no longer tracks.
 
-            # Save a checkpoint before interruption
-            checkpoint_data = {
-                "job_id": job_id,
-                "progress": 75,
-                "timestamp": time.time(),
-            }
+        The monitor polls on its own thread, so a job that finished and was
+        cleaned up between the poll and the dispatch is routine. Raising here
+        would kill the monitoring thread and take every *other* instance's
+        interruption handling down with it.
+        """
+        instance_id = f"i-{uuid.uuid4().hex[:16]}"
+        mode._register_spot_instance(instance_id)
 
-            # Set up task in handler
-            mode.spot_interruption_handler.register_task(job_id, mock_spot_instance_id)
-            uri = mode.spot_interruption_handler.save_checkpoint(
-                job_id, checkpoint_data
-            )
+        _interrupt_instance(mode.spot_interruption_monitor, instance_id)
 
-            # Trigger interruption handler
-            handler_func = mode.spot_interruption_monitor.instance_handlers[
-                mock_spot_instance_id
-            ]
-            handler_func(mock_spot_instance_id, event["detail"])
+        assert instance_id not in mode.resources
 
-            # Verify task was queued for recovery
-            assert not mode.spot_interruption_handler.recovery_queue.empty()
 
-            # Get the recovery task
-            recovery_task = mode.spot_interruption_handler.get_next_recovery_task()
-            assert recovery_task is not None
-            assert recovery_task["task_id"] == job_id
+class TestDetachedModeInterruption:
+    """DetachedMode's registrations have to survive a restart.
 
-            # Load the checkpoint
-            loaded_data = mode.spot_interruption_handler.load_checkpoint(job_id)
-            assert loaded_data is not None
-            assert loaded_data["job_id"] == job_id
-            assert loaded_data["progress"] == 75
+    Its whole reason to exist is that the driver can go away and come back, so a
+    registration held only in the monitor's in-memory dict would be lost exactly
+    when it is most needed.
+    """
 
-        finally:
-            # Clean up resources
-            if (
-                hasattr(mode, "spot_interruption_monitor")
-                and mode.spot_interruption_monitor
-            ):
-                mode.spot_interruption_monitor.stop_monitoring()
-
-            mode.cleanup_infrastructure()
-
-    @pytest.mark.substrate
-    def test_detached_mode_with_spot_interruption(
-        self,
-        substrate_session,
-        temp_state_store,
-        provider_id,
-        checkpoint_bucket,
-        mock_spot_instance_id,
-    ):
-        """Test that DetachedMode can handle spot interruptions."""
-        # Create DetachedMode instance with spot interruption handling
-        workflow_id = f"test-workflow-{uuid.uuid4().hex[:8]}"
-        mode = DetachedMode(
+    def _mode(self, session, state_store, provider_id, network, workflow_id):
+        return DetachedMode(
             provider_id=provider_id,
-            session=substrate_session,
-            state_store=temp_state_store,
+            session=session,
+            state_store=state_store,
             region="us-east-1",
-            instance_type="t2.micro",
-            image_id="ami-12345678",  # Dummy AMI ID for testing
+            instance_type="t3.micro",
+            image_id="ami-12345678",
+            vpc_id=network["vpc_id"],
+            subnet_id=network["subnet_id"],
+            security_group_id=network["security_group_id"],
             workflow_id=workflow_id,
-            bastion_instance_type="t2.micro",
-            bastion_host_type="direct",  # Use direct mode for simpler testing
+            bastion_instance_type="t3.micro",
+            bastion_host_type="direct",
             use_spot=True,
             spot_interruption_handling=True,
-            checkpoint_bucket=checkpoint_bucket,
-            checkpoint_prefix="test/checkpoints",
         )
 
-        try:
-            # Initialize mode
-            with patch.object(mode, "_create_bastion_host") as mock_create_bastion:
-                mock_create_bastion.return_value = {
-                    "instance_id": f"i-bastion-{uuid.uuid4().hex[:8]}",
-                    "private_ip": "10.0.0.2",
-                    "public_ip": "54.123.456.789",
-                    "dns_name": "ec2-54-123-456-789.compute-1.amazonaws.com",
-                }
-                mode.initialize()
-
-            # Verify spot interruption monitor was created
-            assert mode.spot_interruption_monitor is not None
-            assert mode.spot_interruption_handler is not None
-
-            # Mock instance creation response
-            with patch.object(mode, "_create_ec2_instance") as mock_create_instance:
-                mock_create_instance.return_value = {
-                    "instance_id": mock_spot_instance_id,
-                    "private_ip": "10.0.0.5",
-                    "public_ip": "54.123.456.789",
-                    "dns_name": "ec2-54-123-456-789.compute-1.amazonaws.com",
-                }
-
-                # Submit a job
-                job_id = f"test-job-{uuid.uuid4().hex[:8]}"
-                command = "echo hello"
-                resource_id = mode.submit_job(job_id, command, 1)
-
-            # Verify spot instance was registered with monitor
-            assert (
-                mock_spot_instance_id
-                in mode.spot_interruption_monitor.instance_handlers
-            )
-
-            # Verify state persistence
-            mode.save_state()
-
-            # Create a new mode instance to simulate restart
-            mode2 = DetachedMode(
-                provider_id=provider_id,
-                session=substrate_session,
-                state_store=temp_state_store,
-                region="us-east-1",
-                instance_type="t2.micro",
-                image_id="ami-12345678",  # Dummy AMI ID for testing
-                workflow_id=workflow_id,
-                bastion_instance_type="t2.micro",
-                bastion_host_type="direct",  # Use direct mode for simpler testing
-                use_spot=True,
-                spot_interruption_handling=True,
-                checkpoint_bucket=checkpoint_bucket,
-                checkpoint_prefix="test/checkpoints",
-            )
-
-            # Load state
-            mode2.load_state()
-
-            # Verify spot interruption monitor was recreated with the same registrations
-            assert mode2.spot_interruption_monitor is not None
-            assert (
-                mock_spot_instance_id
-                in mode2.spot_interruption_monitor.instance_handlers
-            )
-
-        finally:
-            # Clean up resources
-            if (
-                hasattr(mode, "spot_interruption_monitor")
-                and mode.spot_interruption_monitor
-            ):
-                mode.spot_interruption_monitor.stop_monitoring()
-
-            mode.preserve_bastion = False  # Ensure bastion cleanup
-            mode.cleanup_infrastructure()
-
-    @pytest.mark.substrate
-    def test_serverless_mode_with_spot_fleet(
-        self,
-        substrate_session,
-        temp_state_store,
-        provider_id,
-        checkpoint_bucket,
-        mock_spot_fleet_id,
+    def test_registrations_are_rebuilt_from_state_after_a_restart(
+        self, substrate_session, state_store, provider_id, network
     ):
-        """Test that ServerlessMode can handle spot fleet interruptions."""
-        # Create ServerlessMode instance with spot interruption handling
+        instance_id = f"i-{uuid.uuid4().hex[:16]}"
+        workflow_id = f"test-workflow-{uuid.uuid4().hex[:8]}"
+
+        first = self._mode(
+            substrate_session, state_store, provider_id, network, workflow_id
+        )
+        try:
+            first.resources[instance_id] = {
+                "type": RESOURCE_TYPE_EC2,
+                "job_id": "job-1",
+                "status": STATUS_RUNNING,
+                "is_spot": True,
+            }
+            first.save_state()
+        finally:
+            if first.spot_interruption_monitor:
+                first.spot_interruption_monitor.stop_monitoring()
+
+        second = self._mode(
+            substrate_session, state_store, provider_id, network, workflow_id
+        )
+        try:
+            assert second.load_state() is True
+
+            # Re-registered from the persisted resource record, without the
+            # instance ever being launched again.
+            assert instance_id in second.spot_interruption_monitor.instance_handlers
+
+            _interrupt_instance(second.spot_interruption_monitor, instance_id)
+
+            assert second.resources[instance_id]["status"] == STATUS_INTERRUPTED
+            # This mode reads status from a document the worker writes, so a
+            # reclaimed instance cannot report its own reclaim — it just stops
+            # updating. Re-deriving would overwrite the marker with a stale
+            # RUNNING.
+            assert (
+                second.get_job_status([instance_id])[instance_id] == STATUS_INTERRUPTED
+            )
+        finally:
+            if second.spot_interruption_monitor:
+                second.spot_interruption_monitor.stop_monitoring()
+
+
+class TestServerlessModeFleetInterruption:
+    """A fleet ID is never the resource key, in any mode.
+
+    ServerlessMode keys a fleet-backed job by ``serverless-<job_id>`` and records
+    the fleet as a ``fleet_request_id`` *field*, so the direct
+    ``resources[fleet_id]`` lookup ``handle_fleet_interruption`` used to do missed
+    every single time — the block Parsl holds kept reporting healthy straight
+    through the reclaim. This is that gap, closed and pinned.
+    """
+
+    @pytest.fixture
+    def mode(self, substrate_session, state_store, provider_id, network):
         mode = ServerlessMode(
             provider_id=provider_id,
             session=substrate_session,
-            state_store=temp_state_store,
+            state_store=state_store,
             region="us-east-1",
             worker_type="ecs",
-            ecs_task_cpu=256,
-            ecs_task_memory=512,
-            ecs_container_image="amazon/amazon-ecs-sample",
+            vpc_id=network["vpc_id"],
+            subnet_id=network["subnet_id"],
+            security_group_id=network["security_group_id"],
             use_spot=True,
             use_spot_fleet=True,
             spot_interruption_handling=True,
-            checkpoint_bucket=checkpoint_bucket,
-            checkpoint_prefix="test/checkpoints",
-            instance_types=["t2.micro", "t3.micro"],
+            instance_types=["t3.micro", "t3.small"],
+        )
+        yield mode
+        if mode.spot_interruption_monitor:
+            mode.spot_interruption_monitor.stop_monitoring()
+
+    def test_a_fleet_reclaim_reaches_the_block_that_records_the_fleet(self, mode):
+        fleet_id = f"fleet-{uuid.uuid4().hex[:12]}"
+        resource_id = "serverless-job-1"
+        instance_ids = [f"i-{uuid.uuid4().hex[:16]}" for _ in range(2)]
+
+        mode.resources[resource_id] = {
+            "job_id": "job-1",
+            "resource_type": RESOURCE_TYPE_SPOT_FLEET,
+            "use_spot_fleet": True,
+            "fleet_request_id": fleet_id,
+            "instance_ids": instance_ids,
+            "status": STATUS_RUNNING,
+        }
+        mode.spot_interruption_monitor.register_fleet(
+            fleet_id, mode.handle_fleet_interruption
         )
 
-        try:
-            # Initialize mode
-            mode.initialize()
+        _interrupt_fleet(mode.spot_interruption_monitor, fleet_id, instance_ids[:1])
 
-            # Verify spot interruption monitor was created
-            assert mode.spot_interruption_monitor is not None
-            assert mode.spot_interruption_handler is not None
+        assert mode.resources[resource_id]["status"] == STATUS_INTERRUPTED
+        # A reclaimed fleet still reports itself active, so re-deriving status
+        # from it would hand back a healthy-looking answer on the next poll.
+        assert mode.get_job_status([resource_id])[resource_id] == STATUS_INTERRUPTED
 
-            # Mock CloudFormation stack creation
-            with patch.object(
-                mode, "_create_cloudformation_stack"
-            ) as mock_create_stack:
-                mock_create_stack.return_value = {
-                    "stack_id": f"arn:aws:cloudformation:us-east-1:123456789012:stack/stack-{uuid.uuid4().hex[:8]}/abcdef12",
-                    "stack_name": f"stack-{uuid.uuid4().hex[:8]}",
-                }
+    def test_the_monitor_is_started_by_construction(self, mode):
+        """This mode starts monitoring in ``__init__``, unlike StandardMode.
 
-                # Mock CloudFormation stack description to include spot fleet ID
-                cf_client = substrate_session.client("cloudformation")
-                cf_client.describe_stacks.return_value = {
-                    "Stacks": [
-                        {
-                            "StackStatus": "CREATE_COMPLETE",
-                            "Outputs": [
-                                {
-                                    "OutputKey": "SpotFleetRequestId",
-                                    "OutputValue": mock_spot_fleet_id,
-                                }
-                            ],
-                        }
-                    ]
-                }
-
-                # Submit a job
-                job_id = f"test-job-{uuid.uuid4().hex[:8]}"
-                command = "echo hello"
-                resource_id = mode._submit_ecs_job(
-                    job_id, command, 1, "test-job", job_id
-                )
-
-            # Register fleet manually to test
-            mode.spot_interruption_monitor.register_fleet(
-                mock_spot_fleet_id,
-                mode.spot_interruption_handler.handle_fleet_interruption,
-            )
-
-            # Verify spot fleet was registered with monitor
-            assert mock_spot_fleet_id in mode.spot_interruption_monitor.fleet_handlers
-
-            # Mock a spot fleet interruption event
-            event = {
-                "detail-type": "EC2 Spot Fleet Interruption Warning",
-                "source": "aws.ec2",
-                "detail": {
-                    "spot-fleet-request-id": mock_spot_fleet_id,
-                    "instance-action": "terminate",
-                },
-            }
-
-            # Get a list of instances in the fleet (mock)
-            instance_ids = [f"i-fleet-{uuid.uuid4().hex[:8]}" for _ in range(2)]
-
-            # Trigger fleet interruption handler
-            handler_func = mode.spot_interruption_monitor.fleet_handlers[
-                mock_spot_fleet_id
-            ]
-            handler_func(mock_spot_fleet_id, instance_ids, event["detail"])
-
-            # Verify state persistence
-            mode.save_state()
-
-            # Create a new mode instance to simulate restart
-            mode2 = ServerlessMode(
-                provider_id=provider_id,
-                session=substrate_session,
-                state_store=temp_state_store,
-                region="us-east-1",
-                worker_type="ecs",
-                ecs_task_cpu=256,
-                ecs_task_memory=512,
-                ecs_container_image="amazon/amazon-ecs-sample",
-                use_spot=True,
-                use_spot_fleet=True,
-                spot_interruption_handling=True,
-                checkpoint_bucket=checkpoint_bucket,
-                checkpoint_prefix="test/checkpoints",
-                instance_types=["t2.micro", "t3.micro"],
-            )
-
-            # Load state
-            mode2.load_state()
-
-            # Verify fleet resources were restored in state
-            assert mode2.spot_interruption_monitor is not None
-
-            # Re-register fleet for testing
-            mode2.spot_interruption_monitor.register_fleet(
-                mock_spot_fleet_id,
-                mode2.spot_interruption_handler.handle_fleet_interruption,
-            )
-
-            assert mock_spot_fleet_id in mode2.spot_interruption_monitor.fleet_handlers
-
-        finally:
-            # Clean up resources
-            if (
-                hasattr(mode, "spot_interruption_monitor")
-                and mode.spot_interruption_monitor
-            ):
-                mode.spot_interruption_monitor.stop_monitoring()
-
-            mode.cleanup_infrastructure()
+        Worth pinning: a monitor nobody started detects nothing, and the
+        difference between the two modes is easy to lose in a refactor.
+        """
+        assert isinstance(mode.spot_interruption_monitor, SpotInterruptionMonitor)
+        assert mode.spot_interruption_monitor.monitoring_thread.is_alive()

--- a/tests/integration/test_spot_interruption_substrate.py
+++ b/tests/integration/test_spot_interruption_substrate.py
@@ -1,456 +1,223 @@
-"""Integration tests for spot interruption handling with substrate.
+"""Integration tests for spot interruption detection against substrate.
 
-This module focuses on testing spot interruption handling with substrate's
-mocked AWS services, simulating actual AWS API calls and responses.
+The monitor is exercised against a real endpoint rather than MagicMocks, so every
+call it makes has to be a shape the emulator will actually answer: SQS
+receive/delete, ``describe_instances``, tag-filtered pagination.
+
+The ``substrate_session`` fixture comes from ``tests/conftest.py`` deliberately
+rather than being redefined here. It wraps ``session.client`` to bind
+``endpoint_url``; ``get_substrate_session()`` alone returns a plain session with
+synthetic credentials and no endpoint, so clients built from it reach *real* AWS
+and fail on authentication.
+
+Two substrate limitations shape what is testable, both verified against the
+running emulator rather than assumed:
+
+* ``events`` is not emulated -- ``PutRule`` returns ``501 service not emulated:
+  awsevents``. That makes the degradation path in
+  :meth:`test_the_notifier_degrades_when_eventbridge_is_absent` testable for
+  real. The warning path itself is still covered end to end by wiring a queue
+  directly, since the monitor only ever reads warnings through SQS.
+* ``InstanceLifecycle`` is never set, even for ``InstanceMarketOptions``
+  ``MarketType: spot``, so the EC2-state track cannot fire here at all -- it
+  requires ``InstanceLifecycle == "spot"``. That branch stays with the mocked
+  unit tests; here the instances are real and the queue is the input.
+
+The checkpoint/recovery API these tests used to cover was deleted in #137: its
+entry point was ``register_task(task_id, instance_id)``, and a Parsl provider is
+never told a task ID.
 
 SPDX-License-Identifier: Apache-2.0
 SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
 """
 
-import pytest
-import time
 import json
 import uuid
-from unittest.mock import patch
 
-from parsl_ephemeral_aws.compute.spot_interruption import (
-    SpotInterruptionMonitor,
-    SpotInterruptionHandler,
-    ParslSpotInterruptionHandler,
-    checkpointable,
-)
-from tests.substrate_support import (
-    get_substrate_session,
-    is_substrate_available,
-)
+import pytest
 
+from parsl_ephemeral_aws.compute.spot_interruption import SpotInterruptionMonitor
 
-@pytest.fixture(scope="session")
-def substrate_available():
-    """Check if substrate is available for testing."""
-    if not is_substrate_available():
-        pytest.skip("substrate not available - start with 'make substrate-up'")
-    return True
-
-
-@pytest.fixture(scope="session")
-def substrate_session(substrate_available):
-    """Create a session connected to substrate."""
-    return get_substrate_session()
+pytestmark = [pytest.mark.integration, pytest.mark.substrate]
 
 
 @pytest.fixture
-def checkpoint_bucket(substrate_session):
-    """Create a temporary S3 bucket for checkpoints."""
-    bucket_name = f"test-checkpoint-bucket-{uuid.uuid4().hex[:8]}"
-    s3_client = substrate_session.client("s3")
+def warning_queue(substrate_session):
+    """An SQS queue standing in for the one the EventBridge rule delivers to.
+
+    Substrate cannot create the rule, but the monitor reads warnings only through
+    SQS, so a queue wired in directly exercises the identical code path with the
+    identical message shape.
+    """
+    sqs = substrate_session.client("sqs")
+    url = sqs.create_queue(QueueName=f"spot-warning-{uuid.uuid4().hex[:8]}")["QueueUrl"]
+
+    yield url
 
     try:
-        s3_client.create_bucket(Bucket=bucket_name)
-    except Exception as e:
-        pytest.skip(f"Failed to create S3 bucket: {e}")
-
-    yield bucket_name
-
-    # Cleanup
-    try:
-        # Delete all objects in the bucket
-        objects = s3_client.list_objects_v2(Bucket=bucket_name)
-        if "Contents" in objects:
-            delete_keys = {
-                "Objects": [{"Key": obj["Key"]} for obj in objects["Contents"]]
-            }
-            s3_client.delete_objects(Bucket=bucket_name, Delete=delete_keys)
-
-        # Delete the bucket
-        s3_client.delete_bucket(Bucket=bucket_name)
-    except Exception as e:
-        print(f"Error cleaning up bucket {bucket_name}: {e}")
+        sqs.delete_queue(QueueUrl=url)
+    except Exception as exc:  # pragma: no cover - cleanup only
+        print(f"Error cleaning up queue {url}: {exc}")
 
 
-@pytest.fixture
-def cloudwatch_event_client(substrate_session):
-    """Create a CloudWatch Events client."""
-    return substrate_session.client("events")
-
-
-@pytest.fixture
-def setup_cloudwatch_events(cloudwatch_event_client):
-    """Set up CloudWatch Events for spot interruption testing."""
-    # Create rule for spot instance interruption warnings
-    rule_name = f"spot-interruption-rule-{uuid.uuid4().hex[:8]}"
-    cloudwatch_event_client.put_rule(
-        Name=rule_name,
-        EventPattern=json.dumps(
-            {
-                "source": ["aws.ec2"],
-                "detail-type": ["EC2 Spot Instance Interruption Warning"],
-            }
-        ),
+def _warning_body(instance_id, action="terminate"):
+    """Build the EventBridge envelope AWS delivers for a reclaim warning."""
+    return json.dumps(
+        {
+            "source": "aws.ec2",
+            "detail-type": "EC2 Spot Instance Interruption Warning",
+            "detail": {"instance-id": instance_id, "instance-action": action},
+        }
     )
 
-    yield rule_name
 
-    # Cleanup rule
-    try:
-        cloudwatch_event_client.delete_rule(Name=rule_name)
-    except Exception as e:
-        print(f"Error cleaning up CloudWatch Events rule {rule_name}: {e}")
-
-
-@pytest.mark.integration
 class TestSpotInterruptionSubstrate:
-    """Integration tests for spot interruption using substrate."""
+    """Detection driven against substrate's AWS endpoint."""
 
-    @pytest.mark.substrate
-    def test_s3_checkpoint_persistence(self, substrate_session, checkpoint_bucket):
-        """Test that checkpoints can be saved and loaded from S3."""
-        task_id = f"test-task-{uuid.uuid4().hex[:8]}"
-        checkpoint_data = {
-            "task_id": task_id,
-            "state": "running",
-            "iteration": 42,
-            "results": [1, 2, 3, 4],
-            "timestamp": time.time(),
-        }
+    def test_the_notifier_degrades_when_eventbridge_is_absent(self, substrate_session):
+        """A notifier that cannot be created must not fail the workflow.
 
-        # Create handler
-        handler = SpotInterruptionHandler(
-            session=substrate_session,
-            checkpoint_bucket=checkpoint_bucket,
-            checkpoint_prefix="test/checkpoints",
+        Every mode starts the monitor during ``initialize()``, so raising here
+        would take down a provider that could otherwise run perfectly well --
+        just without advance warning. Substrate's missing ``events`` service
+        makes this the realistic failure; an IAM policy lacking
+        ``events:PutRule`` produces the same shape.
+        """
+        monitor = SpotInterruptionMonitor(
+            session=substrate_session, check_interval=1, provider_id="degrade-test"
         )
 
-        # Save checkpoint
-        uri = handler.save_checkpoint(task_id, checkpoint_data)
-        assert uri == f"s3://{checkpoint_bucket}/test/checkpoints/{task_id}.json"
-
-        # Verify object exists in S3
-        s3_client = substrate_session.client("s3")
-        response = s3_client.list_objects_v2(
-            Bucket=checkpoint_bucket, Prefix=f"test/checkpoints/{task_id}"
-        )
-
-        assert "Contents" in response
-        assert len(response["Contents"]) == 1
-        assert response["Contents"][0]["Key"] == f"test/checkpoints/{task_id}.json"
-
-        # Load checkpoint directly from S3
-        obj = s3_client.get_object(
-            Bucket=checkpoint_bucket, Key=f"test/checkpoints/{task_id}.json"
-        )
-
-        loaded_data = json.loads(obj["Body"].read().decode("utf-8"))
-        assert loaded_data == checkpoint_data
-
-        # Load checkpoint using handler
-        handler_loaded_data = handler.load_checkpoint(task_id)
-        assert handler_loaded_data == checkpoint_data
-
-    @pytest.mark.substrate
-    def test_checkpointable_decorator_with_s3(
-        self, substrate_session, checkpoint_bucket
-    ):
-        """Test that the checkpointable decorator works with real S3."""
-        s3_client = substrate_session.client("s3")
-
-        # Define a checkpointable function
-        @checkpointable(
-            checkpoint_bucket=checkpoint_bucket, checkpoint_prefix="test/checkpoints"
-        )
-        def test_function(iterations=5, checkpoint_data=None):
-            # Initialize state
-            if checkpoint_data:
-                state = checkpoint_data
-                print(f"Resuming from iteration {state['iteration']}")
-            else:
-                state = {"iteration": 0, "result": 0}
-                print("Starting new computation")
-
-            # Process iterations with checkpointing
-            for i in range(state["iteration"], iterations):
-                state["result"] += i
-                state["iteration"] = i + 1
-                print(f"Iteration {i + 1}/{iterations}, result: {state['result']}")
-
-                # Yield checkpoint at each iteration
-                yield state
-
-            return state["result"]
-
-        # Run function to completion
-        result = test_function(iterations=5)
-        assert result == 10  # 0+1+2+3+4=10
-
-        # Verify checkpoints were created in S3
-        response = s3_client.list_objects_v2(
-            Bucket=checkpoint_bucket, Prefix="test/checkpoints"
-        )
-
-        # Should have at least one checkpoint
-        assert "Contents" in response
-
-        # Get the latest checkpoint
-        checkpoints = sorted(
-            response["Contents"], key=lambda x: x["LastModified"], reverse=True
-        )
-        latest_checkpoint_key = checkpoints[0]["Key"]
-
-        # Load the checkpoint
-        obj = s3_client.get_object(Bucket=checkpoint_bucket, Key=latest_checkpoint_key)
-
-        checkpoint_data = json.loads(obj["Body"].read().decode("utf-8"))
-        assert checkpoint_data["iteration"] == 5
-        assert checkpoint_data["result"] == 10
-
-        # Now simulate interruption by running with the checkpoint
-        # We'll start from the 3rd iteration (iteration=2)
-        interrupted_checkpoint = {
-            "iteration": 2,
-            "result": 3,  # 0+1+2=3
-        }
-
-        # Save this checkpoint manually
-        interrupted_task_id = latest_checkpoint_key.split("/")[-1].split(".")[0]
-        s3_client.put_object(
-            Bucket=checkpoint_bucket,
-            Key=f"test/checkpoints/{interrupted_task_id}.json",
-            Body=json.dumps(interrupted_checkpoint),
-        )
-
-        # Run the function again - it should load the checkpoint
-        with patch(
-            "parsl_ephemeral_aws.compute.spot_interruption.boto3.Session"
-        ) as mock_session:
-            # Return the real substrate session
-            mock_session.return_value = substrate_session
-
-            # Run with the latest task_id which has our interrupted checkpoint
-            result = test_function(task_id=interrupted_task_id)
-
-            # Should complete from iteration 2 onwards: 3+4=7, plus existing 3 = 10
-            assert result == 10
-
-    @pytest.mark.substrate
-    def test_spot_interruption_event_detection(
-        self, substrate_session, checkpoint_bucket, setup_cloudwatch_events
-    ):
-        """Test that spot interruption events can be detected and processed."""
-        # Create a spot interruption monitor
-        monitor = SpotInterruptionMonitor(session=substrate_session)
-
-        # Create a handler for tests
-        handler = SpotInterruptionHandler(
-            session=substrate_session,
-            checkpoint_bucket=checkpoint_bucket,
-            checkpoint_prefix="test/interruptions",
-        )
-
-        # Create a mock handler function to track interruption events
-        interruption_events = []
-
-        def mock_interruption_handler(instance_id, event):
-            interruption_events.append({"instance_id": instance_id, "event": event})
-
-        # Register an instance
-        instance_id = f"i-spot-{uuid.uuid4().hex[:8]}"
-        monitor.register_instance(instance_id, mock_interruption_handler)
-
-        # Start monitoring
         monitor.start_monitoring()
-
-        # Simulate an interruption notice event
-        cloudwatch_event_client = substrate_session.client("events")
-
-        event_detail = {
-            "instance-id": instance_id,
-            "instance-action": "terminate",
-            "time": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-        }
-
-        # Put the event - the emulator should deliver it to our monitor
-        # Note: the emulator may not fully simulate event delivery to our monitor
-        # This is a limitation of the testing environment
         try:
-            cloudwatch_event_client.put_events(
-                Entries=[
-                    {
-                        "Source": "aws.ec2",
-                        "DetailType": "EC2 Spot Instance Interruption Warning",
-                        "Detail": json.dumps(event_detail),
-                        "Resources": [
-                            f"arn:aws:ec2:us-east-1:123456789012:instance/{instance_id}"
-                        ],
-                    }
-                ]
-            )
-
-            # In a real environment, we would wait for the event to be processed
-            # Against the emulator, mock this by directly calling the handler
-            monitor._handle_instance_interruption(instance_id, event_detail)
-
-            # Verify the handler was called
-            assert len(interruption_events) == 1
-            assert interruption_events[0]["instance_id"] == instance_id
-            assert interruption_events[0]["event"] == event_detail
-
+            assert monitor.monitoring_thread.is_alive()
+            # Running on the EC2-state track alone, with no notifier behind it.
+            assert monitor.warning_rule_name is None
+            assert monitor.warning_queue_url is None
         finally:
-            # Stop monitoring
             monitor.stop_monitoring()
 
-    @pytest.mark.substrate
-    def test_spot_fleet_interruption(self, substrate_session, checkpoint_bucket):
-        """Test handling of spot fleet interruptions."""
-        # Create a spot interruption monitor
-        monitor = SpotInterruptionMonitor(session=substrate_session)
+        assert monitor.monitoring_thread is None
 
-        # Create a handler for tests
-        handler = SpotInterruptionHandler(
-            session=substrate_session,
-            checkpoint_bucket=checkpoint_bucket,
-            checkpoint_prefix="test/fleet-interruptions",
+    def test_a_queued_warning_reaches_the_instance_handler(
+        self, substrate_session, warning_queue
+    ):
+        """The warning path, end to end over real SQS.
+
+        This is the track that matters: it fires while the instance is still
+        running, the only point at which anything can be done about the reclaim.
+        """
+        monitor = SpotInterruptionMonitor(session=substrate_session, check_interval=1)
+        monitor.warning_queue_url = warning_queue
+
+        seen = []
+        instance_id = f"i-{uuid.uuid4().hex[:16]}"
+        monitor.register_instance(
+            instance_id, lambda iid, event: seen.append((iid, event))
         )
 
-        # Create a mock handler function to track fleet interruption events
-        fleet_interruption_events = []
+        sqs = substrate_session.client("sqs")
+        sqs.send_message(QueueUrl=warning_queue, MessageBody=_warning_body(instance_id))
 
-        def mock_fleet_handler(fleet_id, instance_ids, event):
-            fleet_interruption_events.append(
-                {"fleet_id": fleet_id, "instance_ids": instance_ids, "event": event}
-            )
+        monitor._poll_warning_queue(sqs, substrate_session.client("ec2"))
+        monitor._process_interruption_events()
 
-        # Register a fleet
-        fleet_id = f"sfr-{uuid.uuid4().hex[:8]}"
-        instance_ids = [f"i-fleet-{uuid.uuid4().hex[:8]}" for _ in range(3)]
+        assert len(seen) == 1
+        handled_id, event = seen[0]
+        assert handled_id == instance_id
+        assert event["InstanceAction"] == "terminate"
+        # Marks this as the advance track, so a handler can tell it still has
+        # roughly two minutes rather than none.
+        assert event["Source"] == "eventbridge"
 
-        monitor.register_fleet(fleet_id, mock_fleet_handler)
+    def test_a_warning_for_an_unowned_instance_is_dropped(
+        self, substrate_session, warning_queue
+    ):
+        """The rule matches the whole account and region, not our instances.
 
-        # Start monitoring
-        monitor.start_monitoring()
+        Their IDs are not known until launch, so the pattern cannot be scoped.
+        Warnings for instances this monitor does not track are therefore the
+        common case, and must be dropped silently rather than raising into the
+        monitoring thread.
+        """
+        monitor = SpotInterruptionMonitor(session=substrate_session, check_interval=1)
+        monitor.warning_queue_url = warning_queue
 
-        # Simulate a fleet interruption
-        event_detail = {
-            "spot-fleet-request-id": fleet_id,
-            "instance-action": "terminate",
-            "time": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-        }
+        seen = []
+        monitor.register_instance("i-ours", lambda iid, event: seen.append(iid))
+
+        sqs = substrate_session.client("sqs")
+        sqs.send_message(
+            QueueUrl=warning_queue, MessageBody=_warning_body("i-somebody-elses")
+        )
+
+        monitor._poll_warning_queue(sqs, substrate_session.client("ec2"))
+        monitor._process_interruption_events()
+
+        assert seen == []
+        # And the message is gone: deletion happens before parsing, so an unowned
+        # warning cannot be redelivered on every poll for the whole retention
+        # period.
+        remaining = sqs.receive_message(QueueUrl=warning_queue, MaxNumberOfMessages=10)
+        assert remaining.get("Messages", []) == []
+
+    def test_an_unparseable_warning_is_deleted_not_retried(
+        self, substrate_session, warning_queue
+    ):
+        """A malformed body must not wedge the queue."""
+        monitor = SpotInterruptionMonitor(session=substrate_session, check_interval=1)
+        monitor.warning_queue_url = warning_queue
+
+        sqs = substrate_session.client("sqs")
+        sqs.send_message(QueueUrl=warning_queue, MessageBody="not json at all")
+
+        monitor._poll_warning_queue(sqs, substrate_session.client("ec2"))
+
+        assert monitor.event_queue.empty()
+        remaining = sqs.receive_message(QueueUrl=warning_queue, MaxNumberOfMessages=10)
+        assert remaining.get("Messages", []) == []
+
+    def test_a_fleet_instance_warning_reaches_the_fleet_handler(
+        self, substrate_session, warning_queue
+    ):
+        """A warning names an instance; the handler owed it may own the fleet.
+
+        The link is the reserved ``aws:ec2:fleet-id`` tag EC2 stamps on every
+        fleet-launched instance -- the only workable route, since
+        ``describe_fleet_instances`` rejects an instant fleet outright (#86).
+        Substrate serves both ``create_tags`` and the tag filter, so the lookup
+        is exercised for real here rather than mocked.
+        """
+        ec2 = substrate_session.client("ec2")
+        fleet_id = f"fleet-{uuid.uuid4().hex[:12]}"
+        instance_id = ec2.run_instances(
+            ImageId="ami-12345678", MinCount=1, MaxCount=1, InstanceType="t3.micro"
+        )["Instances"][0]["InstanceId"]
+        ec2.create_tags(
+            Resources=[instance_id],
+            Tags=[{"Key": "aws:ec2:fleet-id", "Value": fleet_id}],
+        )
+
+        monitor = SpotInterruptionMonitor(session=substrate_session, check_interval=1)
+        monitor.warning_queue_url = warning_queue
+
+        seen = []
+        monitor.register_fleet(
+            fleet_id, lambda fid, iids, event: seen.append((fid, iids, event))
+        )
+
+        sqs = substrate_session.client("sqs")
+        sqs.send_message(QueueUrl=warning_queue, MessageBody=_warning_body(instance_id))
 
         try:
-            # Against the emulator, mock this by directly calling the handler
-            monitor._handle_fleet_interruption(fleet_id, instance_ids, event_detail)
+            monitor._poll_warning_queue(sqs, ec2)
+            monitor._process_interruption_events()
 
-            # Verify the handler was called
-            assert len(fleet_interruption_events) == 1
-            assert fleet_interruption_events[0]["fleet_id"] == fleet_id
-            assert fleet_interruption_events[0]["instance_ids"] == instance_ids
-            assert fleet_interruption_events[0]["event"] == event_detail
-
+            assert len(seen) == 1
+            handled_fleet, instance_ids, event = seen[0]
+            assert handled_fleet == fleet_id
+            # Only the warned instance, not the whole fleet: a reclaim is
+            # per-instance, and taking the rest down would be gratuitous.
+            assert instance_ids == [instance_id]
+            assert event["FleetRequestId"] == fleet_id
         finally:
-            # Stop monitoring
-            monitor.stop_monitoring()
-
-    @pytest.mark.substrate
-    def test_parsl_handler_recovery_queue(self, substrate_session, checkpoint_bucket):
-        """Test the recovery queue in ParslSpotInterruptionHandler."""
-        # Create handler
-        handler = ParslSpotInterruptionHandler(
-            session=substrate_session,
-            checkpoint_bucket=checkpoint_bucket,
-            checkpoint_prefix="test/recovery",
-        )
-
-        # Queue tasks for recovery with different priorities
-        task_ids = [f"task-{uuid.uuid4().hex[:8]}" for _ in range(5)]
-        priorities = [
-            3,
-            1,
-            5,
-            2,
-            4,
-        ]  # Mix of priorities, lower number = higher priority
-
-        for i, task_id in enumerate(task_ids):
-            # Create a checkpoint
-            checkpoint_data = {
-                "task_id": task_id,
-                "priority": priorities[i],
-                "state": "interrupted",
-                "progress": i * 20,  # 0, 20, 40, 60, 80
-            }
-
-            # Save checkpoint
-            uri = handler.save_checkpoint(task_id, checkpoint_data)
-
-            # Queue for recovery
-            handler.queue_task_for_recovery(task_id, uri, priorities[i])
-
-        # Get tasks in priority order
-        recovered_tasks = []
-        while not handler.recovery_queue.empty():
-            task = handler.get_next_recovery_task()
-            recovered_tasks.append(task)
-
-        # Verify tasks were recovered in priority order
-        expected_order = sorted(range(5), key=lambda i: priorities[i])
-        for i, task_idx in enumerate(expected_order):
-            assert recovered_tasks[i]["task_id"] == task_ids[task_idx]
-            assert recovered_tasks[i]["priority"] == priorities[task_idx]
-
-    @pytest.mark.substrate
-    def test_checkpoint_interval_timing(self, substrate_session, checkpoint_bucket):
-        """Test that checkpoints are created at the specified interval."""
-        # Set a short checkpoint interval for testing
-        checkpoint_interval = 0.5  # seconds
-
-        # Define a checkpointable function with forced timing
-        @checkpointable(
-            checkpoint_bucket=checkpoint_bucket,
-            checkpoint_prefix="test/intervals",
-            checkpoint_interval=checkpoint_interval,
-        )
-        def timed_function(iterations=10, checkpoint_data=None):
-            # Initialize state
-            if checkpoint_data:
-                state = checkpoint_data
-            else:
-                state = {"iteration": 0, "result": 0, "checkpoints": []}
-
-            # Process iterations with checkpointing
-            for i in range(state["iteration"], iterations):
-                # Do some work
-                state["result"] += i
-                state["iteration"] = i + 1
-
-                # Record checkpoint times
-                if "last_checkpoint_time" in state:
-                    time_since_last = time.time() - state["last_checkpoint_time"]
-                    state["checkpoints"].append(time_since_last)
-
-                state["last_checkpoint_time"] = time.time()
-
-                # Yield state for checkpointing
-                yield state
-
-                # Sleep to control timing
-                time.sleep(0.1)  # Short sleep between iterations
-
-            return state
-
-        # Run the function
-        result = timed_function(iterations=8)
-
-        # Verify checkpoints were created at the correct interval
-        # The first checkpoint happens immediately, so we start checking from the second
-        intervals = result["checkpoints"][1:]
-        assert len(intervals) > 0
-
-        # Allow some timing flexibility (between 0.4x and 2x the interval)
-        # This is to account for test environment variability
-        for interval in intervals:
-            assert interval >= checkpoint_interval * 0.4, (
-                f"Interval {interval} is too short"
-            )
-            # Upper bound is more flexible as scheduling can delay things
-            assert interval <= checkpoint_interval * 2.0, (
-                f"Interval {interval} is too long"
-            )
+            ec2.terminate_instances(InstanceIds=[instance_id])

--- a/tests/integration/test_workflow_error_scenarios.py
+++ b/tests/integration/test_workflow_error_scenarios.py
@@ -8,7 +8,6 @@ SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
 """
 
 import os
-import time
 import uuid
 import pytest
 import tempfile
@@ -472,87 +471,59 @@ class TestWorkflowErrorScenarios:
             assert mode.security_group_id is None
 
     @pytest.mark.substrate
-    def test_spot_instance_interruption(self, substrate_session, file_state_store):
-        """Test handling of spot instance interruption."""
-        # Create a StandardMode instance with spot instances
+    def test_a_spot_interruption_is_reported_as_a_failure(
+        self, substrate_session, file_state_store
+    ):
+        """A reclaim must surface as a failure, not a success.
+
+        This is the error scenario this file is about: AWS takes the capacity
+        away mid-job. What made it dangerous was not that it went unhandled but
+        that it was reported *wrongly* -- a reclaimed instance reaches
+        ``shutting-down``, which ``EC2_STATUS_MAPPING`` renders COMPLETED, so the
+        block claimed success and its tasks were silently dropped rather than
+        re-run under Parsl's ``retries`` (#137).
+        """
         provider_id = f"test-provider-{uuid.uuid4().hex[:8]}"
+        instance_id = "i-spot-12345"
 
-        # Set up mocks for AWS services using substrate
-        with patch("boto3.Session", return_value=substrate_session):
-            # Create a standard mode with spot instances
-            mode = StandardMode(
-                provider_id=provider_id,
-                session=substrate_session,
-                state_store=file_state_store,
-                region="us-east-1",
-                instance_type="t2.micro",
-                image_id="ami-12345678",  # Dummy AMI
-                use_spot=True,
-                spot_interruption_handling=True,
-            )
+        mode = StandardMode(
+            provider_id=provider_id,
+            session=substrate_session,
+            state_store=file_state_store,
+            region="us-east-1",
+            instance_type="t3.micro",
+            image_id="ami-12345678",
+            vpc_id="vpc-12345",
+            subnet_id="subnet-12345",
+            security_group_id="sg-12345",
+            use_spot=True,
+            spot_interruption_handling=True,
+        )
 
-            # Initialize mode
-            with patch.object(mode, "_create_vpc", return_value="vpc-12345"):
-                with patch.object(mode, "_create_subnet", return_value="subnet-12345"):
-                    with patch.object(
-                        mode, "_create_security_group", return_value="sg-12345"
-                    ):
-                        mode.initialize()
-
-            # Verify spot interruption handler is set up
+        try:
             assert mode.spot_interruption_monitor is not None
-            assert mode.spot_interruption_handler is not None
 
-            # Create a spot instance
-            with patch.object(mode, "_create_ec2_instance") as mock_create_instance:
-                # Return a spot instance
-                instance_id = "i-spot-12345"
-                mock_create_instance.return_value = {
-                    "instance_id": instance_id,
-                    "private_ip": "10.0.0.1",
-                    "public_ip": "54.123.456.789",
-                    "dns_name": "ec2-54-123-456-789.compute-1.amazonaws.com",
-                    "spot_instance": True,
-                }
-
-                # Submit a job
-                job_id = f"test-job-{uuid.uuid4().hex[:8]}"
-                resource_id = mode.submit_job(job_id, "echo 'Test job'", 1)
-
-            # Verify instance was registered with the spot interruption monitor
+            mode.resources[instance_id] = {
+                "type": "ec2",
+                "job_id": f"test-job-{uuid.uuid4().hex[:8]}",
+                "status": "RUNNING",
+                "is_spot": True,
+            }
+            # The registration every spot launch performs.
+            mode._register_spot_instance(instance_id)
             assert instance_id in mode.spot_interruption_monitor.instance_handlers
 
-            # Simulate spot interruption event
-            with patch.object(mode, "_create_ec2_instance") as mock_create_instance:
-                # Return a new spot instance (replacement)
-                new_instance_id = "i-spot-replacement"
-                mock_create_instance.return_value = {
-                    "instance_id": new_instance_id,
-                    "private_ip": "10.0.0.2",
-                    "public_ip": "54.123.456.790",
-                    "dns_name": "ec2-54-123-456-790.compute-1.amazonaws.com",
-                    "spot_instance": True,
-                }
-
-                # Mock resource state to job mapping
-                mode.resource_job_mapping = {resource_id: job_id}
-
-                # Trigger the spot interruption handler
-                handler = mode.spot_interruption_monitor.instance_handlers[instance_id]
-                handler(
+            mode.spot_interruption_monitor.event_queue.put(
+                (
+                    "instance",
                     instance_id,
-                    {
-                        "InstanceAction": "terminate",
-                        "InstanceId": instance_id,
-                        "Time": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-                    },
+                    {"InstanceId": instance_id, "InstanceAction": "terminate"},
                 )
+            )
+            mode.spot_interruption_monitor._process_interruption_events()
 
-            # Clean up
-            with patch.object(mode, "_delete_ec2_instance"):
-                with patch.object(mode, "_delete_security_group"):
-                    with patch.object(mode, "_delete_subnet"):
-                        with patch.object(mode, "_delete_vpc"):
-                            if mode.spot_interruption_monitor:
-                                mode.spot_interruption_monitor.stop_monitoring()
-                            mode.cleanup_infrastructure()
+            assert mode.resources[instance_id]["status"] == "INTERRUPTED"
+            assert mode.get_job_status([instance_id])[instance_id] == "INTERRUPTED"
+        finally:
+            if mode.spot_interruption_monitor:
+                mode.spot_interruption_monitor.stop_monitoring()

--- a/tests/integration/test_workflow_state_persistence.py
+++ b/tests/integration/test_workflow_state_persistence.py
@@ -408,122 +408,88 @@ class TestWorkflowStatePersistence:
             assert len(mode2.resources) == 0
 
     @pytest.mark.substrate
-    def test_interruption_and_recovery(self, substrate_session, file_state_store):
-        """Test interruption and recovery with state persistence."""
-        # Create a StandardMode instance
+    def test_an_interruption_survives_a_restart(
+        self, substrate_session, file_state_store
+    ):
+        """An interrupted block must still read as interrupted after a restart.
+
+        A reclaim is precisely the event most likely to be followed by the driver
+        going away, so a marker held only in memory would be lost exactly when it
+        matters. If the restored block came back RUNNING, the provider would keep
+        waiting on capacity AWS already took, and if it came back COMPLETED --
+        which is what ``EC2_STATUS_MAPPING`` makes of a ``shutting-down``
+        instance -- its tasks would be silently dropped instead of re-run (#137).
+
+        This used to test a checkpoint/recovery API that #137 deleted: its entry
+        point was ``register_task(task_id, instance_id)``, and a Parsl provider is
+        never told a task ID. What replaces it is the response that *is*
+        implementable at this layer -- mark the block, let Parsl's own ``retries``
+        re-run the tasks -- checked across the persistence boundary this file
+        exists to cover.
+        """
         provider_id = f"test-provider-{uuid.uuid4().hex[:8]}"
+        instance_id = f"i-spot-{uuid.uuid4().hex[:12]}"
 
-        # Set up mocks for AWS services using substrate
-        with patch("boto3.Session", return_value=substrate_session):
-            # Create a standard mode
-            mode = StandardMode(
+        def build_mode():
+            return StandardMode(
                 provider_id=provider_id,
                 session=substrate_session,
                 state_store=file_state_store,
                 region="us-east-1",
-                instance_type="t2.micro",
-                image_id="ami-12345678",  # Dummy AMI
-                use_spot=True,  # Enable spot instances
-                spot_interruption_handling=True,  # Enable spot interruption handling
-            )
-
-            # Initialize mode - mock infrastructure creation
-            with patch.object(mode, "_create_vpc", return_value="vpc-12345"):
-                with patch.object(mode, "_create_subnet", return_value="subnet-12345"):
-                    with patch.object(
-                        mode, "_create_security_group", return_value="sg-12345"
-                    ):
-                        mode.initialize()
-
-            # Verify mode is initialized with spot interruption handling
-            assert mode.initialized
-            assert mode.spot_interruption_monitor is not None
-            assert mode.spot_interruption_handler is not None
-
-            # Mock job submission with spot instance
-            with patch.object(mode, "_create_ec2_instance") as mock_create_instance:
-                instance_id = f"i-spot-{uuid.uuid4().hex[:12]}"
-                mock_create_instance.return_value = {
-                    "instance_id": instance_id,
-                    "private_ip": "10.0.0.1",
-                    "public_ip": "54.123.456.789",
-                    "dns_name": "ec2-54-123-456-789.compute-1.amazonaws.com",
-                    "spot_instance": True,
-                }
-
-                # Submit a job
-                job_id = f"test-job-{uuid.uuid4().hex[:8]}"
-                resource_id = mode.submit_job(job_id, "echo 'Test job'", 1)
-
-            # Verify resource was created and registered
-            assert resource_id in mode.resources
-            assert instance_id in mode.spot_interruption_monitor.instance_handlers
-
-            # Save state
-            mode.save_state()
-
-            # Simulate spot interruption by manually calling the handler
-            event = {
-                "InstanceId": instance_id,
-                "InstanceAction": "terminate",
-                "Time": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-            }
-
-            # Register a mock task with the handler
-            mode.spot_interruption_handler.register_task(job_id, instance_id)
-
-            # Save checkpoint data
-            checkpoint_data = {
-                "job_id": job_id,
-                "progress": 50,
-                "timestamp": time.time(),
-            }
-            mode.spot_interruption_handler.save_checkpoint(job_id, checkpoint_data)
-
-            # Trigger spot interruption handler
-            handler_func = mode.spot_interruption_monitor.instance_handlers[instance_id]
-            handler_func(instance_id, event)
-
-            # Verify task was queued for recovery
-            assert not mode.spot_interruption_handler.recovery_queue.empty()
-
-            # Save state after interruption
-            mode.save_state()
-
-            # Create a new mode instance to simulate restart
-            mode2 = StandardMode(
-                provider_id=provider_id,
-                session=substrate_session,
-                state_store=file_state_store,
-                region="us-east-1",
-                instance_type="t2.micro",
-                image_id="ami-12345678",  # Dummy AMI
+                instance_type="t3.micro",
+                image_id="ami-12345678",
+                vpc_id="vpc-12345",
+                subnet_id="subnet-12345",
+                security_group_id="sg-12345",
                 use_spot=True,
                 spot_interruption_handling=True,
             )
 
-            # Load state
-            mode2.load_state()
+        mode = build_mode()
+        try:
+            mode.resources[instance_id] = {
+                "type": "ec2",
+                "job_id": f"test-job-{uuid.uuid4().hex[:8]}",
+                "status": "RUNNING",
+                "is_spot": True,
+                "created_at": time.time(),
+            }
+            # The real registration path, as used by every spot launch.
+            mode._register_spot_instance(instance_id)
 
-            # Verify spot interruption state was loaded
-            assert mode2.spot_interruption_handler is not None
+            # Drive the reclaim through the queue the monitoring thread drains,
+            # rather than reaching for the handler directly -- substrate emulates
+            # neither EventBridge nor a spot ``InstanceLifecycle``, so this is the
+            # only seam that can originate one here.
+            mode.spot_interruption_monitor.event_queue.put(
+                (
+                    "instance",
+                    instance_id,
+                    {"InstanceId": instance_id, "InstanceAction": "terminate"},
+                )
+            )
+            mode.spot_interruption_monitor._process_interruption_events()
 
-            # Get recovery task
-            recovery_task = mode2.spot_interruption_handler.get_next_recovery_task()
-            assert recovery_task is not None
-            assert recovery_task["task_id"] == job_id
+            assert mode.resources[instance_id]["status"] == "INTERRUPTED"
+            mode.save_state()
+        finally:
+            if mode.spot_interruption_monitor:
+                mode.spot_interruption_monitor.stop_monitoring()
 
-            # Verify checkpoint data was preserved
-            checkpoint = mode2.spot_interruption_handler.load_checkpoint(job_id)
-            assert checkpoint is not None
-            assert checkpoint["job_id"] == job_id
-            assert checkpoint["progress"] == 50
+        mode2 = build_mode()
+        try:
+            assert mode2.load_state() is True
 
-            # Clean up
-            with patch.object(mode2, "_delete_ec2_instance"):
-                with patch.object(mode2, "_delete_security_group"):
-                    with patch.object(mode2, "_delete_subnet"):
-                        with patch.object(mode2, "_delete_vpc"):
-                            if mode2.spot_interruption_monitor:
-                                mode2.spot_interruption_monitor.stop_monitoring()
-                            mode2.cleanup_infrastructure()
+            assert mode2.resources[instance_id]["status"] == "INTERRUPTED"
+            # And the reason came back with it, so a FAILED block is diagnosable
+            # without going to CloudTrail.
+            assert mode2.resources[instance_id]["interruption_event"] == {
+                "InstanceId": instance_id,
+                "InstanceAction": "terminate",
+            }
+            # Still sticky on the far side: get_job_status must not re-derive a
+            # healthy-looking status from the instance EC2 is tearing down.
+            assert mode2.get_job_status([instance_id])[instance_id] == "INTERRUPTED"
+        finally:
+            if mode2.spot_interruption_monitor:
+                mode2.spot_interruption_monitor.stop_monitoring()

--- a/tests/unit/test_detached_mode.py
+++ b/tests/unit/test_detached_mode.py
@@ -19,6 +19,7 @@ from parsl_ephemeral_aws.exceptions import (
 )
 from parsl_ephemeral_aws.constants import (
     RESOURCE_TYPE_BASTION,
+    STATUS_INTERRUPTED,
     STATUS_PENDING,
     STATUS_RUNNING,
     STATUS_CANCELLED,
@@ -377,6 +378,25 @@ class TestDetachedMode:
 
         # Verify resource was updated
         assert detached_mode.resources[resource_id]["status"] == STATUS_RUNNING
+
+    def test_get_job_status_keeps_an_interruption(self, detached_mode, mock_ssm_client):
+        """A reclaim marked by the monitor survives the next poll (#137).
+
+        The status document this mode reads is written by the worker itself, so a
+        reclaimed instance cannot report its own reclaim — it simply stops
+        updating, leaving the last value it wrote. Re-reading would therefore
+        overwrite ``STATUS_INTERRUPTED`` with a stale RUNNING.
+        """
+        resource_id = "serverless-job-1"
+        detached_mode.resources = {
+            resource_id: {"job_id": "job-1", "status": STATUS_INTERRUPTED}
+        }
+
+        status = detached_mode.get_job_status([resource_id])
+
+        assert status[resource_id] == STATUS_INTERRUPTED
+        assert detached_mode.resources[resource_id]["status"] == STATUS_INTERRUPTED
+        mock_ssm_client.get_parameter.assert_not_called()
 
     def test_cancel_jobs(self, detached_mode, mock_ssm_client):
         """Test canceling jobs via bastion host."""

--- a/tests/unit/test_globus_config_loading.py
+++ b/tests/unit/test_globus_config_loading.py
@@ -300,7 +300,6 @@ class TestEveryParameterSurvivesTheRoundTrip:
             pytest.param({"baked_ami_id": "ami-0bakedbakedbaked0"}, id="baked-ami"),
             pytest.param({"key_name": "mykey", "use_public_ips": False}, id="access"),
             pytest.param({"auto_shutdown": False, "max_idle_time": 900}, id="idle"),
-            pytest.param({"checkpoint_bucket": "ckpt"}, id="checkpoint"),
             pytest.param({"profile_name": "aws"}, id="profile"),
         ],
     )
@@ -431,8 +430,6 @@ class TestEveryParameterSurvivesTheRoundTrip:
             "spot_max_price": "0.05",
             "spot_allocation_strategy": "capacity-optimized",
             "spot_interruption_handling": True,
-            "checkpoint_prefix": "cp",
-            "checkpoint_interval": 30,
             "auto_shutdown": False,
             "max_idle_time": 900,
             "bastion_instance_type": "t3.small",

--- a/tests/unit/test_provider_edge_cases.py
+++ b/tests/unit/test_provider_edge_cases.py
@@ -14,9 +14,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from parsl.jobs.states import JobState
+
 from parsl_ephemeral_aws.constants import (
     DEFAULT_WARM_POOL_SIZE,
     DEFAULT_WARM_POOL_TTL,
+    STATUS_INTERRUPTED,
 )
 from parsl_ephemeral_aws.exceptions import ProviderConfigurationError, ProviderError
 from parsl_ephemeral_aws.provider import EphemeralAWSProvider
@@ -1207,3 +1210,123 @@ class TestStandardOnlyOptionGuard:
             _construct(
                 "detached", warm_pool_size=1, iam_instance_profile_arn=_FAKE_IAM_ARN
             )
+
+
+# ---------------------------------------------------------------------------
+# TestSpotInterruptionStatus
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSpotInterruptionStatus:
+    """The provider half of the interruption response (#137).
+
+    The mode marks the resource ``STATUS_INTERRUPTED``; these are the three
+    things the provider must then do with it. Before #137 an interrupted
+    instance went to "shutting-down", which ``EC2_STATUS_MAPPING`` renders
+    COMPLETED, so the block reported success and its tasks were dropped.
+    """
+
+    @pytest.fixture
+    def tmp_dir(self):
+        with tempfile.TemporaryDirectory() as d:
+            yield d
+
+    def test_interrupted_reports_failed_to_parsl(self, tmp_dir):
+        """FAILED, not COMPLETED: the block did not finish its work.
+
+        FAILED is what stops the executor dispatching to the block and lets
+        Parsl's own ``retries`` re-run the lost tasks. COMPLETED was the bug.
+        """
+        provider, mode = _make_provider(tmp_dir)
+        provider.resources["i-001"] = {
+            "job_id": "j-001",
+            "status": STATUS_INTERRUPTED,
+            "timestamp": time.time(),
+        }
+        provider.job_map["j-001"] = {
+            "resource_id": "i-001",
+            "status": STATUS_INTERRUPTED,
+        }
+        mode.get_job_status.return_value = {"i-001": STATUS_INTERRUPTED}
+
+        statuses = provider.status(["j-001"])
+
+        assert statuses[0].state == JobState.FAILED
+
+    def test_interrupted_is_terminal(self, tmp_dir):
+        """Once interrupted, a later poll cannot walk the job back.
+
+        ``status()`` short-circuits terminal states, so a reclaimed instance
+        whose EC2 state has since become "terminated" -- which maps to
+        COMPLETED -- must not be re-reported as a success.
+        """
+        provider, mode = _make_provider(tmp_dir)
+        provider.resources["i-001"] = {
+            "job_id": "j-001",
+            "status": STATUS_INTERRUPTED,
+            "timestamp": time.time(),
+        }
+        provider.job_map["j-001"] = {
+            "resource_id": "i-001",
+            "status": STATUS_INTERRUPTED,
+        }
+        mode.get_job_status.return_value = {"i-001": "COMPLETED"}
+
+        statuses = provider.status(["j-001"])
+
+        assert statuses[0].state == JobState.FAILED
+        assert mode.get_job_status.call_count == 0
+
+    def test_interrupted_resource_is_cleaned_up(self, tmp_dir):
+        """It must be terminated like any other terminal state.
+
+        Omitting ``STATUS_INTERRUPTED`` from the cleanup list would trade a
+        silently-successful reclaim for a silent cost leak: an instance the
+        provider has stopped tracking but never terminated.
+        """
+        provider, mode = _make_provider(tmp_dir)
+        provider.resources["i-001"] = {
+            "job_id": "j-001",
+            "status": STATUS_INTERRUPTED,
+            "timestamp": time.time(),
+        }
+        provider.job_map["j-001"] = {
+            "resource_id": "i-001",
+            "status": STATUS_INTERRUPTED,
+        }
+
+        provider._cleanup_resources()
+
+        mode.cleanup_resources.assert_called_once_with(["i-001"])
+        assert "i-001" not in provider.resources
+
+    def test_an_interrupted_warm_instance_is_not_recycled(self, tmp_dir):
+        """AWS is taking the instance, so it must not go back into the pool.
+
+        The warm-pool branch runs before the general one, so this needs its own
+        case: recycling a doomed instance would hand the next job an instance
+        about to vanish.
+        """
+        provider, mode = _make_provider(
+            tmp_dir,
+            warm_pool_size=2,
+            iam_instance_profile_arn=_FAKE_IAM_ARN,
+        )
+        mode._warm_instances = []
+        provider.resources["i-001"] = {
+            "job_id": "j-001",
+            "status": STATUS_INTERRUPTED,
+            "warm_pool": True,
+            "timestamp": time.time(),
+        }
+        provider.job_map["j-001"] = {
+            "resource_id": "i-001",
+            "status": STATUS_INTERRUPTED,
+        }
+
+        provider._cleanup_resources()
+
+        mode.cleanup_resources.assert_called_once_with(["i-001"])
+        assert "i-001" not in mode._warm_instances
+        assert "i-001" not in provider.resources

--- a/tests/unit/test_serverless_mode.py
+++ b/tests/unit/test_serverless_mode.py
@@ -22,6 +22,7 @@ from parsl_ephemeral_aws.constants import (
     WORKER_TYPE_LAMBDA,
     WORKER_TYPE_ECS,
     WORKER_TYPE_AUTO,
+    STATUS_INTERRUPTED,
     STATUS_PENDING,
     STATUS_RUNNING,
     STATUS_SUCCEEDED,
@@ -565,6 +566,34 @@ class TestServerlessMode:
 
         # Verify resource was updated
         assert serverless_mode.resources[resource_id]["status"] == STATUS_RUNNING
+
+    def test_get_job_status_keeps_an_interruption(
+        self, serverless_mode, mock_cf_client
+    ):
+        """A reclaim marked by the monitor survives the next poll (#137).
+
+        Neither route below can see a reclaim: a fleet whose instances AWS is
+        taking back still reports itself active, and the CloudFormation stack
+        stays CREATE_COMPLETE. Re-deriving would overwrite the marker with a
+        healthy-looking RUNNING on the very next poll.
+        """
+        resource_id = "serverless-lambda-job-1"
+        serverless_mode.resources = {
+            resource_id: {
+                "job_id": "job-1",
+                "worker_type": WORKER_TYPE_LAMBDA,
+                "stack_name": "parsl-lambda-12345",
+                "status": STATUS_INTERRUPTED,
+                "created_at": time.time() - 10,
+                "resource_type": RESOURCE_TYPE_LAMBDA_FUNCTION,
+            }
+        }
+
+        status = serverless_mode.get_job_status([resource_id])
+
+        assert status[resource_id] == STATUS_INTERRUPTED
+        assert serverless_mode.resources[resource_id]["status"] == STATUS_INTERRUPTED
+        mock_cf_client.describe_stacks.assert_not_called()
 
     def test_get_lambda_status(self, serverless_mode):
         """Test Lambda job status calculation."""

--- a/tests/unit/test_spot_interruption.py
+++ b/tests/unit/test_spot_interruption.py
@@ -1,4 +1,14 @@
-"""Unit tests for the spot interruption handler.
+"""Unit tests for spot interruption detection and the response to it.
+
+Two halves, matching the split in the package: ``SpotInterruptionMonitor``
+detects that AWS is reclaiming capacity and calls the registered handler, and
+``OperatingMode.handle_*_interruption`` decides what that means -- mark the
+block interrupted so the provider reports FAILED and Parsl re-runs the tasks.
+
+The checkpoint/recovery API these tests used to cover was deleted in #137. It
+could not work at this layer: its entry point was
+``register_task(task_id, instance_id)``, and a Parsl provider is never told a
+task ID.
 
 SPDX-License-Identifier: Apache-2.0
 SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
@@ -6,20 +16,13 @@ SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
 
 import pytest
 import boto3
-import json
 import threading
 import queue
 from unittest.mock import MagicMock, patch
 
-from parsl_ephemeral_aws.compute.spot_interruption import (
-    SpotInterruptionMonitor,
-    SpotInterruptionHandler,
-    ParslSpotInterruptionHandler,
-    checkpointable,
-)
-from parsl_ephemeral_aws.exceptions import (
-    SpotInstanceError,
-)
+from parsl_ephemeral_aws.compute.spot_interruption import SpotInterruptionMonitor
+from parsl_ephemeral_aws.constants import STATUS_INTERRUPTED, STATUS_RUNNING
+from parsl_ephemeral_aws.modes.base import OperatingMode
 
 pytestmark = pytest.mark.unit
 
@@ -271,402 +274,151 @@ class TestSpotInterruptionMonitor:
         )
 
 
-class TestSpotInterruptionHandler:
-    """Tests for the SpotInterruptionHandler class."""
+class _StubMode(OperatingMode):
+    """Minimal concrete mode: the interruption response lives on the base class.
+
+    Testing it here rather than through StandardMode keeps the assertions on the
+    one thing under test. The per-mode half -- that ``get_job_status`` does not
+    overwrite the marker on the next poll -- is covered in each mode's own tests.
+    """
+
+    def initialize(self):
+        self.initialized = True
+
+    def submit_job(self, job_id, command, tasks_per_node=1, job_name=None):
+        raise NotImplementedError
+
+    def get_job_status(self, resource_ids):
+        return {rid: self.resources[rid]["status"] for rid in resource_ids}
+
+    def cancel_jobs(self, resource_ids):
+        raise NotImplementedError
+
+    def cleanup_resources(self, resource_ids):
+        raise NotImplementedError
+
+    def cleanup_infrastructure(self):
+        pass
+
+    def list_resources(self):
+        return {"instances": []}
+
+    def cleanup_all(self):
+        pass
+
+
+class TestInterruptionResponse:
+    """``OperatingMode.handle_*_interruption`` — the response to a reclaim (#137).
+
+    Before this existed, an interruption was *invisible* rather than merely
+    unhandled: the reclaimed instance went to "shutting-down", which
+    EC2_STATUS_MAPPING renders COMPLETED, so the block reported success and its
+    tasks were silently dropped.
+    """
 
     @pytest.fixture
-    def mock_session(self):
-        """Create a mock boto3 session."""
-        session = MagicMock(spec=boto3.Session)
-        return session
-
-    @pytest.fixture
-    def mock_s3_client(self):
-        """Create a mock S3 client."""
-        client = MagicMock()
-
-        # Mock head_bucket
-        client.head_bucket.return_value = {}
-
-        # Mock get_object
-        client.get_object.return_value = {
-            "Body": MagicMock(read=lambda: json.dumps({"test": "data"}).encode())
+    def mode(self):
+        mode = _StubMode(
+            provider_id="test-provider",
+            session=MagicMock(spec=boto3.Session),
+            state_store=MagicMock(),
+            vpc_id="vpc-12345",
+            subnet_id="subnet-12345",
+            security_group_id="sg-12345",
+            use_spot=True,
+            spot_interruption_handling=True,
+        )
+        mode.resources = {
+            "i-test1": {"status": STATUS_RUNNING},
+            "i-test2": {"status": STATUS_RUNNING},
+            "fleet-test1": {"status": STATUS_RUNNING},
         }
+        return mode
 
-        return client
-
-    @pytest.fixture
-    def handler(self, mock_session, mock_s3_client):
-        """Create a SpotInterruptionHandler instance."""
-        mock_session.client.return_value = mock_s3_client
-
-        return SpotInterruptionHandler(
-            session=mock_session,
-            checkpoint_bucket="test-bucket",
-            checkpoint_prefix="test/prefix",
-        )
-
-    def test_init(self, handler, mock_session):
-        """Test initialization of SpotInterruptionHandler."""
-        assert handler.session == mock_session
-        assert handler.checkpoint_bucket == "test-bucket"
-        assert handler.checkpoint_prefix == "test/prefix"
-        assert isinstance(handler.recovery_queue, queue.PriorityQueue)
-
-        # Verify bucket existence was checked
-        mock_session.client.return_value.head_bucket.assert_called_with(
-            Bucket="test-bucket"
-        )
-
-    def test_init_without_bucket(self, mock_session):
-        """Test initialization without a checkpoint bucket."""
-        handler = SpotInterruptionHandler(session=mock_session, checkpoint_bucket=None)
-
-        assert handler.checkpoint_bucket is None
-        assert mock_session.client.return_value.head_bucket.call_count == 0
-
-    def test_save_checkpoint(self, handler, mock_s3_client):
-        """Test saving a checkpoint."""
-        task_id = "task-123"
-        data = {"status": "in_progress", "iteration": 42}
-
-        uri = handler.save_checkpoint(task_id, data)
-
-        assert (
-            uri
-            == f"s3://{handler.checkpoint_bucket}/{handler.checkpoint_prefix}/{task_id}.json"
-        )
-
-        # Verify S3 put_object was called correctly. Checkpoints are encrypted at
-        # rest — the kwarg has been in spot_interruption.py since v0.2.0 and this
-        # expectation never caught up.
-        mock_s3_client.put_object.assert_called_with(
-            Bucket="test-bucket",
-            Key=f"{handler.checkpoint_prefix}/{task_id}.json",
-            Body=json.dumps(data),
-            ServerSideEncryption="AES256",
-            Metadata={
-                "Priority": "1",
-                "Timestamp": mock_s3_client.put_object.call_args[1]["Metadata"][
-                    "Timestamp"
-                ],
-            },
-        )
-
-    def test_save_checkpoint_no_bucket(self, mock_session):
-        """Test saving a checkpoint with no bucket configured.
-
-        ``save_checkpoint`` raises ``SpotInstanceError``, the *parent* of
-        ``SpotInterruptionError`` — which is what its docstring documents and what
-        ``load_checkpoint`` raises for the same reason. The assertion here named
-        the subclass, so it could never match.
-        """
-        handler = SpotInterruptionHandler(session=mock_session)
-
-        with pytest.raises(SpotInstanceError):
-            handler.save_checkpoint("task-123", {})
-
-    def test_load_checkpoint(self, handler, mock_s3_client):
-        """Test loading a checkpoint."""
-        task_id = "task-123"
-
-        data = handler.load_checkpoint(task_id)
-
-        assert data == {"test": "data"}
-
-        # Verify S3 get_object was called correctly
-        mock_s3_client.get_object.assert_called_with(
-            Bucket="test-bucket", Key=f"{handler.checkpoint_prefix}/{task_id}.json"
-        )
-
-    def test_load_checkpoint_not_found(self, handler, mock_s3_client):
-        """Test loading a checkpoint that doesn't exist."""
-        from botocore.exceptions import ClientError
-
-        # Mock get_object to raise NoSuchKey error
-        mock_s3_client.get_object.side_effect = ClientError(
-            {"Error": {"Code": "NoSuchKey", "Message": "Not found"}}, "GetObject"
-        )
-
-        data = handler.load_checkpoint("missing-task")
-
-        assert data is None
-
-    def test_queue_task_for_recovery(self, handler):
-        """Test queuing a task for recovery."""
-        task_id = "task-123"
-        checkpoint_uri = "s3://test-bucket/test/prefix/task-123.json"
-        priority = 2
-
-        handler.queue_task_for_recovery(task_id, checkpoint_uri, priority)
-
-        # Verify the task was added to the queue
-        queued_item = handler.recovery_queue.get()
-        assert queued_item[0] == priority  # Priority
-        assert queued_item[2] == task_id  # Task ID
-        assert queued_item[3] == checkpoint_uri  # Checkpoint URI
-
-    def test_get_next_recovery_task(self, handler):
-        """Test getting the next recovery task."""
-        # Add tasks to the queue
-        handler.queue_task_for_recovery("task-1", "uri-1", 2)
-        handler.queue_task_for_recovery("task-2", "uri-2", 1)  # Higher priority
-
-        # Get the next task (should be task-2)
-        task = handler.get_next_recovery_task()
-
-        assert task["task_id"] == "task-2"
-        assert task["checkpoint_uri"] == "uri-2"
-        assert task["priority"] == 1
-
-        # Get the next task (should be task-1)
-        task = handler.get_next_recovery_task()
-
-        assert task["task_id"] == "task-1"
-        assert task["checkpoint_uri"] == "uri-1"
-        assert task["priority"] == 2
-
-        # No more tasks
-        task = handler.get_next_recovery_task()
-        assert task is None
-
-    def test_handle_instance_interruption(self, handler):
-        """Test the base implementation of handle_instance_interruption."""
-        # This is just a placeholder in the base class, so no real logic to test
-        instance_id = "i-test1"
+    def test_instance_interruption_marks_the_block(self, mode):
         event = {"InstanceId": "i-test1", "InstanceAction": "terminate"}
 
-        # Should not raise an exception
-        handler.handle_instance_interruption(instance_id, event)
+        mode.handle_instance_interruption("i-test1", event)
 
-    def test_handle_fleet_interruption(self, handler):
-        """Test the base implementation of handle_fleet_interruption."""
-        # This is just a placeholder in the base class, so no real logic to test
-        fleet_id = "fleet-test1"
-        instance_ids = ["i-test1", "i-test2"]
-        event = {"FleetRequestId": fleet_id, "InstanceAction": "terminate"}
+        assert mode.resources["i-test1"]["status"] == STATUS_INTERRUPTED
+        # The event is kept so a FAILED block is diagnosable without going back
+        # to CloudTrail for the reason.
+        assert mode.resources["i-test1"]["interruption_event"] == event
+        # Only the named instance: a reclaim is per-instance, not per-provider.
+        assert mode.resources["i-test2"]["status"] == STATUS_RUNNING
 
-        # Should not raise an exception
-        handler.handle_fleet_interruption(fleet_id, instance_ids, event)
+    def test_untracked_instance_is_ignored(self, mode):
+        """A warning can arrive for an instance we no longer track.
 
+        The monitor polls on its own thread, so a job that finished and was
+        cleaned up between the poll and the dispatch is normal, not an error --
+        this must not raise into the monitoring thread.
+        """
+        mode.handle_instance_interruption("i-unknown", {"InstanceAction": "terminate"})
 
-class TestParslSpotInterruptionHandler:
-    """Tests for the ParslSpotInterruptionHandler class."""
+        assert "i-unknown" not in mode.resources
 
-    @pytest.fixture
-    def mock_session(self):
-        """Create a mock boto3 session."""
-        session = MagicMock(spec=boto3.Session)
-        return session
+    def test_fleet_interruption_marks_fleet_and_named_instances(self, mode):
+        event = {"FleetRequestId": "fleet-test1", "Source": "eventbridge"}
 
-    @pytest.fixture
-    def mock_s3_client(self):
-        """Create a mock S3 client."""
-        client = MagicMock()
+        mode.handle_fleet_interruption("fleet-test1", ["i-test1"], event)
 
-        # Mock head_bucket
-        client.head_bucket.return_value = {}
+        # The fleet block is what Parsl holds a job ID for, so it is the one that
+        # must go FAILED; the instances are marked too so status is consistent.
+        assert mode.resources["fleet-test1"]["status"] == STATUS_INTERRUPTED
+        assert mode.resources["fleet-test1"]["interruption_event"] == event
+        assert mode.resources["i-test1"]["status"] == STATUS_INTERRUPTED
+        # A fleet reclaim names the affected instances; the rest keep running.
+        assert mode.resources["i-test2"]["status"] == STATUS_RUNNING
 
-        # Mock get_object
-        client.get_object.return_value = {
-            "Body": MagicMock(read=lambda: json.dumps({"test": "data"}).encode())
+    def test_untracked_fleet_still_marks_its_instances(self, mode):
+        """The fleet ID may not be a tracked resource in every mode.
+
+        DetachedMode tracks the bastion-side job rather than the fleet, so the
+        instance loop has to run whether or not the fleet ID resolves.
+        """
+        mode.handle_fleet_interruption("fleet-unknown", ["i-test2"], {})
+
+        assert mode.resources["i-test2"]["status"] == STATUS_INTERRUPTED
+
+    def test_fleet_is_found_through_the_block_that_records_it(self, mode):
+        """The fleet ID is a *field*, not the resource key, in every real mode.
+
+        StandardMode keys a fleet block by block ID and the other two by
+        ``serverless-<job_id>``, recording the fleet as ``fleet_request_id``. A
+        direct ``resources[fleet_id]`` lookup therefore missed every time, so the
+        block Parsl holds kept reporting healthy through the reclaim — the
+        original bug, surviving in the fleet path only.
+        """
+        mode.resources["block-7"] = {
+            "status": STATUS_RUNNING,
+            "fleet_request_id": "fleet-abc",
         }
 
-        return client
-
-    @pytest.fixture
-    def mock_executor(self):
-        """Create a mock Parsl executor."""
-        executor = MagicMock()
-        return executor
-
-    @pytest.fixture
-    def handler(self, mock_session, mock_s3_client, mock_executor):
-        """Create a ParslSpotInterruptionHandler instance."""
-        mock_session.client.return_value = mock_s3_client
-
-        return ParslSpotInterruptionHandler(
-            session=mock_session,
-            checkpoint_bucket="test-bucket",
-            checkpoint_prefix="test/prefix",
-            executor=mock_executor,
-            executor_label="test_executor",
+        mode.handle_fleet_interruption(
+            "fleet-abc", ["i-test1"], {"Source": "ec2-state"}
         )
 
-    def test_init(self, handler, mock_session, mock_executor):
-        """Test initialization of ParslSpotInterruptionHandler."""
-        assert handler.session == mock_session
-        assert handler.checkpoint_bucket == "test-bucket"
-        assert handler.checkpoint_prefix == "test/prefix"
-        assert handler.executor == mock_executor
-        assert handler.executor_label == "test_executor"
-        assert handler.task_mapping == {}
-
-    def test_register_task(self, handler):
-        """Test registering a task."""
-        handler.register_task("task-1", "i-test1")
-        handler.register_task("task-2", "i-test1")
-        handler.register_task("task-3", "i-test2")
-
-        assert "i-test1" in handler.task_mapping
-        assert "i-test2" in handler.task_mapping
-        assert handler.task_mapping["i-test1"] == ["task-1", "task-2"]
-        assert handler.task_mapping["i-test2"] == ["task-3"]
-
-    def test_handle_instance_interruption(self, handler, mock_s3_client):
-        """Test handling an instance interruption."""
-        # Register tasks
-        handler.register_task("task-1", "i-test1")
-        handler.register_task("task-2", "i-test1")
-
-        # Mock successful checkpoint loading
-        mock_s3_client.get_object.return_value = {
-            "Body": MagicMock(read=lambda: json.dumps({"checkpoint": "data"}).encode())
+        assert mode.resources["block-7"]["status"] == STATUS_INTERRUPTED
+        assert mode.resources["block-7"]["interruption_event"] == {
+            "Source": "ec2-state"
         }
+        # A block backed by a different fleet is untouched.
+        assert mode.resources["fleet-test1"]["status"] == STATUS_RUNNING
 
-        # Handle interruption
-        instance_id = "i-test1"
-        event = {"InstanceId": instance_id, "InstanceAction": "terminate"}
+    def test_monitor_dispatches_to_the_mode(self, mode):
+        """The two halves connect: what the monitor calls is what the mode does.
 
-        handler.handle_instance_interruption(instance_id, event)
-
-        # Verify checkpoints were loaded
-        assert mock_s3_client.get_object.call_count == 2
-
-        # Verify tasks were queued for recovery
-        assert not handler.recovery_queue.empty()
-        priority1, time1, task_id1, uri1 = handler.recovery_queue.get()
-        priority2, time2, task_id2, uri2 = handler.recovery_queue.get()
-
-        assert task_id1 in ["task-1", "task-2"]
-        assert task_id2 in ["task-1", "task-2"]
-        assert task_id1 != task_id2
-
-        # Verify task mapping was cleaned up
-        assert "i-test1" not in handler.task_mapping
-
-    def test_handle_fleet_interruption(self, handler):
-        """Test handling a fleet interruption."""
-        # Setup spy on handle_instance_interruption
-        handler.handle_instance_interruption = MagicMock()
-
-        # Handle fleet interruption
-        fleet_id = "fleet-test1"
-        instance_ids = ["i-test1", "i-test2"]
-        event = {"FleetRequestId": fleet_id, "InstanceAction": "terminate"}
-
-        handler.handle_fleet_interruption(fleet_id, instance_ids, event)
-
-        # Verify handle_instance_interruption was called for each instance
-        assert handler.handle_instance_interruption.call_count == 2
-        handler.handle_instance_interruption.assert_any_call("i-test1", event)
-        handler.handle_instance_interruption.assert_any_call("i-test2", event)
-
-    def test_recover_tasks(self, handler, mock_s3_client, mock_executor):
-        """Test recovering tasks."""
-        # Queue tasks for recovery
-        handler.queue_task_for_recovery(
-            "task-1", "s3://test-bucket/test/prefix/task-1.json"
-        )
-        handler.queue_task_for_recovery(
-            "task-2", "s3://test-bucket/test/prefix/task-2.json", priority=2
+        Registering the *bound method* is the whole wiring. This used to point at
+        a handler object whose task mapping nothing ever populated, so every
+        interruption logged "No registered tasks found" and did nothing.
+        """
+        monitor = SpotInterruptionMonitor(session=MagicMock(spec=boto3.Session))
+        monitor.register_instance("i-test1", mode.handle_instance_interruption)
+        monitor.event_queue.put(
+            ("instance", "i-test1", {"InstanceAction": "terminate"})
         )
 
-        # Process recovery queue
-        handler.recover_tasks()
+        monitor._process_interruption_events()
 
-        # Executor would be used in a real implementation, but we just verify
-        # that the method doesn't fail for now. In a real implementation we
-        # would check if new futures were created.
-        assert handler.recovery_queue.empty()
-
-
-class TestCheckpointableDecorator:
-    """Tests for the checkpointable decorator."""
-
-    def test_checkpointable_function(self):
-        """Test that a function can be decorated with checkpointable."""
-
-        @checkpointable(checkpoint_bucket="test-bucket")
-        def test_func(x, y, checkpoint_data=None):
-            if checkpoint_data:
-                state = checkpoint_data
-            else:
-                state = {"iteration": 0, "result": 0}
-
-            for i in range(state["iteration"], 5):
-                state["result"] += x * y
-                state["iteration"] = i + 1
-                yield state
-
-            return state["result"]
-
-        # Function should still be callable
-        result = test_func(2, 3)
-
-        # Should have computed 2*3*5 = 30
-        assert result == 30
-
-    def test_checkpointable_with_initial_checkpoint(self):
-        """Test resuming from a checkpoint."""
-
-        @checkpointable()
-        def test_func(checkpoint_data=None):
-            if checkpoint_data:
-                state = checkpoint_data
-            else:
-                state = {"iteration": 0, "result": 0}
-
-            for i in range(state["iteration"], 5):
-                state["result"] += i
-                state["iteration"] = i + 1
-                yield state
-
-            return state["result"]
-
-        # Start from a checkpoint at iteration 3
-        checkpoint_data = {"iteration": 3, "result": 3}  # 0+1+2=3
-        result = test_func(checkpoint_data=checkpoint_data)
-
-        # Should have computed 3+3+4 = 10
-        assert result == 10
-
-    def test_checkpointable_non_generator(self):
-        """Test using checkpointable on a non-generator function."""
-
-        @checkpointable()
-        def test_func(x, checkpoint_data=None):
-            if checkpoint_data:
-                return checkpoint_data["result"] + x
-            return x
-
-        # Regular function call
-        assert test_func(5) == 5
-
-        # With checkpoint
-        assert test_func(5, checkpoint_data={"result": 10}) == 15
-
-    def test_checkpointable_exception_handling(self):
-        """Test exception handling in checkpointable function."""
-
-        @checkpointable()
-        def test_func(checkpoint_data=None):
-            if checkpoint_data:
-                iteration = checkpoint_data["iteration"]
-            else:
-                iteration = 0
-
-            for i in range(iteration, 5):
-                if i == 3:
-                    raise ValueError("Test exception")
-                yield {"iteration": i + 1}
-
-            return "Done"
-
-        # Function should raise the exception
-        with pytest.raises(ValueError):
-            test_func()
-
-        # With checkpoint before the exception
-        result = test_func(checkpoint_data={"iteration": 4})
-        assert result == "Done"
+        assert mode.resources["i-test1"]["status"] == STATUS_INTERRUPTED

--- a/tests/unit/test_spot_warning_notifier.py
+++ b/tests/unit/test_spot_warning_notifier.py
@@ -2,7 +2,8 @@
 
 The EC2-state poll that predated this could only ever report an interruption
 post-facto: an interrupted instance is first observable at ``shutting-down``,
-which is after the reclaim and far too late to checkpoint. An ``instant`` fleet
+which is after the reclaim and after the executor has already dispatched work to
+a worker that is gone. An ``instant`` fleet
 gets no Capacity Rebalance either -- ``CreateFleet`` rejects
 ``SpotOptions.MaintenanceStrategies`` for that type -- so an EventBridge rule
 delivering to SQS, polled by the driver, is what supplies the two-minute
@@ -161,8 +162,8 @@ class TestCreateSpotInterruptionNotifier:
         Without the condition the policy grants ``events.amazonaws.com`` at
         large, which is every EventBridge rule in every account -- a queue any
         stranger can inject a fabricated interruption warning into, and this
-        monitor's handlers act on those warnings by checkpointing and
-        rescheduling.
+        monitor's handlers act on those warnings by failing the block the
+        instance belongs to.
         """
         _, events, sqs = _clients()
 
@@ -182,9 +183,9 @@ class TestCreateSpotInterruptionNotifier:
         """A warning is worthless once its two minutes are up.
 
         Default SQS retention is four days. Replaying a stale warning against a
-        long-dead instance would have the handler checkpoint and reschedule work
-        that already finished or already failed, so the retention is cut to the
-        window in which the message can still be acted on.
+        long-dead instance would fail a block that already finished, so the
+        retention is cut to the window in which the message can still be acted
+        on.
         """
         _, events, sqs = _clients()
 
@@ -426,9 +427,9 @@ class TestMonitorNotifierLifecycle:
         """Losing the advance warning is worse than the poll, not fatal.
 
         A caller whose IAM policy grants no ``events``/``sqs`` still gets a
-        working provider; what it loses is the lead time to checkpoint. Raising
-        here would make the two new permissions mandatory for every spot
-        workflow, including ones that do no checkpointing at all.
+        working provider; what it loses is the two-minute lead time, falling back
+        to the post-facto EC2-state poll. Raising here would make the two new
+        permissions mandatory for every spot workflow.
         """
         monitor = SpotInterruptionMonitor(session, provider_id="abcdef123456")
 
@@ -582,10 +583,9 @@ class TestPollWarningQueue:
     def test_the_source_marks_it_as_an_advance_warning(self, monitor, sqs):
         """This is how a handler knows it has two minutes rather than none.
 
-        The EC2-state track stamps ``ec2-state`` and fires on an instance that
-        is already dying; a handler that cannot tell them apart must either
-        assume the worst and skip checkpointing entirely, or attempt a
-        checkpoint that cannot complete.
+        The EC2-state track stamps ``ec2-state`` and fires on an instance that is
+        already dying, so a handler that cannot tell the two apart cannot tell
+        whether it is marking a block ahead of the reclaim or after it.
         """
         monitor.register_instance("i-abc123", MagicMock())
 

--- a/tests/unit/test_standard_mode.py
+++ b/tests/unit/test_standard_mode.py
@@ -17,6 +17,7 @@ from parsl_ephemeral_aws.exceptions import (
 )
 from parsl_ephemeral_aws.constants import (
     RESOURCE_TYPE_EC2,
+    STATUS_INTERRUPTED,
     STATUS_PENDING,
     STATUS_RUNNING,
     STATUS_CANCELED,
@@ -130,6 +131,95 @@ class TestStandardMode:
         # switch entirely. The old `mode.create_vpc is False` assertion outlived
         # the attribute it read.
         assert not hasattr(mode, "create_vpc")
+
+    @pytest.mark.parametrize(
+        ("use_spot", "use_spot_fleet", "expect_manager"),
+        [
+            (False, False, False),
+            (True, False, False),
+            (False, True, True),
+            (True, True, True),
+        ],
+    )
+    def test_the_fleet_manager_follows_use_spot_fleet_alone(
+        self,
+        mock_session,
+        mock_state_store,
+        mock_ec2_client,
+        use_spot,
+        use_spot_fleet,
+        expect_manager,
+    ):
+        """``use_spot_fleet`` decides, and nothing else (#137).
+
+        The gate was ``use_spot and use_spot_fleet``, but every consumer of the
+        manager tests ``use_spot_fleet`` alone -- so ``use_spot_fleet=True``
+        without ``use_spot`` left the manager ``None``, ``_create_spot_instance``
+        found nothing to dispatch to, and the block launched as a single
+        on-demand instance with no error. The reverse case matters too: a
+        ``use_spot``-only caller never reaches the fleet path, so building a
+        manager for it would be dead weight.
+        """
+        mock_session.client.return_value = mock_ec2_client
+
+        mode = StandardMode(
+            provider_id="test-provider",
+            session=mock_session,
+            state_store=mock_state_store,
+            instance_type="t3.micro",
+            image_id="ami-12345678",
+            region="us-east-1",
+            vpc_id="vpc-12345",
+            subnet_id="subnet-12345",
+            security_group_id="sg-12345",
+            use_spot=use_spot,
+            use_spot_fleet=use_spot_fleet,
+        )
+
+        assert (mode.spot_fleet_manager is not None) is expect_manager
+
+    @pytest.mark.parametrize(
+        ("use_spot", "use_spot_fleet", "expect_monitor"),
+        [
+            (False, False, False),
+            (True, False, True),
+            (False, True, True),
+        ],
+    )
+    def test_the_interruption_monitor_covers_both_spot_paths(
+        self,
+        mock_session,
+        mock_state_store,
+        mock_ec2_client,
+        use_spot,
+        use_spot_fleet,
+        expect_monitor,
+    ):
+        """Unlike the manager, the monitor is wanted on either spot path (#137).
+
+        Its gate was ``use_spot and spot_interruption_handling``, which left a
+        fleet-only caller with no detection at all despite asking for it -- and a
+        fleet is the configuration most exposed to reclaims. On-demand capacity is
+        never reclaimed, so the no-spot case must still build nothing.
+        """
+        mock_session.client.return_value = mock_ec2_client
+
+        mode = StandardMode(
+            provider_id="test-provider",
+            session=mock_session,
+            state_store=mock_state_store,
+            instance_type="t3.micro",
+            image_id="ami-12345678",
+            region="us-east-1",
+            vpc_id="vpc-12345",
+            subnet_id="subnet-12345",
+            security_group_id="sg-12345",
+            use_spot=use_spot,
+            use_spot_fleet=use_spot_fleet,
+            spot_interruption_handling=True,
+        )
+
+        assert (mode.spot_interruption_monitor is not None) is expect_monitor
 
     def test_initialize(self, standard_mode, mock_ec2_client):
         """Initialize verifies the caller's network; it never creates one.
@@ -251,6 +341,40 @@ class TestStandardMode:
 
         # Verify resource was updated
         assert standard_mode.resources[resource_id]["status"] == STATUS_RUNNING
+
+    def test_get_job_status_keeps_an_interruption(self, standard_mode, mock_ec2_client):
+        """A reclaim marked by the monitor survives the next poll (#137).
+
+        This is the half that makes the marker mean anything. EC2 reports a
+        reclaimed instance as "shutting-down", which ``EC2_STATUS_MAPPING``
+        renders COMPLETED, so re-deriving status here would overwrite
+        ``STATUS_INTERRUPTED`` and report the lost block as a success — exactly
+        the silent task loss the marker exists to prevent.
+        """
+        resource_id = "i-12345678"
+        standard_mode.resources = {
+            resource_id: {
+                "type": RESOURCE_TYPE_EC2,
+                "job_id": "job-1",
+                "status": STATUS_INTERRUPTED,
+            }
+        }
+        mock_ec2_client.describe_instances.return_value = {
+            "Reservations": [
+                {
+                    "Instances": [
+                        {"InstanceId": resource_id, "State": {"Name": "shutting-down"}}
+                    ]
+                }
+            ]
+        }
+
+        status = standard_mode.get_job_status([resource_id])
+
+        assert status[resource_id] == STATUS_INTERRUPTED
+        assert standard_mode.resources[resource_id]["status"] == STATUS_INTERRUPTED
+        # Not even asked: the answer could only be wrong.
+        mock_ec2_client.describe_instances.assert_not_called()
 
     def test_cancel_jobs(self, standard_mode, mock_ec2_client):
         """Test canceling jobs."""


### PR DESCRIPTION
Closes #137.

`spot_interruption_handling=True` did nothing useful in three separate ways, and the recovery API the docs pointed at could never have worked at this layer.

## What was broken

**The monitor was usually never built.** The gate was `use_spot and spot_interruption_handling and checkpoint_bucket`. A fleet-only caller — the configuration *most* exposed to reclaims — fell out on `use_spot`; any caller without an S3 bucket fell out on `checkpoint_bucket`. Either way you got one WARNING at startup and then silence.

**`use_spot_fleet=True` alone launched on-demand.** `SpotFleetManager` was gated on `use_spot and use_spot_fleet`, but every consumer of it (including `_create_spot_instance`) tests `use_spot_fleet` alone. With `use_spot` unset the manager stayed `None`, the block silently launched as a single on-demand instance, and nothing reported it.

**A reclaimed instance reported success.** An interrupted instance goes to `shutting-down`, which `EC2_STATUS_MAPPING` renders `COMPLETED`. Parsl saw a block that finished normally, so `retries` never fired for the tasks that died with it — the exact silent task loss the feature exists to prevent.

**Fleet interruptions reached no block.** `handle_fleet_interruption()` did `resources.get(fleet_id)`, but `resources` is keyed by block ID (standard mode) or `serverless-<job_id>`, carrying the fleet as a `fleet_request_id` *field*. Every fleet reclaim found nothing and logged a miss.

## What this does

- Monitor gate is `(use_spot or use_spot_fleet) and spot_interruption_handling`, with no bucket involved. `SpotFleetManager`'s gate is `use_spot_fleet` alone — and deliberately *not* `use_spot`, since a `use_spot`-only caller never reaches the fleet path.
- A detected interruption marks the resource `STATUS_INTERRUPTED`; the provider maps that to `JobState.FAILED`. That, not any checkpointing, is what makes the executor stop dispatching into a doomed block and re-run its tasks.
- The marker is **sticky**. All three modes' `get_job_status()` re-derive status from live AWS state on every poll, so the mark was being overwritten on the next call — an instance AWS is taking back still reports itself `running`. Each mode now short-circuits an already-marked resource, and the marker survives a save/load round trip.
- `OperatingMode._resource_ids_for_fleet()` searches the `fleet_request_id` field, and `StandardMode` now writes that field on the block record so there is something to find.

## The recovery stub is deleted, not fixed

`SpotInterruptionHandler`, `ParslSpotInterruptionHandler`, the `checkpointable` decorator, and the `checkpoint_bucket`/`checkpoint_prefix`/`checkpoint_interval` parameters are gone.

Its entry point was `register_task(task_id, instance_id)` — and **a Parsl provider is never told a task ID**. `submit(command, tasks_per_node, job_name) -> str` is the whole contract, because providers manage *blocks* while the executor manages tasks. Nothing in the package could populate `task_mapping`; it was always empty, every interruption logged "No registered tasks found", and `save_checkpoint`/`recover_tasks`/`queue_task_for_recovery` were unreachable alongside it. The `checkpointable` decorator's own source said "in a real implementation, we would save to S3 here" and saved nothing.

**Breaking config-schema change:** the three `checkpoint_*` keywords now raise `ProviderConfigurationError` rather than being accepted and ignored. Documented under `Removed` in the changelog.

`checkpoint_bucket` had a second, legitimate job: it also overrode the Lambda code-staging bucket, and `_owns_lambda_code_bucket` (which protects a caller's bucket from deletion) was reachable only through it. That half survives as a new `lambda_code_bucket` parameter — same behaviour, under a name that says what it does.

## Verification

- `tests/unit`: **983 passed**, 2 skipped (0 failed). Includes 16 rewritten tests in `test_spot_interruption.py`, 4 in `test_provider_edge_cases.py::TestSpotInterruptionStatus`, 3 mode-level stickiness tests, and 7 new parametrised cases pinning both gates — the fleet-manager gate in all four `use_spot`×`use_spot_fleet` combinations, since the first draft of this fix over-broadened it and a unit test caught that.
- `tests/security`: **93 passed**.
- `mypy`: **76 errors, down from 79** on `main`; diffed error-by-error, none introduced.
- `ruff check` / `ruff format`: clean over `parsl_ephemeral_aws tests examples`.
- `tests/integration` against substrate: **41 failing, down from 47** on `main`; diffed node-ID-by-node-ID, **zero regressions**. Two previously-uncollectable files are rewritten and green (10 tests), which also restores collection for the whole directory — it had been aborting on `ImportError`. The residual failures are the fixture damage the plan defers to v0.8.0.
- `tests/aws`: 77 collected. Not run — needs real AWS and money; the FIS-driven probe in `test_spot_warning_e2e.py` is what proves the warning arrives while the instance is still `running`.

Substrate limits found while writing the integration tests, and recorded in the file headers: EventBridge is not emulated (`501 service not emulated: awsevents`, so the monitor degrades and its thread still starts), and `InstanceLifecycle` is always `None` even with `MarketType: spot`, so the EC2-state track cannot fire there at all. Both tests therefore drive `monitor.event_queue` directly.

Docs (`examples.md`, `spot_fleet.md`, `globus_compute.md`) and both spot examples now state the honest contract: the provider detects and fails the block, Parsl's `retries` re-runs the work.