### PR TITLE
fix: delete auto-created IAM role and profile on cleanup (closes #132)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the removed API only, and never exported from the package root (refs #137).
 
 ### Fixed
+- **Every `auto_create_instance_profile` run leaked an IAM role and an instance
+  profile.** `StandardMode._resolve_instance_profile()` created a
+  `parsl-ephemeral-ssm-{role,profile}-<provider_id>` pair, and `provider_id` is a
+  fresh UUID per run, so each run made a new pair.
+  `cleanup_infrastructure()` deleted the launch template, EventBridge rule, SQS
+  queue, and baked AMI — never the IAM pair, and no
+  `remove_role_from_instance_profile` / `delete_role` call existed anywhere on the
+  path. Cleanup now deletes both, in the only order IAM accepts
+  (`remove_role_from_instance_profile` → `delete_instance_profile` →
+  `detach_role_policy` → `delete_role`), tolerating `NoSuchEntity` at every step
+  so it stays idempotent, and logging rather than raising so a cleanup failure
+  cannot mask the caller's real error.
+
+  **A caller-supplied `iam_instance_profile_arn` is never deleted.** Ownership
+  gates on having taken the auto-create branch and is persisted as
+  `owns_instance_profile`, not recomputed from create-vs-fetch: the names derive
+  from `provider_id`, so a provider resumed from a state file *fetches* the pair
+  it created on its first run, and a create-vs-fetch gate would disown it on
+  every restart and leak it permanently. Deleting shared infrastructure other
+  workloads depend on would be a worse bug than the leak — the hazard class of
+  the serverless security-group deletion fixed in #100 (closes #132).
+- `tools/cleanup_aws_resources.py` reaps orphaned IAM pairs, which it previously
+  ignored entirely. Roles and profiles can be orphaned independently by a partial
+  teardown, so both listings are scanned and the suffixes unioned, and IAM runs
+  after the instance terminations because IAM refuses to delete a profile still
+  attached to an instance. Prefixes derive from the same
+  `ssm_instance_profile_names()` helper the provider creates with, so the creator
+  and the reaper cannot drift apart (refs #132).
 - **A reclaimed spot instance reported its work as successful.** An interrupted
   instance goes to `shutting-down`, which `EC2_STATUS_MAPPING` renders
   `COMPLETED` — so Parsl saw a block that finished normally, and `retries` never
@@ -123,6 +151,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   their sandbox. The watched filename is read from the `state_file_path` signature
   default rather than hardcoded, so renaming the default cannot quietly disable
   the check (refs #93).
+
+### Security
+- **The IAM leak fixed above was accumulating standing privileged principals.**
+  Each orphaned role carried `AmazonSSMManagedInstanceCore` — which grants
+  `ssm:SendCommand`-reachable command execution — and outlived the instances it
+  was made for with nothing to delete it. Verified against a real account: **94
+  orphaned roles and 94 matching instance profiles**, part of 450 roles against
+  IAM's default quota of 1,000, so the drift was also walking toward a hard
+  account-level failure that would have blocked unrelated work. Both halves of the
+  problem are addressed: the provider no longer creates orphans, and the cleanup
+  tool removes existing ones (closes #132).
 
 ## [0.7.0] - 2026-07-31
 

--- a/parsl_ephemeral_aws/modes/standard.py
+++ b/parsl_ephemeral_aws/modes/standard.py
@@ -47,6 +47,7 @@ from parsl_ephemeral_aws.utils.aws import (
     build_launch_template_data,
     create_launch_template,
     delete_launch_template,
+    delete_ssm_instance_profile,
     get_default_ami,
     get_or_create_ssm_instance_profile,
     wait_for_resource,
@@ -205,6 +206,10 @@ class StandardMode(OperatingMode):
         self.warm_pool_ttl = warm_pool_ttl
         self.iam_instance_profile_arn = iam_instance_profile_arn
         self.auto_create_instance_profile = auto_create_instance_profile
+        # True when this mode auto-created the IAM role and instance profile, and
+        # so is the one responsible for deleting them (#132). A caller-supplied
+        # iam_instance_profile_arn is never ours to delete.
+        self._owns_instance_profile: bool = False
         # List of instance IDs currently in the warm pool (ready for reuse, FIFO)
         self._warm_instances: List[str] = []
 
@@ -552,6 +557,31 @@ class StandardMode(OperatingMode):
             self._launch_template_id = None
             self._launch_template_version = None
 
+    def _delete_instance_profile(self) -> None:
+        """Delete the IAM role and instance profile, if this mode created them.
+
+        ``_owns_instance_profile`` is the guard, and it is the whole point: a
+        profile the caller supplied through ``iam_instance_profile_arn`` is shared
+        infrastructure that other workloads may depend on, so deleting it would
+        be a far worse bug than the leak this fixes (#132, same hazard class as
+        the serverless security-group deletion in #100).
+
+        Called during cleanup after the instances are confirmed terminated --
+        IAM refuses to delete a profile still attached to a running instance.
+        """
+        if not self._owns_instance_profile:
+            return
+
+        try:
+            delete_ssm_instance_profile(self.session, self.provider_id)
+        except Exception as e:
+            logger.error(f"Failed to delete IAM instance profile: {e}")
+        finally:
+            # Dropped either way: the ARN no longer names something usable, and
+            # cleanup is not retried.
+            self._owns_instance_profile = False
+            self.iam_instance_profile_arn = None
+
     def _launch_template_reference(self) -> Optional[Dict[str, str]]:
         """Return the ``LaunchTemplate`` kwarg for a launch, or None.
 
@@ -584,6 +614,9 @@ class StandardMode(OperatingMode):
             "owns_baked_ami": self._owns_baked_ami,
             "launch_template_id": self._launch_template_id,
             "launch_template_version": self._launch_template_version,
+            # Without this, a provider resumed from state would not know it owns
+            # the IAM pair and would leave it behind on cleanup (#132).
+            "owns_instance_profile": self._owns_instance_profile,
         }
 
         # Include spot fleet state if applicable
@@ -640,6 +673,10 @@ class StandardMode(OperatingMode):
                 # second one (#85).
                 self._launch_template_id = state.get("launch_template_id")
                 self._launch_template_version = state.get("launch_template_version")
+
+                # Reclaim ownership of the IAM pair this provider created on an
+                # earlier run, so cleanup can still delete it (#132).
+                self._owns_instance_profile = state.get("owns_instance_profile", False)
 
                 # Restore baked AMI state
                 saved_baked_ami = state.get("baked_ami_id")
@@ -849,6 +886,12 @@ class StandardMode(OperatingMode):
                 name_suffix=self.provider_id,
                 auto_create=True,
             )
+            # Ownership follows taking this branch, not create-vs-fetch (#132).
+            # The names derive from provider_id, so a provider resumed from a
+            # state file *fetches* the pair it made on its first run -- gating on
+            # "did this call create it" would disown it on every restart and leak
+            # the pair permanently.
+            self._owns_instance_profile = True
             logger.info(
                 f"Resolved IAM instance profile {self.iam_instance_profile_arn} "
                 "for SSM command dispatch"
@@ -2064,6 +2107,12 @@ class StandardMode(OperatingMode):
             # above and before the state save below, so a failure to delete it
             # still leaves the ID cleared in the persisted state.
             self._delete_launch_template()
+
+            # Delete the IAM role and instance profile, but only if we made them
+            # (#132). Before the fix nothing deleted them, so every run left a
+            # standing principal carrying AmazonSSMManagedInstanceCore behind and
+            # the account walked toward IAM's 1,000-role quota.
+            self._delete_instance_profile()
 
             # Clean up Spot Fleet resources if using spot fleet
             if self.use_spot_fleet and self.spot_fleet_manager:

--- a/parsl_ephemeral_aws/utils/aws.py
+++ b/parsl_ephemeral_aws/utils/aws.py
@@ -1858,8 +1858,7 @@ def get_or_create_ssm_instance_profile(
         return None
 
     iam = session.client("iam")
-    role_name = f"parsl-ephemeral-ssm-role-{name_suffix}"
-    profile_name = f"parsl-ephemeral-ssm-profile-{name_suffix}"
+    role_name, profile_name = ssm_instance_profile_names(name_suffix)
 
     get_or_create_iam_role(
         iam_client=iam,
@@ -1908,6 +1907,113 @@ def get_or_create_ssm_instance_profile(
         raise ResourceCreationError(
             f"Failed to create instance profile {profile_name}: {e}"
         ) from e
+
+
+def ssm_instance_profile_names(name_suffix: str) -> Tuple[str, str]:
+    """Return the ``(role_name, profile_name)`` pair for *name_suffix*.
+
+    The names are derived, not stored, so the creator and the deleter cannot
+    drift apart. ``get_or_create_ssm_instance_profile`` and
+    ``delete_ssm_instance_profile`` are the two callers.
+    """
+    return (
+        f"parsl-ephemeral-ssm-role-{name_suffix}",
+        f"parsl-ephemeral-ssm-profile-{name_suffix}",
+    )
+
+
+def delete_ssm_instance_profile(session: boto3.Session, name_suffix: str) -> bool:
+    """Delete the SSM role and instance profile named for *name_suffix*.
+
+    The inverse of ``get_or_create_ssm_instance_profile``. **Only call this for a
+    pair this provider created** — see ``StandardMode._owns_instance_profile``. A
+    caller-supplied profile belongs to the caller, and deleting it would break
+    every other workload using it.
+
+    IAM enforces the teardown order: a profile holding a role cannot be deleted,
+    and a role that is still in a profile or has policies attached cannot be
+    deleted either. So it goes role-out-of-profile, profile, policies-off-role,
+    role. Getting this wrong yields ``DeleteConflict`` rather than a partial
+    success, which is why the order is not a matter of taste.
+
+    Every step tolerates ``NoSuchEntity``: cleanup runs on paths that may already
+    have partially completed, and a missing resource is the desired end state
+    rather than an error.
+
+    Parameters
+    ----------
+    session : boto3.Session
+        AWS session used to build the IAM client.
+    name_suffix : str
+        The same discriminator passed to ``get_or_create_ssm_instance_profile``
+        — normally the provider ID.
+
+    Returns
+    -------
+    bool
+        True if the pair is gone (including "was already gone"), False if
+        something could not be deleted. Never raises: a cleanup failure must not
+        mask whatever the caller was originally doing.
+    """
+    role_name, profile_name = ssm_instance_profile_names(name_suffix)
+    iam = session.client("iam")
+    ok = True
+
+    def _tolerate_missing(op: str, fn: Any) -> bool:
+        """Run *fn*, treating an absent resource as success."""
+        try:
+            fn()
+            return True
+        except ClientError as e:
+            if e.response["Error"]["Code"] in ("NoSuchEntity", "NoSuchEntityException"):
+                logger.debug(f"{op}: already gone")
+                return True
+            logger.warning(f"{op} failed: {e}")
+            return False
+        except Exception as e:
+            logger.warning(f"{op} failed: {e}")
+            return False
+
+    ok &= _tolerate_missing(
+        f"Removing role {role_name} from profile {profile_name}",
+        lambda: iam.remove_role_from_instance_profile(
+            InstanceProfileName=profile_name, RoleName=role_name
+        ),
+    )
+    ok &= _tolerate_missing(
+        f"Deleting instance profile {profile_name}",
+        lambda: iam.delete_instance_profile(InstanceProfileName=profile_name),
+    )
+
+    # Detach whatever is actually attached rather than assuming only
+    # AmazonSSMManagedInstanceCore is: delete_role refuses while any policy
+    # remains, so an operator-added policy would otherwise strand the role.
+    try:
+        attached = iam.list_attached_role_policies(RoleName=role_name).get(
+            "AttachedPolicies", []
+        )
+    except ClientError as e:
+        if e.response["Error"]["Code"] not in ("NoSuchEntity", "NoSuchEntityException"):
+            logger.warning(f"Listing policies on role {role_name} failed: {e}")
+            ok = False
+        attached = []
+
+    for policy in attached:
+        ok &= _tolerate_missing(
+            f"Detaching {policy['PolicyArn']} from role {role_name}",
+            lambda p=policy: iam.detach_role_policy(
+                RoleName=role_name, PolicyArn=p["PolicyArn"]
+            ),
+        )
+
+    ok &= _tolerate_missing(
+        f"Deleting role {role_name}",
+        lambda: iam.delete_role(RoleName=role_name),
+    )
+
+    if ok:
+        logger.info(f"Deleted IAM role {role_name} and profile {profile_name}")
+    return ok
 
 
 #: How long to wait for a new instance profile to become visible to EC2.

--- a/tests/unit/test_instance_profile.py
+++ b/tests/unit/test_instance_profile.py
@@ -19,7 +19,9 @@ from moto import mock_aws
 from parsl_ephemeral_aws.modes.standard import StandardMode
 from parsl_ephemeral_aws.utils.aws import (
     _wait_for_instance_profile,
+    delete_ssm_instance_profile,
     get_or_create_ssm_instance_profile,
+    ssm_instance_profile_names,
 )
 
 
@@ -369,4 +371,253 @@ class TestStandardModeProfileResolution:
             mode.initialize()
 
         assert mode.initialized is True
+        assert mode.iam_instance_profile_arn is None
+
+
+class TestDeleteSSMInstanceProfile:
+    """``delete_ssm_instance_profile`` is the inverse of the creator (#132).
+
+    Nothing deleted the role or profile before this, so every run left a standing
+    principal holding ``AmazonSSMManagedInstanceCore`` behind. The account under
+    test had accumulated 94 of them against IAM's 1,000-role quota.
+    """
+
+    def test_round_trip_leaves_nothing_behind(self, iam_session):
+        """Create then delete must return IAM to its starting state."""
+        session = iam_session
+        iam = session.client("iam")
+
+        get_or_create_ssm_instance_profile(
+            session=session, name_suffix="rt", auto_create=True
+        )
+        role_name, profile_name = ssm_instance_profile_names("rt")
+        # Precondition: both really exist, so the assertions below mean something.
+        iam.get_role(RoleName=role_name)
+        iam.get_instance_profile(InstanceProfileName=profile_name)
+
+        assert delete_ssm_instance_profile(session, "rt") is True
+
+        with pytest.raises(ClientError) as role_gone:
+            iam.get_role(RoleName=role_name)
+        assert role_gone.value.response["Error"]["Code"] == "NoSuchEntity"
+
+        with pytest.raises(ClientError) as profile_gone:
+            iam.get_instance_profile(InstanceProfileName=profile_name)
+        assert profile_gone.value.response["Error"]["Code"] == "NoSuchEntity"
+
+    def test_deleting_what_was_never_created_succeeds(self, iam_session):
+        """Cleanup runs on partially-completed paths, so absent means done.
+
+        Reporting failure here would turn an already-clean account into a logged
+        error on every teardown.
+        """
+        assert delete_ssm_instance_profile(iam_session, "never-existed") is True
+
+    def test_is_idempotent(self, iam_session):
+        """A second delete must not report failure."""
+        session = iam_session
+        get_or_create_ssm_instance_profile(
+            session=session, name_suffix="twice", auto_create=True
+        )
+
+        assert delete_ssm_instance_profile(session, "twice") is True
+        assert delete_ssm_instance_profile(session, "twice") is True
+
+    def test_detaches_operator_added_policies_too(self, iam_session):
+        """``delete_role`` refuses while *any* policy is attached.
+
+        Detaching only ``AmazonSSMManagedInstanceCore`` by name would strand the
+        role forever the moment an operator attached anything else, so the
+        implementation lists what is actually there.
+        """
+        session = iam_session
+        iam = session.client("iam")
+        get_or_create_ssm_instance_profile(
+            session=session, name_suffix="extra", auto_create=True
+        )
+        role_name, _ = ssm_instance_profile_names("extra")
+        iam.attach_role_policy(
+            RoleName=role_name,
+            PolicyArn="arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess",
+        )
+
+        assert delete_ssm_instance_profile(session, "extra") is True
+
+        with pytest.raises(ClientError):
+            iam.get_role(RoleName=role_name)
+
+    def test_the_names_match_the_creator(self):
+        """The creator and deleter derive names from one helper, not two literals."""
+        assert ssm_instance_profile_names("abc") == (
+            "parsl-ephemeral-ssm-role-abc",
+            "parsl-ephemeral-ssm-profile-abc",
+        )
+
+
+class TestStandardModeProfileOwnership:
+    """Who deletes the IAM pair, and who must never delete it (#132)."""
+
+    @pytest.fixture
+    def mock_session(self):
+        session = MagicMock(spec=boto3.Session)
+        session.region_name = "us-east-1"
+        return session
+
+    @pytest.fixture
+    def mock_state_store(self):
+        store = MagicMock()
+        store.load_state.return_value = None
+        return store
+
+    def _mode(self, mock_session, mock_state_store, **overrides):
+        params = {
+            "provider_id": "test-provider",
+            "session": mock_session,
+            "state_store": mock_state_store,
+            "image_id": "ami-12345",
+            "region": "us-east-1",
+            **NETWORK_IDS,
+        }
+        params.update(overrides)
+        return StandardMode(**params)
+
+    def test_auto_created_profile_is_owned_and_deleted(
+        self, mock_session, mock_state_store
+    ):
+        """The leak itself: an auto-created pair must be torn down."""
+        mode = self._mode(
+            mock_session,
+            mock_state_store,
+            one_shot=True,
+            auto_create_instance_profile=True,
+        )
+
+        with patch(
+            "parsl_ephemeral_aws.modes.standard.get_or_create_ssm_instance_profile",
+            return_value="arn:aws:iam::1:instance-profile/auto",
+        ):
+            mode.initialize()
+
+        assert mode._owns_instance_profile is True
+
+        with patch(
+            "parsl_ephemeral_aws.modes.standard.delete_ssm_instance_profile"
+        ) as delete:
+            mode.cleanup_infrastructure()
+
+        delete.assert_called_once_with(mock_session, "test-provider")
+
+    def test_a_supplied_profile_is_never_deleted(self, mock_session, mock_state_store):
+        """The dangerous case. A caller's profile is shared infrastructure.
+
+        Deleting it would break every other workload using it -- a worse bug than
+        the leak, and the same hazard as the serverless SG deletion in #100.
+        """
+        mode = self._mode(
+            mock_session,
+            mock_state_store,
+            one_shot=True,
+            iam_instance_profile_arn="arn:aws:iam::1:instance-profile/theirs",
+            auto_create_instance_profile=True,
+        )
+        mode.initialize()
+
+        assert mode._owns_instance_profile is False
+
+        with patch(
+            "parsl_ephemeral_aws.modes.standard.delete_ssm_instance_profile"
+        ) as delete:
+            mode.cleanup_infrastructure()
+
+        delete.assert_not_called()
+
+    def test_nothing_is_deleted_when_nothing_was_created(
+        self, mock_session, mock_state_store
+    ):
+        """No flag, no ARN, no IAM call on either end."""
+        mode = self._mode(mock_session, mock_state_store)
+        mode.initialize()
+
+        assert mode._owns_instance_profile is False
+
+        with patch(
+            "parsl_ephemeral_aws.modes.standard.delete_ssm_instance_profile"
+        ) as delete:
+            mode.cleanup_infrastructure()
+
+        delete.assert_not_called()
+
+    def test_ownership_survives_a_restart(self, mock_session, mock_state_store):
+        """A resumed provider must still delete the pair it created earlier.
+
+        The names derive from ``provider_id``, so on restart the resolver *fetches*
+        rather than creates. Gating ownership on create-vs-fetch would therefore
+        disown the pair on every restart and leak it permanently -- which is why
+        the flag is persisted rather than recomputed.
+        """
+        mock_state_store.load_state.return_value = {
+            "provider_id": "test-provider",
+            "resources": {},
+            "initialized": True,
+            "owns_instance_profile": True,
+        }
+        mode = self._mode(
+            mock_session,
+            mock_state_store,
+            one_shot=True,
+            auto_create_instance_profile=True,
+        )
+
+        assert mode.load_state() is True
+        assert mode._owns_instance_profile is True
+
+        with patch(
+            "parsl_ephemeral_aws.modes.standard.delete_ssm_instance_profile"
+        ) as delete:
+            mode.cleanup_infrastructure()
+
+        delete.assert_called_once_with(mock_session, "test-provider")
+
+    def test_ownership_is_persisted(self, mock_session, mock_state_store):
+        """``save_state`` must carry the flag, or the restart case cannot work."""
+        mode = self._mode(
+            mock_session,
+            mock_state_store,
+            one_shot=True,
+            auto_create_instance_profile=True,
+        )
+
+        with patch(
+            "parsl_ephemeral_aws.modes.standard.get_or_create_ssm_instance_profile",
+            return_value="arn:aws:iam::1:instance-profile/auto",
+        ):
+            mode.initialize()
+
+        mode.save_state()
+
+        saved = mock_state_store.save_state.call_args[0][1]
+        assert saved["owns_instance_profile"] is True
+
+    def test_a_failed_deletion_does_not_raise(self, mock_session, mock_state_store):
+        """Cleanup must not mask whatever the caller was originally doing."""
+        mode = self._mode(
+            mock_session,
+            mock_state_store,
+            one_shot=True,
+            auto_create_instance_profile=True,
+        )
+
+        with patch(
+            "parsl_ephemeral_aws.modes.standard.get_or_create_ssm_instance_profile",
+            return_value="arn:aws:iam::1:instance-profile/auto",
+        ):
+            mode.initialize()
+
+        with patch(
+            "parsl_ephemeral_aws.modes.standard.delete_ssm_instance_profile",
+            side_effect=RuntimeError("AccessDenied"),
+        ):
+            mode.cleanup_infrastructure()  # must not raise
+
+        # And the ARN is dropped either way: it no longer names anything usable.
         assert mode.iam_instance_profile_arn is None

--- a/tools/cleanup_aws_resources.py
+++ b/tools/cleanup_aws_resources.py
@@ -10,9 +10,20 @@ import sys
 from typing import List, Dict
 import logging
 
+from parsl_ephemeral_aws.utils.aws import (
+    delete_ssm_instance_profile,
+    ssm_instance_profile_names,
+)
+
 # Configure logging
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
+
+# Both halves of the pair are named for the provider_id, so the suffix is what
+# identifies an orphan. See ssm_instance_profile_names().
+_ROLE_PREFIX, _PROFILE_PREFIX = (
+    prefix[: -len("suffix")] for prefix in ssm_instance_profile_names("suffix")
+)
 
 
 class AWSResourceCleaner:
@@ -23,6 +34,7 @@ class AWSResourceCleaner:
         try:
             self.session = boto3.Session(profile_name=profile_name, region_name=region)
             self.ec2_client = self.session.client("ec2")
+            self.iam_client = self.session.client("iam")
             self.region = region
             logger.info(
                 f"Initialized AWS session for region {region} with profile {profile_name}"
@@ -185,6 +197,66 @@ class AWSResourceCleaner:
             logger.info(f"✅ All {success_count} security groups deleted successfully")
             return True
 
+    def get_parsl_iam_resources(self) -> List[str]:
+        """Get the provider_id suffixes of orphaned SSM roles and instance profiles.
+
+        Roles and profiles can be orphaned independently — a partial teardown may
+        leave one without the other — so both listings are scanned and the suffixes
+        unioned. IAM is a global service, so this is not scoped by ``--region``.
+        """
+        suffixes = set()
+
+        try:
+            for page in self.iam_client.get_paginator("list_roles").paginate():
+                for role in page["Roles"]:
+                    if role["RoleName"].startswith(_ROLE_PREFIX):
+                        suffixes.add(role["RoleName"][len(_ROLE_PREFIX) :])
+        except Exception as e:
+            logger.error(f"Error listing IAM roles: {e}")
+
+        try:
+            paginator = self.iam_client.get_paginator("list_instance_profiles")
+            for page in paginator.paginate():
+                for profile in page["InstanceProfiles"]:
+                    name = profile["InstanceProfileName"]
+                    if name.startswith(_PROFILE_PREFIX):
+                        suffixes.add(name[len(_PROFILE_PREFIX) :])
+        except Exception as e:
+            logger.error(f"Error listing IAM instance profiles: {e}")
+
+        return sorted(suffixes)
+
+    def delete_iam_resources(self, suffixes: List[str]) -> bool:
+        """Delete the SSM role and instance profile for each suffix."""
+        if not suffixes:
+            logger.info("No IAM roles or instance profiles to delete")
+            return True
+
+        success_count = 0
+        for suffix in suffixes:
+            role_name, profile_name = ssm_instance_profile_names(suffix)
+            if delete_ssm_instance_profile(self.session, suffix):
+                logger.info(f"✅ Deleted IAM role/profile pair: {suffix}")
+                success_count += 1
+            else:
+                logger.warning(
+                    f"❌ Failed to fully delete {role_name} / {profile_name}"
+                )
+
+        if success_count < len(suffixes):
+            logger.info(
+                f"Successfully deleted {success_count}/{len(suffixes)} "
+                "IAM role/profile pairs"
+            )
+            logger.info(
+                "Failed pairs may still be attached to an instance that has not "
+                "finished terminating"
+            )
+            return False
+
+        logger.info(f"✅ All {success_count} IAM role/profile pairs deleted")
+        return True
+
     def cleanup_all(self, dry_run: bool = False) -> bool:
         """Clean up all Parsl AWS resources."""
         logger.info("🧹 Starting AWS resource cleanup")
@@ -197,6 +269,7 @@ class AWSResourceCleaner:
         # Get all resources
         instances = self.get_parsl_instances()
         security_groups = self.get_parsl_security_groups()
+        iam_suffixes = self.get_parsl_iam_resources()
 
         # Report what was found
         logger.info(f"Found {len(instances)} instances to clean up:")
@@ -209,7 +282,12 @@ class AWSResourceCleaner:
         for sg in security_groups:
             logger.info(f"  {sg['id']} - {sg['name']}")
 
-        if not instances and not security_groups:
+        logger.info(f"\nFound {len(iam_suffixes)} IAM role/profile pairs to clean up:")
+        for suffix in iam_suffixes:
+            role_name, profile_name = ssm_instance_profile_names(suffix)
+            logger.info(f"  {role_name} / {profile_name}")
+
+        if not instances and not security_groups and not iam_suffixes:
             logger.info("🎉 No resources to clean up!")
             return True
 
@@ -221,7 +299,8 @@ class AWSResourceCleaner:
         print("\n" + "=" * 50)
         try:
             response = input(
-                f"Delete {len(instances)} instances and {len(security_groups)} security groups? (yes/no): "
+                f"Delete {len(instances)} instances, {len(security_groups)} security "
+                f"groups and {len(iam_suffixes)} IAM role/profile pairs? (yes/no): "
             )
             if response.lower() not in ["yes", "y"]:
                 logger.info("❌ Cleanup cancelled by user")
@@ -263,6 +342,14 @@ class AWSResourceCleaner:
             logger.info("\nCleaning up security groups...")
             time.sleep(30)  # Give AWS time to clean up network interfaces
             if not self.delete_security_groups(security_groups):
+                success = False
+
+        # Delete IAM roles and instance profiles last: IAM refuses to delete a
+        # profile that is still attached to an instance, so the terminations above
+        # have to have settled first.
+        if iam_suffixes:
+            logger.info("\nCleaning up IAM roles and instance profiles...")
+            if not self.delete_iam_resources(iam_suffixes):
                 success = False
 
         if success:


### PR DESCRIPTION
Phase A of v0.8.0 (Stabilization). Closes #132.

## The defect

`StandardMode._resolve_instance_profile()` created a
`parsl-ephemeral-ssm-{role,profile}-<provider_id>` pair, and `provider_id` is a fresh
UUID per run — so every run made a new pair. `cleanup_infrastructure()` deleted the
launch template, EventBridge rule, SQS queue, and baked AMI, but never the IAM pair;
no `remove_role_from_instance_profile` / `delete_instance_profile` /
`detach_role_policy` / `delete_role` call existed anywhere on the `StandardMode` path.

Each orphan is a standing principal carrying `AmazonSSMManagedInstanceCore`, which
grants `ssm:SendCommand`-reachable command execution. Verified live against account
`942542972736`: **94 orphaned roles and 94 matching instance profiles**, part of 450
roles against IAM's default quota of 1,000 — a security drift that was also walking
toward a hard account-level failure that would have blocked unrelated work.

## The fix

`delete_ssm_instance_profile()` in `utils/aws.py`, beside the creator, called from
`cleanup_infrastructure()` after `_delete_launch_template()`:

- **Teardown order is mandatory** — `remove_role_from_instance_profile` →
  `delete_instance_profile` → `detach_role_policy` → `delete_role`. IAM rejects any
  other order with `DeleteConflict` rather than partially succeeding.
- **`NoSuchEntity` is tolerated at every step**, so cleanup is idempotent and
  "already gone" counts as success.
- **Logs rather than raises** — a cleanup failure must not mask whatever the caller
  was originally doing.
- **Detaches whatever is actually attached**, not `AmazonSSMManagedInstanceCore` by
  name: `delete_role` refuses while any policy remains, so an operator-added policy
  would otherwise strand the role forever.
- `ssm_instance_profile_names()` is now the single source of both names, shared by
  creator, deleter, and the cleanup tool, so they cannot drift apart.

### Ownership gating is the load-bearing part

A caller-supplied `iam_instance_profile_arn` is shared infrastructure other workloads
may depend on. Deleting it would be a **worse** bug than the leak — the same hazard
class as the serverless security-group deletion fixed in #100. So `_delete_instance_profile()`
returns early unless `_owns_instance_profile`.

**The gate is "took the auto-create branch," not "did this call create it."** The
issue's suggested design — have `get_or_create_ssm_instance_profile()` report
create-vs-fetch — is wrong here, and reading `load_state()` is what surfaced it: the
names derive from `provider_id`, so a provider resumed from a state file *fetches* the
pair it created on its first run. A create-vs-fetch gate would disown the pair on every
restart and leak it permanently. The flag is therefore persisted as
`owns_instance_profile` and restored in `load_state()`, mirroring the existing
`_owns_baked_ami` pattern. `test_ownership_survives_a_restart` pins that reasoning.

## Reaping the existing orphans

`tools/cleanup_aws_resources.py` touched no IAM at all. It gains a
`get_parsl_iam_resources()` / `delete_iam_resources()` pair reusing
`delete_ssm_instance_profile()`, honouring the existing `--profile`/`--region`/`--dry-run`
flags:

- Roles and profiles can be orphaned **independently** by a partial teardown, so both
  listings are scanned (paginated) and the suffixes unioned.
- The IAM pass runs **after** the instance terminations, because IAM refuses to delete
  a profile still attached to an instance.
- IAM is global, so the pass is deliberately not scoped by `--region`.

## Verification

Gates, all against the v0.7.0 baseline:

| Gate | Result |
|---|---|
| `pytest tests/unit tests/security` | **1094 passed, 2 skipped** (was 1082 passed) |
| `ruff check parsl_ephemeral_aws tests` | clean |
| `mypy parsl_ephemeral_aws` | **76** — diffed error-by-error vs `main`, **zero introduced** |

**12 new tests** in `tests/unit/test_instance_profile.py` (26 total in the file):

- `TestDeleteSSMInstanceProfile` (moto-backed, 5) — round trip leaves nothing behind;
  deleting what was never created succeeds; is idempotent; detaches operator-added
  policies too; the names match the creator.
- `TestStandardModeProfileOwnership` (7) — auto-created profile is owned and deleted;
  **a supplied profile is never deleted**; nothing deleted when nothing was created;
  ownership survives a restart; ownership is persisted; a failed deletion does not raise.

Unit tests cannot prove a role was actually deleted, so this was verified live:

```
before:  94 roles / 94 profiles   (450 roles in account)
after:    0 roles /  0 profiles   (356 roles in account)
```

The reaping run also cleared **174 orphaned `aws-enhanced-*` security groups** via the
tool's pre-existing EC2 pass. Before reaping I confirmed all 174 were provider-created
(`Parsl AWS Provider: …`, zero attached ENIs), that the E2E test SG `sg-b8fbc380` is
named `default` and so unmatched, and that the account's only two live instance-profile
associations belong to an unrelated ElasticGCS project — no parsl-ephemeral profile was
in use.

## Notes

Phase A must precede Phase E (#65 warm-pool E2E): those tests require
`auto_create_instance_profile=True` and would each have leaked another pair.