### PR TITLE
fix: record every classified fleet error, not just unknown ones (closes #120)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the removed API only, and never exported from the package root (refs #137).
 
 ### Fixed
+- **`error_history` recorded only the fleet errors nobody could classify.**
+  `SpotFleetManager._translate_fleet_error()` called
+  `RobustErrorHandler.handle_error()` on the unrecognized fallthrough alone, so
+  the five families it *did* understand — launch-template not found, insufficient
+  capacity, invalid fleet configuration, spot quota exceeded, and throttling —
+  were translated to typed exceptions and never counted. That is backwards: those
+  are exactly the failures a caller reads out of the history to decide whether to
+  back off, diversify instance types, or request a limit increase, whereas an
+  unclassifiable error is the least actionable of the set.
+  `get_error_statistics()` was therefore blind to every failure the code
+  understood. Recording now happens before classification, so every branch
+  records (closes #120).
+
+  The issue's second half — that `_create_spot_fleet_with_retry` named a retry it
+  did not perform — was already resolved: the method is now
+  `_translate_fleet_error`, and `@retry_with_backoff()` decorates `create_blocks`.
+  The two tests pinning the old behaviour still called the removed name, so
+  `patch.object`'s missing-attribute check had been failing them both rather than
+  exercising anything; they are retargeted and parametrized over all six
+  families.
 - **Every `auto_create_instance_profile` run leaked an IAM role and an instance
   profile.** `StandardMode._resolve_instance_profile()` created a
   `parsl-ephemeral-ssm-{role,profile}-<provider_id>` pair, and `provider_id` is a

--- a/parsl_ephemeral_aws/compute/spot_fleet.py
+++ b/parsl_ephemeral_aws/compute/spot_fleet.py
@@ -360,13 +360,28 @@ class SpotFleetManager:
         exc : ClientError
             The error EC2 returned.
         context : ErrorContext
-            Error context, recorded for anything unrecognised.
+            Error context. Every error is recorded against it, whichever branch
+            below classifies it.
 
         Returns
         -------
         Exception
             The exception the caller should raise.
         """
+        # Record before classifying, so the recognized families land in
+        # error_history too. Recording only the unrecognized fallthrough had it
+        # backwards (#120): capacity shortages, quota rejections, and throttling
+        # are precisely the failures worth counting, because a caller deciding
+        # whether to back off, diversify instance types, or ask for a limit
+        # increase reads them out of the history. An error nobody classified is
+        # the least actionable of the lot.
+        #
+        # handle_error also attempts recovery for RETRY/FALLBACK actions, but
+        # ErrorRecoveryHandler registers no strategy for "create_ec2_fleet", so
+        # attempt_recovery returns False without doing anything. This stays a
+        # recording call; retries are @retry_with_backoff on create_blocks.
+        self.error_handler.handle_error(exc, context)
+
         error_code = exc.response["Error"]["Code"]
 
         if error_code in (
@@ -406,7 +421,6 @@ class SpotFleetManager:
                 retry_after=retry_after,
             )
 
-        self.error_handler.handle_error(exc, context)
         return SpotFleetError(f"Failed to create EC2 Fleet: {exc}")
 
     @retry_with_backoff()

--- a/tests/integration/test_error_handling_integration.py
+++ b/tests/integration/test_error_handling_integration.py
@@ -11,10 +11,11 @@ from botocore.exceptions import ClientError
 from parsl_ephemeral_aws.compute.ec2 import EC2Manager
 from parsl_ephemeral_aws.compute.ecs import ECSManager
 from parsl_ephemeral_aws.compute.spot_fleet import SpotFleetManager
-from parsl_ephemeral_aws.error_handling import RobustErrorHandler
+from parsl_ephemeral_aws.error_handling import ErrorContext, RobustErrorHandler
 from parsl_ephemeral_aws.exceptions import (
     ResourceCreationError,
     SpotFleetError,
+    SpotFleetRequestError,
     SpotFleetThrottlingError,
 )
 from tests.support import make_manager, mock_provider
@@ -88,52 +89,96 @@ class TestErrorHandlingIntegration:
         error_record = manager.error_handler.error_history[-1]
         assert "InternalError" in str(error_record.exception)
 
+    @staticmethod
+    def _translate(manager, code, message):
+        """Put *code* through ``_translate_fleet_error`` and return the exception.
+
+        Retargeted from ``_create_spot_fleet_with_retry``, which went away with
+        the legacy ``RequestSpotFleet`` API in #86 -- these two tests had been
+        raising ``AttributeError`` from ``patch.object``'s missing-attribute
+        check ever since, so neither had exercised anything.
+
+        The method *returns* rather than raises, so the caller keeps its
+        ``raise ... from`` chain and the botocore traceback survives.
+        """
+        exc = ClientError(
+            error_response={"Error": {"Code": code, "Message": message}},
+            operation_name="CreateFleet",
+        )
+        context = ErrorContext(
+            operation="create_ec2_fleet",
+            resource_type="ec2_fleet",
+            resource_id="block-1",
+        )
+        return manager._translate_fleet_error(exc, context)
+
     def test_spot_fleet_throttling_becomes_a_typed_error(self):
         """A throttled request is reported as throttling, not a bare ClientError.
 
         The caller can only back off if it can tell throttling apart from a
-        launch-spec mistake, so the specific type is the contract.
-
-        Note the recognized codes are *not* added to ``error_history`` -- only the
-        unrecognized fallthrough is (#120). The original test asserted
-        ``len(error_history) > 0`` here and could never have passed; see
-        ``test_spot_fleet_unrecognized_error_is_recorded`` for the branch that
-        does record.
+        launch-spec mistake, so the specific type is the contract, and
+        ``retry_after`` is what it carries that the base class does not.
         """
-        ec2_client = MagicMock()
-        ec2_client.request_spot_fleet.side_effect = ClientError(
-            error_response={
-                "Error": {"Code": "Throttling", "Message": "Request rate exceeded"}
-            },
-            operation_name="RequestSpotFleet",
-        )
+        manager = make_manager(SpotFleetManager, "spot_fleet", client=MagicMock())
 
-        manager = make_manager(SpotFleetManager, "spot_fleet", client=ec2_client)
+        result = self._translate(manager, "Throttling", "Request rate exceeded")
 
-        with pytest.raises(SpotFleetThrottlingError, match="API throttling error"):
-            manager._create_spot_fleet_with_retry(
-                {"SpotFleetRequestConfig": {}}, MagicMock()
-            )
+        assert isinstance(result, SpotFleetThrottlingError)
+        assert result.retry_after == 60
 
-    def test_spot_fleet_unrecognized_error_is_recorded(self):
-        """An unmapped error code lands in the handler's history for analysis."""
-        ec2_client = MagicMock()
-        ec2_client.request_spot_fleet.side_effect = ClientError(
-            error_response={
-                "Error": {"Code": "InternalError", "Message": "Server error"}
-            },
-            operation_name="RequestSpotFleet",
-        )
+    @pytest.mark.parametrize(
+        "code,expected",
+        [
+            ("InvalidLaunchTemplateId.NotFound", SpotFleetRequestError),
+            ("InsufficientInstanceCapacity", SpotFleetError),
+            ("InvalidFleetConfig", SpotFleetRequestError),
+            ("MaxSpotInstanceCountExceeded", SpotFleetRequestError),
+            ("Throttling", SpotFleetThrottlingError),
+            ("InternalError", SpotFleetError),  # the unrecognized fallthrough
+        ],
+    )
+    def test_every_classified_fleet_error_is_recorded(self, code, expected):
+        """Recognized error families reach ``error_history``, not just unknown ones.
 
-        manager = make_manager(SpotFleetManager, "spot_fleet", client=ec2_client)
+        Recording used to happen on the fallthrough branch alone (#120), which is
+        backwards: an insufficient-capacity or quota rejection is exactly what a
+        caller counts in order to decide whether to diversify instance types or
+        request a limit increase, whereas an error nobody could classify is the
+        least actionable of the set. ``get_error_statistics()`` was therefore
+        blind to every failure the code understood.
+        """
+        manager = make_manager(SpotFleetManager, "spot_fleet", client=MagicMock())
 
-        with pytest.raises(SpotFleetError):
-            manager._create_spot_fleet_with_retry(
-                {"SpotFleetRequestConfig": {}}, MagicMock()
-            )
+        result = self._translate(manager, code, "boom")
 
+        assert isinstance(result, expected)
         assert len(manager.error_handler.error_history) == 1
-        assert "InternalError" in str(manager.error_handler.error_history[-1].exception)
+        record = manager.error_handler.error_history[-1]
+        assert code in str(record.exception)
+        assert record.context.operation == "create_ec2_fleet"
+
+    def test_recording_does_not_swallow_the_error(self):
+        """The handler records; the caller still gets an exception to raise.
+
+        ``handle_error`` runs a recovery attempt for RETRY/FALLBACK actions, and
+        ``InsufficientInstanceCapacity`` maps to FALLBACK -- so this pins that a
+        "successful" recovery cannot silently turn a failed fleet into a
+        pass. No strategy is registered for ``create_ec2_fleet``, but the point
+        is that translation does not depend on that staying true.
+        """
+        manager = make_manager(SpotFleetManager, "spot_fleet", client=MagicMock())
+
+        with patch.object(
+            manager.error_handler.recovery_handler,
+            "attempt_recovery",
+            return_value=True,
+        ):
+            result = self._translate(
+                manager, "InsufficientInstanceCapacity", "no capacity"
+            )
+
+        assert isinstance(result, SpotFleetError)
+        assert len(manager.error_handler.error_history) == 1
 
     def test_error_statistics_collection(self):
         """Test that error statistics are properly collected across modules."""


### PR DESCRIPTION
## What

`SpotFleetManager._translate_fleet_error()` called
`RobustErrorHandler.handle_error()` on the **unrecognized fallthrough only**
(`spot_fleet.py:409`). The five families it *did* understand were translated to
typed exceptions and never recorded:

| Error code | Typed as | Recorded before? |
|---|---|---|
| `InvalidLaunchTemplateId.NotFound` (+2) | `SpotFleetRequestError` | no |
| `InsufficientInstanceCapacity` (+1) | `SpotFleetError` | no |
| `InvalidParameter` / `InvalidFleetConfig` (+1) | `SpotFleetRequestError` | no |
| `MaxSpotInstanceCountExceeded` / `VcpuLimitExceeded` | `SpotFleetRequestError` | no |
| `Throttling` / `RequestLimitExceeded` | `SpotFleetThrottlingError` | no |
| anything else | `SpotFleetError` | **yes** |

That inverts what you want. Those five are exactly the failures a caller reads
out of `error_history` in order to decide whether to back off, diversify
instance types, or ask for a service-limit increase. An error nobody could
classify is the least actionable of the set — and it was the only one counted,
so `get_error_statistics()` was blind to every failure the code could name.

Recording now happens **before** the classification chain, so every branch
records. One line moved; the classification and the return-don't-raise contract
(which is what preserves the caller's `raise ... from` botocore traceback) are
unchanged.

## One thing worth flagging

`handle_error()` does more than record — it runs `attempt_recovery()` for
`RETRY`/`FALLBACK` actions, and `InsufficientInstanceCapacity` maps to
`FALLBACK` in `ErrorAnalyzer.error_patterns`. In practice this is inert:
`ErrorRecoveryHandler.recovery_strategies` registers `ec2_instance_launch`,
`spot_fleet_request`, `vpc_creation`, and `security_group_creation`, and this
context's operation is `create_ec2_fleet`, so `attempt_recovery` returns `False`
without acting.

I did not want that to be load-bearing, so `test_recording_does_not_swallow_the_error`
patches `attempt_recovery` to return `True` and asserts translation *still*
returns an exception. A "successful" recovery must not be able to turn a failed
fleet into a pass. The call site notes this and says retries belong to
`@retry_with_backoff` on `create_blocks`.

## The tests had not been running

The issue's second complaint — that `_create_spot_fleet_with_retry` named a
retry it did not perform — **is already resolved**: the method is now
`_translate_fleet_error`, and `@retry_with_backoff()` decorates `create_blocks`
(`spot_fleet.py:412`).

But the two tests pinning the old behaviour still called that removed name.
`patch.object` raises `AttributeError` for a missing attribute rather than
creating one, so both had been failing on the patch itself since #86 and
exercised nothing:

```
E   AttributeError: 'SpotFleetManager' object has no attribute '_create_spot_fleet_with_retry'
```

One of them also carried a docstring asserting the old behaviour was correct
("the recognized codes are *not* added to `error_history` … the original test
asserted `len(error_history) > 0` here and could never have passed") — a
comment documenting the bug as intended. Both are retargeted at
`_translate_fleet_error` and parametrized over all six families.

## Verification

| Check | Result |
|---|---|
| `pytest tests/integration/test_error_handling_integration.py` | **14 passed** (was 6 passed / 2 failed) |
| `pytest tests/unit tests/security` | 1138 passed, 2 skipped |
| `pytest tests/integration` | 31F / 51P / 8E — baseline held, #92 territory |
| `ruff check` / `format --check` | clean / 111 formatted |
| `mypy parsl_ephemeral_aws` | 76 errors — baseline, no new |

**Negative control.** Reverting `spot_fleet.py` fails exactly the five
recognized families:

```
FAILED ...[InvalidLaunchTemplateId.NotFound-SpotFleetRequestError]
FAILED ...[InsufficientInstanceCapacity-SpotFleetError]
FAILED ...[InvalidFleetConfig-SpotFleetRequestError]
FAILED ...[MaxSpotInstanceCountExceeded-SpotFleetRequestError]
FAILED ...[Throttling-SpotFleetThrottlingError]
FAILED ...test_recording_does_not_swallow_the_error
6 failed, 8 passed
```

The `InternalError` case passes either way, which is correct — that branch
always recorded. No other test in the tree asserts against the fleet path's
`error_history`, so nothing else pinned the old behaviour.
