### PR TITLE
test: turn the integration suite green (closes #92, closes #159)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the removed API only, and never exported from the package root (refs #137).
 
 ### Fixed
+- **Every Spot Fleet `StandardMode` created went to the account the environment
+  named, not the one the caller configured.** `StandardMode.__init__` builds a
+  stand-in provider object for `SpotFleetManager`, and that object carried the
+  region, the profile name, the network IDs and every launch parameter — but no
+  `session`. `resolve_manager_session()` prefers `provider.session` and falls back
+  to building one from ambient environment credentials only when there is none, so
+  the fallback fired every time: a caller passing temporary role credentials, a
+  chosen profile, or an `endpoint_url` had their fleet created somewhere else
+  while the rest of the mode used the session they supplied.
+
+  This is the defect #117 fixed for the four `compute/` managers and the state
+  stores. This call site was missed because it constructs the stand-in inline
+  rather than passing `self`, so the audit that found the others did not reach it.
+  The only fleet integration test constructed `SpotFleetManager` directly and then
+  rebound `aws_session` and `ec2_client` by hand, which masked it exactly;
+  the replacement asserts the manager's session **is** the mode's (closes #159).
 - **`error_history` recorded only the fleet errors nobody could classify.**
   `SpotFleetManager._translate_fleet_error()` called
   `RobustErrorHandler.handle_error()` on the unrecognized fallthrough alone, so

--- a/docker-compose.substrate.yml
+++ b/docker-compose.substrate.yml
@@ -18,7 +18,13 @@ services:
   substrate:
     # Pinned, not `latest`: an emulator that silently changes under CI turns an
     # unrelated PR red. Bump deliberately.
-    image: ghcr.io/scttfrdmn/substrate:0.76.0
+    #
+    # 0.82.0 is the first release with an EC2 `CreateFleet` handler (substrate
+    # #387), which is what lets the spot-fleet suite run against an endpoint
+    # instead of moto. `RequestSpotFleet`/`RequestSpotInstances` are still
+    # unimplemented and are not coming back here -- #86 moved this provider onto
+    # CreateFleet, so nothing calls them.
+    image: ghcr.io/scttfrdmn/substrate:0.82.0
     container_name: parsl-substrate
     ports:
       - "4566:4566"

--- a/parsl_ephemeral_aws/compute/ecs.py
+++ b/parsl_ephemeral_aws/compute/ecs.py
@@ -226,10 +226,16 @@ class ECSManager:
         cluster_name = f"{TAG_PREFIX}-cluster-{self.provider.workflow_id}"
 
         try:
-            # Check if cluster already exists
+            # Check if cluster already exists. ``clusters`` is optional in the
+            # response shape -- ECS omits it rather than returning an empty list
+            # when nothing matched, and the name goes into ``failures`` instead.
+            # Indexing it raised ``KeyError: 'clusters'``, which the handler below
+            # then reported as "Failed to create ECS cluster": the wrong
+            # operation, since the create had not been attempted yet.
             response = self.ecs_client.describe_clusters(clusters=[cluster_name])
+            existing = response.get("clusters") or []
 
-            if response["clusters"] and response["clusters"][0]["status"] == "ACTIVE":
+            if existing and existing[0]["status"] == "ACTIVE":
                 logger.info(f"Using existing ECS cluster: {cluster_name}")
                 self.clusters.add(cluster_name)
 

--- a/parsl_ephemeral_aws/modes/detached.py
+++ b/parsl_ephemeral_aws/modes/detached.py
@@ -361,25 +361,37 @@ class DetachedMode(OperatingMode):
                 "Groups": [self.security_group_id],
             }
 
-            # Create the bastion host
-            response = ec2.run_instances(
-                ImageId=self.image_id,
-                InstanceType=self.bastion_instance_type,
-                MaxCount=1,
-                MinCount=1,
-                UserData=init_script,
-                KeyName=self.key_name,
-                TagSpecifications=[{"ResourceType": "instance", "Tags": tags}],
-                NetworkInterfaces=[network_interface],
-                InstanceInitiatedShutdownBehavior="terminate",
-                Monitoring={"Enabled": True},
+            run_args: Dict[str, Any] = {
+                "ImageId": self.image_id,
+                "InstanceType": self.bastion_instance_type,
+                "MaxCount": 1,
+                "MinCount": 1,
+                "UserData": init_script,
+                "TagSpecifications": [{"ResourceType": "instance", "Tags": tags}],
+                "NetworkInterfaces": [network_interface],
+                "InstanceInitiatedShutdownBehavior": "terminate",
+                "Monitoring": {"Enabled": True},
                 # IMDSv2 required (#85). This matters more here than on a
                 # worker: the bastion is long-lived and its instance profile
                 # carries the permissions to launch and terminate instances, so
                 # an SSRF against anything running on it would otherwise hand
                 # over role credentials through an unauthenticated IMDSv1 GET.
-                MetadataOptions=dict(IMDSV2_METADATA_OPTIONS),
-            )
+                "MetadataOptions": dict(IMDSV2_METADATA_OPTIONS),
+            }
+
+            # Only send KeyName when there is one. Passing ``KeyName=None``
+            # failed botocore's own parameter validation before any request was
+            # made, so a direct-mode bastion could never launch without a key
+            # pair -- and SSM is the documented way in, which needs no key at
+            # all. Both the standard-mode launch path and the bastion agent's
+            # own run_instances call already add it conditionally; this one did
+            # not. The CloudFormation path was unaffected, which is why the gap
+            # survived: it maps an empty key to AWS::NoValue (bastion.yml).
+            if self.key_name:
+                run_args["KeyName"] = self.key_name
+
+            # Create the bastion host
+            response = ec2.run_instances(**run_args)
 
             instance_id = response["Instances"][0]["InstanceId"]
             logger.debug(f"Created bastion host instance {instance_id}")

--- a/parsl_ephemeral_aws/modes/standard.py
+++ b/parsl_ephemeral_aws/modes/standard.py
@@ -244,6 +244,16 @@ class StandardMode(OperatingMode):
                 (),
                 {
                     "workflow_id": self.provider_id,
+                    # The mode's own session, so the manager inherits whatever
+                    # the caller configured -- a profile, role credentials, or an
+                    # endpoint_url. resolve_manager_session() prefers
+                    # provider.session and only falls back to building one from
+                    # ambient environment credentials when there is none, so
+                    # omitting it sent every fleet to the default account for the
+                    # region while the rest of the mode used the caller's (#159).
+                    # #117 fixed this everywhere the provider is passed as self;
+                    # this stand-in was built inline and so was missed.
+                    "session": self.session,
                     "region": self.session.region_name,
                     "aws_profile": None,
                     "vpc_id": self.vpc_id,

--- a/parsl_ephemeral_aws/provider.py
+++ b/parsl_ephemeral_aws/provider.py
@@ -160,6 +160,12 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
         EC2 key pair name for SSH access. If not provided, instances will be created without a key pair.
     profile_name : str, optional
         AWS profile name to use. If not provided, the default profile will be used.
+    endpoint_url : str, optional
+        Override the endpoint every AWS client uses. Set this for VPC interface
+        endpoints, FIPS endpoints, or to point the provider at an emulator such
+        as substrate. Applies to clients the operating modes and compute managers
+        build from the session too, not just the provider's own. A caller that
+        needs one service elsewhere can still override it per client.
     state_store_type : str, optional
         Type of state store to use ('file', 'parameter_store', or 's3'). Default is 'file'.
     state_file_path : str, optional
@@ -325,6 +331,7 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
         security_group_id: Optional[str] = None,
         key_name: Optional[str] = None,
         profile_name: Optional[str] = None,
+        endpoint_url: Optional[str] = None,
         state_store_type: str = StateStoreType.FILE,
         state_file_path: str = "ephemeral_aws_state.json",
         s3_bucket: Optional[str] = None,
@@ -429,6 +436,7 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
         self.security_group_id = security_group_id
         self.key_name = key_name
         self.profile_name = profile_name
+        self.endpoint_url = endpoint_url
         self.state_store_type = StateStoreType(state_store_type.lower())
         self.state_file_path = state_file_path
         self.s3_bucket = s3_bucket
@@ -607,7 +615,9 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
 
         # Initialize state
         self.session = create_session(
-            region=self.region, profile_name=self.profile_name
+            region=self.region,
+            profile_name=self.profile_name,
+            endpoint_url=self.endpoint_url,
         )
 
         # Resolve the AMI now that a credentialed session exists. Deferred from

--- a/parsl_ephemeral_aws/utils/aws.py
+++ b/parsl_ephemeral_aws/utils/aws.py
@@ -87,6 +87,42 @@ _CREDENTIAL_EXCEPTIONS = (
 )
 
 
+def _bind_endpoint(session: boto3.Session, endpoint_url: str) -> None:
+    """Make every client built from *session* default to *endpoint_url*.
+
+    Wrapping ``session.client`` is the only approach that reaches all of it.
+    Passing ``endpoint_url`` at each call site would mean touching ~90 client
+    constructions across the modes and compute managers, and would still miss
+    any added later. Setting it on the botocore config store does not work:
+    ``endpoint_url`` is resolved per-service from ``AWS_ENDPOINT_URL`` and
+    ``AWS_ENDPOINT_URL_<SERVICE>``, and a value injected into the store is not
+    consulted by client construction (verified against botocore 1.42).
+
+    ``setdefault`` rather than an override, so a caller that deliberately points
+    one service elsewhere still wins.
+
+    Parameters
+    ----------
+    session : boto3.Session
+        Session to modify in place.
+    endpoint_url : str
+        Endpoint every client should use unless told otherwise.
+    """
+    original_client = session.client
+    original_resource = session.resource
+
+    def client(*args: Any, **kwargs: Any) -> Any:
+        kwargs.setdefault("endpoint_url", endpoint_url)
+        return original_client(*args, **kwargs)
+
+    def resource(*args: Any, **kwargs: Any) -> Any:
+        kwargs.setdefault("endpoint_url", endpoint_url)
+        return original_resource(*args, **kwargs)
+
+    session.client = client
+    session.resource = resource
+
+
 def resolve_manager_session(provider: Any, credential_manager: Any) -> boto3.Session:
     """Return the session a compute manager should use.
 
@@ -149,7 +185,8 @@ def create_session(
     aws_session_token : Optional[str], optional
         AWS session token, by default None
     endpoint_url : Optional[str], optional
-        Custom endpoint URL for AWS services (e.g., for LocalStack), by default None
+        Custom endpoint URL for every AWS service, by default None. Use for VPC
+        or FIPS endpoints, or to point the whole package at an emulator.
 
     Returns
     -------
@@ -171,6 +208,9 @@ def create_session(
             aws_secret_access_key=aws_secret_access_key,
             aws_session_token=aws_session_token,
         )
+
+        if endpoint_url:
+            _bind_endpoint(session, endpoint_url)
 
         # Verify that the session is valid by calling a simple operation
         sts = session.client("sts", endpoint_url=endpoint_url)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,9 +16,11 @@ from typing import Generator
 
 from parsl_ephemeral_aws.provider import EphemeralAWSProvider
 from tests.substrate_support import (
+    cleanup_substrate_vpc,
     create_substrate_session,
     get_substrate_endpoint,
     is_substrate_running,
+    setup_substrate_vpc,
 )
 
 # Configure logging for tests
@@ -433,6 +435,71 @@ def substrate_available() -> bool:
     except Exception as exc:
         logging.warning("substrate health check failed: %s", exc)
     return False
+
+
+@pytest.fixture(scope="session")
+def cloudformation_available() -> bool:
+    """Return whether the emulator serves CloudFormation.
+
+    Substrate has a Go ``StackDeployer`` but exposes no ``cloudformation`` plugin
+    over HTTP, so ``create_stack`` answers ``ServiceNotAvailable``. ``DetachedMode``
+    provisions its bastion through a stack, so tests that reach it must *skip*
+    rather than fail -- an emulator gap is not a defect in the provider, and a red
+    suite that stays red teaches everyone to ignore it (same treatment as the
+    un-emulated EventBridge in #137).
+
+    Probed rather than hardcoded to ``False``: substrate may grow the plugin, and
+    a skip that outlives its reason is how coverage quietly disappears. The real
+    bastion path is covered against live CloudFormation in ``tests/aws/``.
+    """
+    endpoint = get_substrate_endpoint()
+    try:
+        response = requests.get(f"{endpoint}/_localstack/health", timeout=5)
+        if response.status_code == 200:
+            services = response.json().get("services", {})
+            return services.get("cloudformation") == "available"
+    except Exception as exc:
+        logging.warning("cloudformation availability check failed: %s", exc)
+    return False
+
+
+@pytest.fixture
+def requires_cloudformation(cloudformation_available) -> None:
+    """Skip the requesting test unless the emulator serves CloudFormation."""
+    if not cloudformation_available:
+        pytest.skip(
+            "substrate does not emulate cloudformation; DetachedMode's bastion "
+            "stack is covered against real AWS in tests/aws/"
+        )
+
+
+@pytest.fixture
+def substrate_network(substrate_session) -> Generator[dict, None, None]:
+    """Provision a real VPC, subnet and security group in the emulator.
+
+    Since #69 every mode requires ``vpc_id``/``subnet_id``/``security_group_id``
+    to exist beforehand, and ``modes/base.py`` *verifies* each one with a
+    ``describe_*`` call. So the unit suite's ``vpc-12345`` placeholders do not
+    work here: they are only sufficient where the session itself is mocked, and
+    against a live endpoint they raise ``ResourceNotFoundError``. These IDs are
+    real, emulator-side resources.
+
+    Provisioned through ``substrate_session`` rather than
+    ``setup_substrate_vpc()``'s own client, because that helper hardcodes
+    ``us-east-1`` while this session follows ``AWS_TEST_REGION`` (default
+    ``us-west-2``). Substrate partitions resources by region, so the mismatch
+    created the network in one region and then looked for it in another --
+    surfacing as ``InvalidGroup.NotFound`` for a group that had just been created
+    successfully.
+
+    Torn down per test rather than shared: a leftover VPC makes the next test's
+    failure depend on execution order, which is the hardest kind to read.
+    """
+    network = setup_substrate_vpc(session=substrate_session)
+    try:
+        yield network
+    finally:
+        cleanup_substrate_vpc(network["vpc_id"], session=substrate_session)
 
 
 @pytest.fixture

--- a/tests/integration/test_autoscaling_workflows.py
+++ b/tests/integration/test_autoscaling_workflows.py
@@ -1,649 +1,324 @@
-"""Integration tests for autoscaling workflows.
+"""Integration tests for scaling behaviour against the substrate emulator.
 
-These tests verify that the provider correctly scales resources up and down
-based on workload demands in various operating modes.
+These drive the *real* provider and the *real* operating modes -- nothing about
+the scaling path is mocked -- so the assertions are about instances that actually
+exist in the emulator, not about calls made to a double.
+
+The previous version of this file could not have tested that. It patched a dozen
+methods that do not exist on any mode (``_create_vpc``, ``_create_subnet``,
+``_create_security_group``, ``_create_ec2_instance``, ``_delete_ec2_instance``,
+``_delete_vpc``, ``_create_ssm_parameter``, ``_create_tags``) and called two more
+(``mode._init_blocks()``, ``mode.scale_out()``/``mode.scale_in()``) that live on
+the provider, not the mode -- ``grep`` finds none of them in
+``parsl_ephemeral_aws/``. ``unittest.mock.patch.object`` raises
+``AttributeError`` for a missing attribute, so every one of those was a hard
+error rather than a passing test, and the network-creating shape they described
+was removed in #69 anyway.
+
+It also shadowed the ``substrate_session`` fixture with a class-scoped one built
+from ``get_substrate_session()``, which binds no endpoint: clients made from it
+reach real AWS and fail on auth. conftest's fixture wraps ``session.client`` to
+inject ``endpoint_url``, which is what makes code under test hit the emulator.
+
+What scaling actually means here:
+
+* ``max_blocks`` is enforced in ``provider.submit()``, which raises
+  ``ProviderError`` rather than silently over-provisioning.
+* ``provider.scale_in(n)`` cancels up to *n* RUNNING blocks and drops them.
+* ``provider.scale_out()`` returns ``[]`` by design -- growing the pool is
+  Parsl's strategy's job, and the provider's docstring says so. A test asserting
+  otherwise would be asserting a feature that does not exist.
 
 SPDX-License-Identifier: Apache-2.0
 SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
 """
 
-import os
 import uuid
+
 import pytest
-import tempfile
-from unittest.mock import MagicMock, patch
+from parsl.jobs.states import JobState
 
-from parsl_ephemeral_aws.provider import EphemeralAWSProvider
-from parsl_ephemeral_aws.modes.standard import StandardMode
-from parsl_ephemeral_aws.modes.detached import DetachedMode
+from parsl_ephemeral_aws.constants import WORKER_TYPE_ECS, WORKER_TYPE_LAMBDA
+from parsl_ephemeral_aws.exceptions import ProviderError
 from parsl_ephemeral_aws.modes.serverless import ServerlessMode
+from parsl_ephemeral_aws.provider import EphemeralAWSProvider
 from parsl_ephemeral_aws.state.file import FileStateStore
-from tests.substrate_support import (
-    get_substrate_session,
-    is_substrate_available,
-)
-
-
-# Skip all tests if the substrate emulator is not available
-pytestmark = pytest.mark.skipif(
-    not is_substrate_available(),
-    reason="substrate not available - start with 'make substrate-up'",
-)
-
-
-@pytest.mark.integration
-class TestAutoscalingWorkflows:
-    """Integration tests for autoscaling workflow scenarios."""
-
-    @pytest.fixture(scope="class")
-    def substrate_session(self):
-        """Create a session connected to substrate."""
-        return get_substrate_session()
-
-    @pytest.fixture
-    def temp_dir(self):
-        """Create a temporary directory for state files."""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            yield tmp_dir
-
-    @pytest.fixture
-    def state_file_path(self, temp_dir):
-        """Create a path for the state file."""
-        return os.path.join(temp_dir, f"test-state-{uuid.uuid4().hex[:8]}.json")
-
-    @pytest.fixture
-    def file_state_store(self, state_file_path):
-        """Create a FileStateStore instance."""
-        provider_id = f"test-provider-{uuid.uuid4().hex[:8]}"
-        return FileStateStore(file_path=state_file_path, provider_id=provider_id)
-
-    @pytest.mark.substrate
-    def test_standard_mode_scaling(self, substrate_session, file_state_store):
-        """Test autoscaling in StandardMode."""
-        # Create a StandardMode instance with scaling configuration
-        provider_id = f"test-provider-{uuid.uuid4().hex[:8]}"
-
-        # Set up mocks for AWS services using substrate
-        with patch("boto3.Session", return_value=substrate_session):
-            # Create standard mode with scaling configuration
-            mode = StandardMode(
-                provider_id=provider_id,
-                session=substrate_session,
-                state_store=file_state_store,
-                region="us-east-1",
-                instance_type="t2.micro",
-                image_id="ami-12345678",  # Dummy AMI
-                max_blocks=3,
-                min_blocks=0,
-                init_blocks=1,
-            )
-
-            # Initialize mode
-            with patch.object(mode, "_create_vpc", return_value="vpc-12345"):
-                with patch.object(mode, "_create_subnet", return_value="subnet-12345"):
-                    with patch.object(
-                        mode, "_create_security_group", return_value="sg-12345"
-                    ):
-                        mode.initialize()
-
-            # Mock instance creation
-            instance_id_counter = 0
-
-            def create_mock_instance(*args, **kwargs):
-                nonlocal instance_id_counter
-                instance_id_counter += 1
-                return {
-                    "instance_id": f"i-{instance_id_counter:05d}",
-                    "private_ip": f"10.0.0.{instance_id_counter}",
-                    "public_ip": f"54.123.456.{instance_id_counter}",
-                    "dns_name": f"ec2-54-123-456-{instance_id_counter}.compute-1.amazonaws.com",
-                }
-
-            # Test initial block creation
-            with patch.object(
-                mode, "_create_ec2_instance", side_effect=create_mock_instance
-            ):
-                # Should create one instance for init_blocks=1
-                mode._init_blocks()
-
-                # Verify one instance was created
-                assert len(mode.resources) == 1
-
-            # Test scaling out (adding instances)
-            with patch.object(
-                mode, "_create_ec2_instance", side_effect=create_mock_instance
-            ):
-                # Try to scale out by 2 more instances
-                new_blocks = mode.scale_out(2)
-
-                # Verify scaling was successful
-                assert new_blocks == 2
-
-                # Verify we now have 3 instances total
-                assert len(mode.resources) == 3
-
-                # Try to scale beyond max_blocks
-                new_blocks = mode.scale_out(1)
-
-                # Should not scale further since max_blocks=3
-                assert new_blocks == 0
-                assert len(mode.resources) == 3
-
-            # Mock job submission and setting status to running
-            job_ids = []
-            resource_ids = list(mode.resources.keys())
-
-            for i, resource_id in enumerate(resource_ids):
-                job_id = f"job-{i + 1}"
-                # Set resource job mapping
-                mode.resources[resource_id]["job_id"] = job_id
-                # Set to running status
-                mode.resources[resource_id]["status"] = "running"
-                job_ids.append(job_id)
-
-            # Test scaling in (removing instances)
-            with patch.object(mode, "_delete_ec2_instance"):
-                # Mark one job as complete
-                complete_resource_id = resource_ids[0]
-                mode.resources[complete_resource_id]["status"] = "completed"
-
-                # Scale in one block
-                num_released = mode.scale_in(1)
-
-                # Should remove the completed job's instance
-                assert num_released == 1
-                assert complete_resource_id not in mode.resources
-                assert len(mode.resources) == 2
-
-                # Try to scale in more than min_blocks
-                all_resource_ids = list(mode.resources.keys())
-                for resource_id in all_resource_ids:
-                    mode.resources[resource_id]["status"] = "completed"
-
-                # Scale in remaining 2 instances
-                num_released = mode.scale_in(2)
-
-                # Should remove both instances
-                assert num_released == 2
-                assert len(mode.resources) == 0
-
-            # Clean up
-            with patch.object(mode, "_delete_ec2_instance"):
-                with patch.object(mode, "_delete_security_group"):
-                    with patch.object(mode, "_delete_subnet"):
-                        with patch.object(mode, "_delete_vpc"):
-                            mode.cleanup_infrastructure()
-
-    @pytest.mark.substrate
-    def test_detached_mode_scaling(self, substrate_session, file_state_store):
-        """Test autoscaling in DetachedMode."""
-        # Create a DetachedMode instance with scaling configuration
-        provider_id = f"test-provider-{uuid.uuid4().hex[:8]}"
-        workflow_id = f"test-workflow-{uuid.uuid4().hex[:8]}"
-
-        # Set up mocks for AWS services using substrate
-        with patch("boto3.Session", return_value=substrate_session):
-            # Create detached mode with scaling configuration
-            mode = DetachedMode(
-                provider_id=provider_id,
-                session=substrate_session,
-                state_store=file_state_store,
-                region="us-east-1",
-                instance_type="t2.micro",
-                image_id="ami-12345678",  # Dummy AMI
-                workflow_id=workflow_id,
-                bastion_instance_type="t2.micro",
-                bastion_host_type="direct",
-                max_blocks=3,
-                min_blocks=0,
-                init_blocks=1,
-            )
-
-            # Initialize mode
-            with patch.object(mode, "_create_vpc", return_value="vpc-12345"):
-                with patch.object(mode, "_create_subnet", return_value="subnet-12345"):
-                    with patch.object(
-                        mode, "_create_security_group", return_value="sg-12345"
-                    ):
-                        with patch.object(
-                            mode, "_create_bastion_host"
-                        ) as mock_create_bastion:
-                            mock_create_bastion.return_value = {
-                                "instance_id": f"i-bastion-{uuid.uuid4().hex[:8]}",
-                                "private_ip": "10.0.0.2",
-                                "public_ip": "54.123.456.789",
-                                "dns_name": "ec2-54-123-456-789.compute-1.amazonaws.com",
-                            }
-                            with patch.object(mode, "_create_tags"):
-                                mode.initialize()
-
-            # Verify bastion was created
-            assert mode.bastion_id is not None
-
-            # Mock instance creation
-            instance_id_counter = 0
-
-            def create_mock_instance(*args, **kwargs):
-                nonlocal instance_id_counter
-                instance_id_counter += 1
-                return {
-                    "instance_id": f"i-{instance_id_counter:05d}",
-                    "private_ip": f"10.0.0.{instance_id_counter + 10}",
-                    "public_ip": None,  # No public IP in detached mode
-                    "dns_name": None,
-                }
-
-            # Test initial block creation
-            with patch.object(
-                mode, "_create_ec2_instance", side_effect=create_mock_instance
-            ):
-                with patch.object(mode, "_create_ssm_parameter"):
-                    # Should create one instance for init_blocks=1
-                    mode._init_blocks()
-
-                    # Verify one instance was created
-                    assert len(mode.resources) == 1
-
-            # Test scaling out (adding instances)
-            with patch.object(
-                mode, "_create_ec2_instance", side_effect=create_mock_instance
-            ):
-                with patch.object(mode, "_create_ssm_parameter"):
-                    # Try to scale out by 2 more instances
-                    new_blocks = mode.scale_out(2)
-
-                    # Verify scaling was successful
-                    assert new_blocks == 2
-
-                    # Verify we now have 3 instances total
-                    assert len(mode.resources) == 3
-
-                    # Try to scale beyond max_blocks
-                    new_blocks = mode.scale_out(1)
-
-                    # Should not scale further since max_blocks=3
-                    assert new_blocks == 0
-                    assert len(mode.resources) == 3
-
-            # Mock job submission and setting status to running
-            job_ids = []
-            resource_ids = list(mode.resources.keys())
-
-            for i, resource_id in enumerate(resource_ids):
-                job_id = f"job-{i + 1}"
-                # Set resource job mapping
-                mode.resources[resource_id]["job_id"] = job_id
-                # Set to running status
-                mode.resources[resource_id]["status"] = "running"
-                job_ids.append(job_id)
-
-            # Test scaling in (removing instances)
-            with patch.object(mode, "_delete_ec2_instance"):
-                with patch.object(mode, "_delete_ssm_parameter"):
-                    # Mark one job as complete
-                    complete_resource_id = resource_ids[0]
-                    mode.resources[complete_resource_id]["status"] = "completed"
-
-                    # Scale in one block
-                    num_released = mode.scale_in(1)
-
-                    # Should remove the completed job's instance
-                    assert num_released == 1
-                    assert complete_resource_id not in mode.resources
-                    assert len(mode.resources) == 2
-
-                    # Try to scale in more than min_blocks
-                    all_resource_ids = list(mode.resources.keys())
-                    for resource_id in all_resource_ids:
-                        mode.resources[resource_id]["status"] = "completed"
-
-                    # Scale in remaining 2 instances
-                    num_released = mode.scale_in(2)
-
-                    # Should remove both instances
-                    assert num_released == 2
-                    assert len(mode.resources) == 0
-
-            # Clean up
-            with patch.object(mode, "_delete_ec2_instance"):
-                with patch.object(mode, "_delete_ssm_parameter"):
-                    with patch.object(mode, "_delete_security_group"):
-                        with patch.object(mode, "_delete_subnet"):
-                            with patch.object(mode, "_delete_vpc"):
-                                mode.preserve_bastion = (
-                                    False  # Ensure bastion is cleaned up
-                                )
-                                mode.cleanup_infrastructure()
-
-    @pytest.mark.substrate
-    def test_serverless_lambda_scaling(self, substrate_session, file_state_store):
-        """Test autoscaling with Lambda functions in ServerlessMode."""
-        # Create a ServerlessMode instance with Lambda and scaling configuration
-        provider_id = f"test-provider-{uuid.uuid4().hex[:8]}"
-
-        # Set up mocks for AWS services using substrate
-        with patch("boto3.Session", return_value=substrate_session):
-            # Create serverless mode with scaling configuration
-            mode = ServerlessMode(
-                provider_id=provider_id,
-                session=substrate_session,
-                state_store=file_state_store,
-                region="us-east-1",
-                worker_type="lambda",
-                lambda_memory=128,
-                lambda_timeout=30,
-                max_blocks=10,
-                min_blocks=0,
-                init_blocks=0,  # Serverless starts with 0 resources
-            )
-
-            # Initialize mode
-            mode.initialize()
-
-            # Mock Lambda function creation
-            function_counter = 0
-
-            def create_mock_function(*args, **kwargs):
-                nonlocal function_counter
-                function_counter += 1
-                function_name = f"lambda-function-{function_counter}"
-                return {
-                    "FunctionName": function_name,
-                    "FunctionArn": f"arn:aws:lambda:us-east-1:123456789012:function:{function_name}",
-                }
-
-            # Mock Lambda invocation for tasks
-            mock_response = {
-                "StatusCode": 200,
-                "Payload": MagicMock(
-                    read=lambda: b'{"statusCode": 200, "body": "Success"}'
-                ),
-            }
-
-            # Set up Lambda mocking
-            mode.lambda_manager = MagicMock()
-            mode.lambda_manager._create_lambda_function.side_effect = (
-                create_mock_function
-            )
-            mode.lambda_manager.invoke_lambda_function.return_value = mock_response
-
-            # Submit multiple jobs in parallel
-            job_ids = []
-            resource_ids = []
-
-            # Lambda functions are created on demand, no initial blocks
-            assert len(mode.resources) == 0
-
-            # Submit 5 jobs - should create 5 Lambda functions
-            for i in range(5):
-                with patch(
-                    "builtins.open", MagicMock()
-                ):  # Mock writing Lambda code to file
-                    job_id = f"job-{i + 1}"
-                    resource_id = mode.submit_job(job_id, f"echo 'Job {i + 1}'", 1)
-                    job_ids.append(job_id)
-                    resource_ids.append(resource_id)
-
-            # Verify Lambda functions were created
-            assert len(mode.resources) == 5
-            assert mode.lambda_manager._create_lambda_function.call_count == 5
-
-            # Test Lambda function invocation
-            with patch(
-                "builtins.open", MagicMock()
-            ):  # Mock writing Lambda code to file
-                for resource_id in resource_ids:
-                    status = mode.get_job_status([resource_id])
-                    assert resource_id in status
-
-            # Lambda functions are automatically cleaned up after execution
-            # This is a key difference from EC2-based modes
-
-            # Clean up remaining resources
-            mode.lambda_manager.delete_lambda_function.return_value = None
-            mode.cleanup_infrastructure()
-
-    @pytest.mark.substrate
-    def test_auto_worker_type_selection(self, substrate_session, file_state_store):
-        """Test automatic worker type selection in ServerlessMode."""
-        # Create a ServerlessMode instance with auto worker type selection
-        provider_id = f"test-provider-{uuid.uuid4().hex[:8]}"
-
-        # Set up mocks for AWS services using substrate
-        with patch("boto3.Session", return_value=substrate_session):
-            # Create serverless mode with auto worker type
-            mode = ServerlessMode(
-                provider_id=provider_id,
-                session=substrate_session,
-                state_store=file_state_store,
-                region="us-east-1",
-                worker_type="auto",  # Auto selection based on job characteristics
-                lambda_memory=128,
-                lambda_timeout=30,
-                ecs_task_cpu=256,
-                ecs_task_memory=512,
-                ecs_container_image="amazon/amazon-ecs-sample",
-                max_blocks=10,
-                min_blocks=0,
-            )
-
-            # Initialize mode
-            mode.initialize()
-
-            # Mock Lambda function creation
-            mode.lambda_manager = MagicMock()
-            mode.lambda_manager._create_lambda_function.return_value = {
-                "FunctionName": "lambda-function",
-                "FunctionArn": "arn:aws:lambda:us-east-1:123456789012:function:lambda-function",
-            }
-            mode.lambda_manager.invoke_lambda_function.return_value = {
-                "StatusCode": 200,
-                "Payload": MagicMock(
-                    read=lambda: b'{"statusCode": 200, "body": "Success"}'
-                ),
-            }
-
-            # Mock ECS task creation
-            mode.ecs_manager = MagicMock()
-            mode.ecs_manager.create_cluster.return_value = "test-cluster"
-            mode.ecs_manager.register_task_definition.return_value = "test-task:1"
-            mode.ecs_manager.run_task.return_value = {
-                "taskArn": "arn:aws:ecs:us-east-1:123456789012:task/test-cluster/abcdef12345",
-                "clusterArn": "arn:aws:ecs:us-east-1:123456789012:cluster/test-cluster",
-                "taskDefinitionArn": "arn:aws:ecs:us-east-1:123456789012:task-definition/test-task:1",
-            }
-
-            # Patch the worker type selection method
-            with patch.object(mode, "_select_worker_type") as mock_select_worker:
-                # First job is small, should use Lambda
-                mock_select_worker.side_effect = ["lambda", "ecs", "lambda"]
-
-                # Submit jobs with different characteristics
-                with patch(
-                    "builtins.open", MagicMock()
-                ):  # Mock writing Lambda code to file
-                    # First job - small, should use Lambda
-                    job1_id = "small-job"
-                    resource1_id = mode.submit_job(job1_id, "echo 'Small job'", 1)
-
-                    # Lambda function should be created
-                    assert mode.resources[resource1_id]["worker_type"] == "lambda"
-                    assert mode.lambda_manager._create_lambda_function.call_count == 1
-                    assert mode.ecs_manager.run_task.call_count == 0
-
-                    # Second job - larger, should use ECS
-                    job2_id = "large-job"
-                    resource2_id = mode.submit_job(
-                        job2_id, "echo 'Large job'", 4, job_name="cpu-intensive"
-                    )
-
-                    # ECS task should be created
-                    assert mode.resources[resource2_id]["worker_type"] == "ecs"
-                    assert mode.lambda_manager._create_lambda_function.call_count == 1
-                    assert mode.ecs_manager.run_task.call_count == 1
-
-                    # Third job - another small job, back to Lambda
-                    job3_id = "another-small-job"
-                    resource3_id = mode.submit_job(
-                        job3_id, "echo 'Another small job'", 1
-                    )
-
-                    # Lambda function should be created
-                    assert mode.resources[resource3_id]["worker_type"] == "lambda"
-                    assert mode.lambda_manager._create_lambda_function.call_count == 2
-                    assert mode.ecs_manager.run_task.call_count == 1
-
-            # Clean up
-            mode.lambda_manager.delete_lambda_function.return_value = None
-            mode.ecs_manager.stop_task.return_value = None
-            mode.ecs_manager.deregister_task_definition.return_value = None
-            mode.ecs_manager.delete_cluster.return_value = None
-            mode.cleanup_infrastructure()
-
-    @pytest.mark.substrate
-    def test_hybrid_scaling_strategy(self, substrate_session, file_state_store):
-        """Test hybrid scaling strategy using mixed resource types."""
-        # Create a provider that uses a hybrid approach
-        provider_id = f"test-provider-{uuid.uuid4().hex[:8]}"
-
-        # Create a provider to handle both the test and implementation
-        provider = EphemeralAWSProvider(
-            provider_id=provider_id,
-            region="us-east-1",
-            mode="serverless",
-            worker_type="auto",
-            lambda_memory=128,
-            lambda_timeout=30,
-            ecs_task_cpu=256,
-            ecs_task_memory=512,
-            ecs_container_image="amazon/amazon-ecs-sample",
-            max_blocks=10,
-            min_blocks=0,
-            init_blocks=0,
-            # Inject our session and state store for testing
-            _test_session=substrate_session,
-            _test_state_store=file_state_store,
+from tests.substrate_support import get_substrate_endpoint, is_substrate_available
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.substrate,
+    pytest.mark.skipif(
+        not is_substrate_available(),
+        reason="substrate not available - start with 'make substrate-up'",
+    ),
+]
+
+
+@pytest.fixture
+def state_file(tmp_path):
+    """Path for the provider's state document, inside the test's sandbox."""
+    return tmp_path / f"state-{uuid.uuid4().hex[:8]}.json"
+
+
+def running_instance_ids(session, provider):
+    """Return the live instance IDs this provider owns.
+
+    Scoped by the ``ProviderId`` tag rather than by subnet: every launch here goes
+    through the mode's launch template (#85), and substrate does not apply the
+    template's network interface -- it places the instance in a subnet of its own
+    choosing, so a ``subnet-id`` filter matches nothing even though the launch
+    succeeded. The tag is set per launch in ``_create_instance``, so it survives
+    that gap and also keeps a concurrent test from inflating the count.
+
+    ``terminated`` is excluded because a torn-down instance lingers in
+    ``describe_instances`` for a while.
+    """
+    ec2 = session.client("ec2")
+    reservations = ec2.describe_instances(
+        Filters=[
+            {"Name": "tag:ProviderId", "Values": [provider.provider_id]},
+            {
+                "Name": "instance-state-name",
+                "Values": ["pending", "running", "stopping", "stopped"],
+            },
+        ]
+    )["Reservations"]
+    return [i["InstanceId"] for r in reservations for i in r["Instances"]]
+
+
+def build_provider(session, state_file, network, **config):
+    """Construct a provider with its real operating mode, bound to the emulator.
+
+    ``region`` follows the session rather than being hardcoded. The provider
+    builds its own session from ``region``, and substrate partitions resources by
+    region exactly as AWS does -- so a fixed ``us-east-1`` here against a
+    ``substrate_network`` provisioned in ``AWS_TEST_REGION`` (default
+    ``us-west-2``) makes the caller's own security group report
+    ``InvalidGroup.NotFound``.
+    """
+    return EphemeralAWSProvider(
+        provider_id=f"test-provider-{uuid.uuid4().hex[:8]}",
+        region=session.region_name,
+        endpoint_url=get_substrate_endpoint(),
+        state_file_path=str(state_file),
+        instance_type="t3.micro",
+        image_id="ami-12345678",
+        vpc_id=network["vpc_id"],
+        subnet_id=network["subnet_id"],
+        security_group_id=network["security_group_id"],
+        **config,
+    )
+
+
+class TestStandardModeScaling:
+    """Scaling in standard mode, where each block is an EC2 instance."""
+
+    def test_submit_stops_at_max_blocks(
+        self, substrate_session, substrate_network, state_file
+    ):
+        """The cap is enforced by refusing the submit, not by over-provisioning."""
+        provider = build_provider(
+            substrate_session, state_file, substrate_network, max_blocks=2, min_blocks=0
+        )
+        try:
+            job_ids = [provider.submit(f"echo {i}", tasks_per_node=1) for i in range(2)]
+            assert len(provider.resources) == 2
+            assert len(running_instance_ids(substrate_session, provider)) == 2
+
+            with pytest.raises(ProviderError, match="already at max_blocks = 2"):
+                provider.submit("echo 3", tasks_per_node=1)
+
+            # The refused submit must not have launched anything.
+            assert len(running_instance_ids(substrate_session, provider)) == 2
+            assert [s.state for s in provider.status(job_ids)] == [
+                JobState.RUNNING,
+                JobState.RUNNING,
+            ]
+        finally:
+            provider.shutdown()
+
+    def test_scale_in_releases_running_blocks(
+        self, substrate_session, substrate_network, state_file
+    ):
+        """scale_in cancels the requested number of blocks and forgets them.
+
+        ``status()`` is polled first on purpose: ``scale_in`` selects blocks whose
+        recorded status is RUNNING, and a freshly submitted block is still
+        PENDING until something asks the mode.
+        """
+        provider = build_provider(
+            substrate_session, state_file, substrate_network, max_blocks=3, min_blocks=0
+        )
+        try:
+            job_ids = [provider.submit(f"echo {i}", tasks_per_node=1) for i in range(3)]
+            provider.status(job_ids)
+
+            released = provider.scale_in(2)
+
+            assert len(released) == 2
+            assert set(released) <= set(job_ids)
+            assert len(provider.resources) == 1
+            # The surviving job is the one not released.
+            assert set(provider.job_map) == set(job_ids) - set(released)
+        finally:
+            provider.shutdown()
+
+    def test_scale_in_of_zero_or_fewer_is_a_no_op(
+        self, substrate_session, substrate_network, state_file
+    ):
+        """A non-positive request touches nothing rather than draining the pool."""
+        provider = build_provider(
+            substrate_session, state_file, substrate_network, max_blocks=2, min_blocks=0
+        )
+        try:
+            job_ids = [provider.submit(f"echo {i}", tasks_per_node=1) for i in range(2)]
+            provider.status(job_ids)
+
+            assert provider.scale_in(0) == []
+            assert provider.scale_in(-1) == []
+            assert len(provider.resources) == 2
+        finally:
+            provider.shutdown()
+
+    def test_scale_out_is_delegated_to_parsl(
+        self, substrate_session, substrate_network, state_file
+    ):
+        """scale_out reports nothing and provisions nothing.
+
+        This is the provider's documented contract -- Parsl's strategy decides
+        when to grow -- so the test pins it rather than treating it as a gap. If
+        that ever changes, this failing is the correct signal.
+        """
+        provider = build_provider(
+            substrate_session, state_file, substrate_network, max_blocks=4, min_blocks=0
+        )
+        try:
+            assert provider.scale_out(2) == []
+
+            assert running_instance_ids(substrate_session, provider) == []
+            assert provider.resources == {}
+        finally:
+            provider.shutdown()
+
+
+class TestDetachedModeScaling:
+    """Scaling in detached mode, where a bastion fronts the blocks.
+
+    ``bastion_host_type="direct"`` throughout: the CloudFormation bastion needs
+    an endpoint substrate does not serve. No ``key_name`` is passed, which is the
+    ordinary configuration -- SSM needs none -- and which used to fail botocore's
+    parameter validation before any request was sent (#158).
+    """
+
+    def _provider(self, session, state_file, network, **config):
+        return build_provider(
+            session,
+            state_file,
+            network,
+            mode="detached",
+            bastion_host_type="direct",
+            bastion_instance_type="t3.micro",
+            workflow_id=f"test-workflow-{uuid.uuid4().hex[:8]}",
+            preserve_bastion=False,
+            **config,
         )
 
-        # Initialize the internal operating mode directly
-        with patch.object(provider, "_initialize_operating_mode"):
-            # Mock the operating mode
-            mode = ServerlessMode(
-                provider_id=provider_id,
-                session=substrate_session,
-                state_store=file_state_store,
-                region="us-east-1",
-                worker_type="auto",
-                lambda_memory=128,
-                lambda_timeout=30,
-                ecs_task_cpu=256,
-                ecs_task_memory=512,
-                ecs_container_image="amazon/amazon-ecs-sample",
-                max_blocks=10,
-                min_blocks=0,
-                init_blocks=0,
-            )
+    def test_submit_stops_at_max_blocks(
+        self, substrate_session, substrate_network, state_file
+    ):
+        """The cap applies to worker blocks and leaves the bastion alone."""
+        provider = self._provider(
+            substrate_session, state_file, substrate_network, max_blocks=2, min_blocks=0
+        )
+        try:
+            bastion_id = provider.operating_mode.bastion_id
+            assert bastion_id is not None
 
-            # Initialize mode
+            for i in range(2):
+                provider.submit(f"echo {i}", tasks_per_node=1)
+            assert len(provider.resources) == 2
+
+            with pytest.raises(ProviderError, match="already at max_blocks = 2"):
+                provider.submit("echo 3", tasks_per_node=1)
+
+            # The bastion is infrastructure, not a block, so it is not counted
+            # against max_blocks and must still be running. It carries the same
+            # ProviderId tag as a worker, which is why it shows up here.
+            assert bastion_id in running_instance_ids(substrate_session, provider)
+        finally:
+            provider.shutdown()
+
+    def test_shutdown_removes_the_bastion(
+        self, substrate_session, substrate_network, state_file
+    ):
+        """With preserve_bastion=False the bastion goes with the provider."""
+        provider = self._provider(
+            substrate_session, state_file, substrate_network, max_blocks=1, min_blocks=0
+        )
+        bastion_id = provider.operating_mode.bastion_id
+        assert bastion_id in running_instance_ids(substrate_session, provider)
+
+        provider.shutdown()
+
+        assert provider.operating_mode.bastion_id is None
+        assert bastion_id not in running_instance_ids(substrate_session, provider)
+
+
+class TestServerlessWorkerSelection:
+    """Which backend a serverless block lands on, given its shape.
+
+    Driven through the real ``_select_worker_type`` rather than a patched one. The
+    old test patched it with a fixed ``side_effect`` list and then asserted the
+    resources matched that list, which tested the mock.
+    """
+
+    def _mode(self, substrate_session, network, tmp_path, **config):
+        provider_id = f"test-provider-{uuid.uuid4().hex[:8]}"
+        return ServerlessMode(
+            provider_id=provider_id,
+            session=substrate_session,
+            state_store=FileStateStore(
+                file_path=str(tmp_path / "state.json"), provider_id=provider_id
+            ),
+            region=substrate_session.region_name,
+            vpc_id=network["vpc_id"],
+            subnet_id=network["subnet_id"],
+            security_group_id=network["security_group_id"],
+            **config,
+        )
+
+    def test_auto_routes_by_job_shape(
+        self, substrate_session, substrate_network, tmp_path
+    ):
+        """A single-task, short command goes to Lambda; anything else to ECS."""
+        mode = self._mode(
+            substrate_session, substrate_network, tmp_path, worker_type="auto"
+        )
+        try:
             mode.initialize()
 
-            # Replace provider's operating mode with our mocked one
-            provider._operating_mode = mode
+            assert mode._select_worker_type("echo hello", 1) == WORKER_TYPE_LAMBDA
+            # More than one task per node cannot be a Lambda invocation.
+            assert mode._select_worker_type("echo hello", 4) == WORKER_TYPE_ECS
+            # Nor can a command past Lambda's practical payload size.
+            assert mode._select_worker_type("x" * 6000, 1) == WORKER_TYPE_ECS
+        finally:
+            mode.cleanup_infrastructure()
 
-            # Mock Lambda function and ECS task creation
-            mode.lambda_manager = MagicMock()
-            mode.ecs_manager = MagicMock()
+    @pytest.mark.parametrize("worker_type", [WORKER_TYPE_LAMBDA, WORKER_TYPE_ECS])
+    def test_an_explicit_worker_type_is_never_overridden(
+        self, substrate_session, substrate_network, tmp_path, worker_type
+    ):
+        """Only ``auto`` inspects the job; a named backend is honoured verbatim."""
+        mode = self._mode(
+            substrate_session, substrate_network, tmp_path, worker_type=worker_type
+        )
+        try:
+            mode.initialize()
 
-            # Configure mocks
-            mode.lambda_manager._create_lambda_function.return_value = {
-                "FunctionName": "lambda-function",
-                "FunctionArn": "arn:aws:lambda:us-east-1:123456789012:function:lambda-function",
-            }
-            mode.lambda_manager.invoke_lambda_function.return_value = {
-                "StatusCode": 200,
-                "Payload": MagicMock(
-                    read=lambda: b'{"statusCode": 200, "body": "Success"}'
-                ),
-            }
-
-            mode.ecs_manager.create_cluster.return_value = "test-cluster"
-            mode.ecs_manager.register_task_definition.return_value = "test-task:1"
-            mode.ecs_manager.run_task.return_value = {
-                "taskArn": "arn:aws:ecs:us-east-1:123456789012:task/test-cluster/abcdef12345",
-                "clusterArn": "arn:aws:ecs:us-east-1:123456789012:cluster/test-cluster",
-                "taskDefinitionArn": "arn:aws:ecs:us-east-1:123456789012:task-definition/test-task:1",
-            }
-
-            # Test the provider's submit method with different job types
-            with patch.object(mode, "_select_worker_type") as mock_select_worker:
-                mock_select_worker.side_effect = [
-                    "lambda",
-                    "ecs",
-                    "lambda",
-                    "ecs",
-                    "lambda",
-                ]
-
-                # Submit a mix of jobs with provider interface
-                with patch(
-                    "builtins.open", MagicMock()
-                ):  # Mock writing Lambda code to file
-                    # Submit 5 mixed jobs
-                    job_ids = []
-                    for i in range(5):
-                        job_id = f"job-{i + 1}"
-                        command = f"echo 'Job {i + 1}'"
-
-                        # Submit through provider interface
-                        with patch.object(provider, "status"):  # Mock status calls
-                            resource_id = provider.submit(job_id, command)
-                            job_ids.append(job_id)
-
-                    # Verify jobs were submitted and tracked
-                    assert len(mode.resources) == 5
-
-                    # Should have 3 Lambda functions and 2 ECS tasks based on our mock
-                    lambda_count = sum(
-                        1
-                        for r in mode.resources.values()
-                        if r.get("worker_type") == "lambda"
-                    )
-                    ecs_count = sum(
-                        1
-                        for r in mode.resources.values()
-                        if r.get("worker_type") == "ecs"
-                    )
-
-                    assert lambda_count == 3
-                    assert ecs_count == 2
-
-                    # Check status through provider interface
-                    all_resource_ids = list(mode.resources.keys())
-
-                    # Patch status to return running for all jobs
-                    with patch.object(mode, "get_job_status") as mock_status:
-                        mock_status.return_value = {
-                            rid: "running" for rid in all_resource_ids
-                        }
-                        status = provider.status(job_ids)
-
-                        # All jobs should be running
-                        for job_id in job_ids:
-                            assert status[job_id] == "running"
-
-                    # Test cancellation through provider interface
-                    with patch.object(mode, "cancel_jobs") as mock_cancel:
-                        mock_cancel.return_value = {
-                            rid: "cancelled" for rid in all_resource_ids
-                        }
-                        cancel_status = provider.cancel(job_ids)
-
-                        # All jobs should be cancelled
-                        for job_id in job_ids:
-                            assert cancel_status[job_id] == "cancelled"
-
-            # Clean up - use provider interface
-            with patch.object(mode, "cleanup_infrastructure"):
-                provider.shutdown()
-                # Verify cleanup was called
-                mode.cleanup_infrastructure.assert_called_once()
+            # The same two jobs that ``auto`` routes differently above.
+            assert mode._select_worker_type("echo hello", 1) == worker_type
+            assert mode._select_worker_type("x" * 6000, 8) == worker_type
+        finally:
+            mode.cleanup_infrastructure()

--- a/tests/integration/test_detached_mode_spot_fleet_integration.py
+++ b/tests/integration/test_detached_mode_spot_fleet_integration.py
@@ -125,19 +125,34 @@ class TestDetachedModeSpotFleetIntegration(unittest.TestCase):
         self.workflow_id = "test-workflow-id"
         self.provider_id = "test-provider-id"
 
-        # Create DetachedMode instance with SpotFleet enabled
+        # Create DetachedMode instance with SpotFleet enabled.
+        #
+        # `bastion_host_type="direct"` rather than the "cloudformation" default:
+        # since #86 bastion.yml puts `ImageId` in a launch template and has the
+        # AWS::EC2::Instance reference it, which is what lets one template serve
+        # both the on-demand and the spot bastion. moto's CloudFormation handler
+        # for AWS::EC2::Instance reads `properties["ImageId"]` directly
+        # (moto/ec2/models/instances.py:400) and resolves no launch template, so
+        # it raises `KeyError: 'ImageId'` on a stack real CloudFormation accepts.
+        # The direct path launches with `run_instances`, which moto does model.
+        # The CloudFormation bastion is covered in `tests/aws/` against real AWS.
+        #
+        # `create_vpc=False` used to be passed here. #69 removed the parameter --
+        # every mode now requires the three network IDs, which are supplied
+        # above -- and the mode's `**kwargs` swallowed it silently rather than
+        # rejecting it, so it read as configuration while doing nothing.
         self.detached_mode = DetachedMode(
             provider_id=self.provider_id,
             session=self.session,
             state_store=self.state_store,
             workflow_id=self.workflow_id,
+            bastion_host_type="direct",
             bastion_instance_type="t2.micro",
             instance_type="t2.micro",
             image_id=self.ami_id,
             vpc_id=self.vpc_id,
             subnet_id=self.subnet_id,
             security_group_id=self.security_group_id,
-            create_vpc=False,  # Use existing VPC
             use_spot_fleet=True,
             instance_types=["t2.micro", "t2.small", "m5.small"],
             nodes_per_block=2,

--- a/tests/integration/test_multinode_workflows.py
+++ b/tests/integration/test_multinode_workflows.py
@@ -1,598 +1,530 @@
-"""Integration tests for multi-node execution workflows.
+"""Integration tests for what ``nodes_per_block`` actually does.
 
-These tests verify that the provider correctly handles multi-node jobs like MPI
-workloads across different operating modes.
+The value has exactly one effect in this package: it becomes an EC2 Fleet's
+``TotalTargetCapacity``. Every other launch path ignores it and launches one
+instance per block. ``docs/examples.md:562`` says so under "Not supported", and
+``docs/spot_fleet.md:79`` repeats it -- so these tests pin the contract from both
+sides, asserting that the single-instance paths *ignore* the value rather than
+leaving that half untested.
+
+There is no MPI support to test. The previous version of this file was written
+against a design that does not exist: it passed ``launcher=MpiExecLauncher()`` to
+modes that accept no such argument, then asserted ``mpirun`` had been spliced
+into the submitted command by launcher wiring the package has never had --
+``grep -rn launcher parsl_ephemeral_aws/`` finds nothing. Since #105 the provider
+*rejects* unknown kwargs rather than absorbing them, so that construction now
+raises, which is asserted below as the honest answer to "how do I run MPI here".
+
+It also patched twelve methods that exist on no mode -- ``_create_vpc``,
+``_create_subnet``, ``_create_security_group``, ``_create_ec2_instance``,
+``_create_ec2_instances_as_block``, ``_create_ec2_instances_as_block_impl``,
+``_create_bastion_host``, ``_create_ssm_parameter``, ``_create_tags``,
+``_delete_ec2_instance``, ``_delete_subnet``, ``_delete_vpc`` -- and
+``patch.object`` raises ``AttributeError`` on a missing attribute, so all four
+tests were hard errors and none of their assertions ever ran. Several were also
+wrong on their face: no resource record has an ``instances`` list, there is no
+``provider.initialize_blocks()``, and ``provider.status()`` returns
+``List[JobStatus]`` rather than a job-id-keyed dict.
+
+"Multi-node" here therefore means "a block holding more than one instance", which
+is a fleet. Everything runs against the emulator with nothing on the modes
+stubbed.
 
 SPDX-License-Identifier: Apache-2.0
 SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
 """
 
-import os
+import json
 import uuid
+
 import pytest
-import tempfile
-from unittest.mock import patch
 
-from parsl.launchers import SimpleLauncher, SingleNodeLauncher, MpiExecLauncher
-
-from parsl_ephemeral_aws.provider import EphemeralAWSProvider
-from parsl_ephemeral_aws.modes.standard import StandardMode
+from parsl_ephemeral_aws.constants import (
+    RESOURCE_TYPE_EC2,
+    RESOURCE_TYPE_SPOT_FLEET,
+    STATUS_CANCELED,
+    WORKER_TYPE_ECS,
+)
+from parsl_ephemeral_aws.exceptions import ProviderConfigurationError
 from parsl_ephemeral_aws.modes.detached import DetachedMode
+from parsl_ephemeral_aws.modes.serverless import ServerlessMode
+from parsl_ephemeral_aws.modes.standard import StandardMode
+from parsl_ephemeral_aws.provider import EphemeralAWSProvider
 from parsl_ephemeral_aws.state.file import FileStateStore
-from tests.substrate_support import (
-    get_substrate_session,
-    is_substrate_available,
-)
+from tests.substrate_support import get_substrate_endpoint, is_substrate_available
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.substrate,
+    pytest.mark.skipif(
+        not is_substrate_available(),
+        reason="substrate not available - start with 'make substrate-up'",
+    ),
+]
+
+#: Large enough that "one per block" and "one per node" cannot be confused, small
+#: enough to stay quick against the emulator.
+NODES = 4
+
+MPI_COMMAND = "mpirun -n 16 -ppn 4 python /path/to/mpi_script.py"
 
 
-# Skip all tests if the substrate emulator is not available
-pytestmark = pytest.mark.skipif(
-    not is_substrate_available(),
-    reason="substrate not available - start with 'make substrate-up'",
-)
+def job_name():
+    """A job name unique to this run.
+
+    Not cosmetic: ``ServerlessMode._create_job_fleet`` derives its launch
+    template name from the job ID, and a name that repeats across runs finds the
+    previous run's template still in the emulator. The mode then tries to add a
+    version to it, and substrate serves no ``CreateLaunchTemplateVersion`` --
+    so a fixed name passes once and fails every time after, which is the worst
+    kind of test.
+    """
+    return f"mpi-job-{uuid.uuid4().hex[:8]}"
 
 
-@pytest.mark.integration
-class TestMultiNodeWorkflows:
-    """Integration tests for multi-node execution workflow scenarios."""
+@pytest.fixture
+def state_store(tmp_path):
+    """A real file-backed state store inside the test's sandbox.
 
-    @pytest.fixture(scope="class")
-    def substrate_session(self):
-        """Create a session connected to substrate."""
-        return get_substrate_session()
+    Real rather than mocked: the fleet paths persist their block map through
+    ``spot_fleet_state``, and a mock hides a serialization error behind a
+    recorded call. It also keeps ``state/file.py``'s ``fcntl.flock`` on a genuine
+    descriptor, which a MagicMock handle cannot supply.
+    """
+    provider_id = f"test-provider-{uuid.uuid4().hex[:8]}"
+    return FileStateStore(
+        file_path=str(tmp_path / f"state-{provider_id}.json"), provider_id=provider_id
+    )
 
-    @pytest.fixture
-    def temp_dir(self):
-        """Create a temporary directory for state files."""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            yield tmp_dir
 
-    @pytest.fixture
-    def state_file_path(self, temp_dir):
-        """Create a path for the state file."""
-        return os.path.join(temp_dir, f"test-state-{uuid.uuid4().hex[:8]}.json")
+def _standard(session, state_store, network, **overrides):
+    """A StandardMode bound to the emulator, using the caller's network."""
+    kwargs = dict(
+        provider_id=f"test-provider-{uuid.uuid4().hex[:8]}",
+        session=session,
+        state_store=state_store,
+        region=session.region_name,
+        instance_type="t3.micro",
+        image_id="ami-12345678",
+        vpc_id=network["vpc_id"],
+        subnet_id=network["subnet_id"],
+        security_group_id=network["security_group_id"],
+    )
+    kwargs.update(overrides)
+    return StandardMode(**kwargs)
 
-    @pytest.fixture
-    def file_state_store(self, state_file_path):
-        """Create a FileStateStore instance."""
-        provider_id = f"test-provider-{uuid.uuid4().hex[:8]}"
-        return FileStateStore(file_path=state_file_path, provider_id=provider_id)
 
-    @pytest.mark.substrate
-    def test_standard_mode_multinode(self, substrate_session, file_state_store):
-        """Test multi-node execution in StandardMode with MPI."""
-        # Create a StandardMode instance for multi-node execution
-        provider_id = f"test-provider-{uuid.uuid4().hex[:8]}"
+def _fleet_mode(session, state_store, network, **overrides):
+    """A StandardMode whose blocks are EC2 Fleets -- the only multi-node path."""
+    kwargs = dict(
+        use_spot_fleet=True,
+        instance_types=["t3.micro", "t3.small"],
+        nodes_per_block=NODES,
+    )
+    kwargs.update(overrides)
+    return _standard(session, state_store, network, **kwargs)
 
-        # Set up mocks for AWS services using substrate
-        with patch("boto3.Session", return_value=substrate_session):
-            # Create standard mode with multi-node configuration
-            mode = StandardMode(
-                provider_id=provider_id,
-                session=substrate_session,
-                state_store=file_state_store,
-                region="us-east-1",
-                instance_type="c5.large",  # Compute-optimized for MPI
-                image_id="ami-12345678",  # Dummy AMI
-                nodes_per_block=4,  # 4 nodes per block for MPI
-                init_blocks=1,
-                max_blocks=3,
-                launcher=MpiExecLauncher(),  # Use MPI launcher
-            )
 
-            # Initialize mode
-            with patch.object(mode, "_create_vpc", return_value="vpc-12345"):
-                with patch.object(mode, "_create_subnet", return_value="subnet-12345"):
-                    with patch.object(
-                        mode, "_create_security_group", return_value="sg-12345"
-                    ):
-                        mode.initialize()
+def instance_states(session, instance_ids):
+    """Return the set of EC2 state names covering *instance_ids*."""
+    described = session.client("ec2").describe_instances(InstanceIds=list(instance_ids))
+    return {
+        instance["State"]["Name"]
+        for reservation in described["Reservations"]
+        for instance in reservation["Instances"]
+    }
 
-            # Mock instance creation for a multi-node block
-            instance_id_counter = 0
 
-            def create_mock_instance(*args, **kwargs):
-                nonlocal instance_id_counter
-                # For multi-node, we need to return different instances
-                # based on min_count parameter
-                min_count = kwargs.get("min_count", 1)
-                instances = []
+def live_instance_ids(session, tag, value):
+    """Live instance IDs carrying ``tag=value``.
 
-                for i in range(min_count):
-                    instance_id_counter += 1
-                    instances.append(
-                        {
-                            "instance_id": f"i-{instance_id_counter:05d}",
-                            "private_ip": f"10.0.0.{instance_id_counter}",
-                            "public_ip": f"54.123.456.{instance_id_counter}",
-                            "dns_name": f"ec2-54-123-456-{instance_id_counter}.compute-1.amazonaws.com",
-                        }
-                    )
+    Scoped by tag rather than by subnet, as in ``test_autoscaling_workflows.py``:
+    substrate does not apply the launch template's network interface, so a
+    ``subnet-id`` filter matches nothing even for a launch that succeeded.
 
-                if min_count == 1:
-                    return instances[0]
-                return instances
+    Which tag depends on the path, and they do not overlap: ``_create_instance``
+    sets ``ProviderId``, while ``SpotFleetManager`` sets ``WorkflowId`` and
+    ``BlockId`` (``compute/spot_fleet.py``) and ``ServerlessMode``'s own fleet
+    sets ``ParslWorkflowId``. Callers name the one they mean rather than have this
+    helper guess, so a rename on one path cannot silently make the count zero
+    here and still pass.
 
-            # Test multi-node block creation
-            with patch.object(
-                mode, "_create_ec2_instance", side_effect=create_mock_instance
-            ):
-                with patch.object(
-                    mode, "_create_ec2_instances_as_block"
-                ) as mock_create_block:
-                    # Call the actual implementation but with our mock
-                    mock_create_block.side_effect = lambda *args, **kwargs: (
-                        mode._create_ec2_instances_as_block_impl(*args, **kwargs)
-                    )
-
-                    # Should create one block with 4 nodes
-                    mode._init_blocks()
-
-                    # Verify block was created
-                    assert len(mode.resources) == 1
-
-                    # Get the resource ID of the block
-                    block_resource_id = list(mode.resources.keys())[0]
-
-                    # Verify block has 4 nodes
-                    assert (
-                        len(mode.resources[block_resource_id].get("instances", [])) == 4
-                    )
-
-                    # Verify each node has an instance ID
-                    for instance in mode.resources[block_resource_id]["instances"]:
-                        assert "instance_id" in instance
-                        assert instance["instance_id"].startswith("i-")
-
-            # Test MPI job submission to the multi-node block
-            job_id = f"mpi-job-{uuid.uuid4().hex[:8]}"
-            mpi_command = "mpirun -n 16 -ppn 4 python /path/to/mpi_script.py"
-
-            # Submit the MPI job
-            resource_id = mode.submit_job(job_id, mpi_command, 4)  # 4 nodes requested
-
-            # Verify job was assigned to the block
-            assert resource_id == block_resource_id
-            assert mode.resources[resource_id]["job_id"] == job_id
-
-            # Verify the command includes MPI launcher components
-            assert "mpirun" in mode.resources[resource_id]["command"]
-            assert "-n 16" in mode.resources[resource_id]["command"]
-
-            # Test scaling with multi-node blocks
-            with patch.object(
-                mode, "_create_ec2_instance", side_effect=create_mock_instance
-            ):
-                with patch.object(
-                    mode, "_create_ec2_instances_as_block"
-                ) as mock_create_block:
-                    # Call the actual implementation but with our mock
-                    mock_create_block.side_effect = lambda *args, **kwargs: (
-                        mode._create_ec2_instances_as_block_impl(*args, **kwargs)
-                    )
-
-                    # Scale out by adding another block
-                    new_blocks = mode.scale_out(1)
-
-                    # Verify scaling was successful
-                    assert new_blocks == 1
-
-                    # Should now have 2 blocks (each with 4 nodes)
-                    assert len(mode.resources) == 2
-
-                    # Verify the new block also has 4 nodes
-                    new_block_resource_id = [
-                        rid for rid in mode.resources.keys() if rid != block_resource_id
-                    ][0]
-                    assert (
-                        len(mode.resources[new_block_resource_id].get("instances", []))
-                        == 4
-                    )
-
-            # Test job cancellation
-            with patch.object(mode, "_cancel_job"):
-                # Cancel the MPI job
-                result = mode.cancel_jobs([resource_id])
-
-                # Verify cancellation
-                assert resource_id in result
-                assert result[resource_id] == "cancelled"
-
-            # Clean up
-            with patch.object(mode, "_delete_ec2_instance"):
-                with patch.object(mode, "_delete_security_group"):
-                    with patch.object(mode, "_delete_subnet"):
-                        with patch.object(mode, "_delete_vpc"):
-                            mode.cleanup_infrastructure()
-
-    @pytest.mark.substrate
-    def test_detached_mode_multinode(self, substrate_session, file_state_store):
-        """Test multi-node execution in DetachedMode with MPI."""
-        # Create a DetachedMode instance for multi-node execution
-        provider_id = f"test-provider-{uuid.uuid4().hex[:8]}"
-        workflow_id = f"test-workflow-{uuid.uuid4().hex[:8]}"
-
-        # Set up mocks for AWS services using substrate
-        with patch("boto3.Session", return_value=substrate_session):
-            # Create detached mode with multi-node configuration
-            mode = DetachedMode(
-                provider_id=provider_id,
-                session=substrate_session,
-                state_store=file_state_store,
-                region="us-east-1",
-                instance_type="c5.large",  # Compute-optimized for MPI
-                image_id="ami-12345678",  # Dummy AMI
-                workflow_id=workflow_id,
-                bastion_instance_type="t3.micro",
-                bastion_host_type="orchestrator",  # Use orchestrator for MPI coordination
-                nodes_per_block=4,  # 4 nodes per block for MPI
-                init_blocks=1,
-                max_blocks=3,
-                launcher=MpiExecLauncher(),  # Use MPI launcher
-            )
-
-            # Initialize mode
-            with patch.object(mode, "_create_vpc", return_value="vpc-12345"):
-                with patch.object(mode, "_create_subnet", return_value="subnet-12345"):
-                    with patch.object(
-                        mode, "_create_security_group", return_value="sg-12345"
-                    ):
-                        with patch.object(
-                            mode, "_create_bastion_host"
-                        ) as mock_create_bastion:
-                            mock_create_bastion.return_value = {
-                                "instance_id": f"i-bastion-{uuid.uuid4().hex[:8]}",
-                                "private_ip": "10.0.0.2",
-                                "public_ip": "54.123.456.789",
-                                "dns_name": "ec2-54-123-456-789.compute-1.amazonaws.com",
-                            }
-                            with patch.object(mode, "_create_tags"):
-                                mode.initialize()
-
-            # Verify bastion was created with orchestrator role
-            assert mode.bastion_id is not None
-            assert mode.bastion_host_type == "orchestrator"
-
-            # Mock instance creation for a multi-node block
-            instance_id_counter = 0
-
-            def create_mock_instance(*args, **kwargs):
-                nonlocal instance_id_counter
-                # For multi-node, we need to return different instances
-                # based on min_count parameter
-                min_count = kwargs.get("min_count", 1)
-                instances = []
-
-                for i in range(min_count):
-                    instance_id_counter += 1
-                    instances.append(
-                        {
-                            "instance_id": f"i-{instance_id_counter:05d}",
-                            "private_ip": f"10.0.0.{instance_id_counter + 10}",
-                            "public_ip": None,  # No public IP in detached mode
-                            "dns_name": None,
-                        }
-                    )
-
-                if min_count == 1:
-                    return instances[0]
-                return instances
-
-            # Test multi-node block creation
-            with patch.object(
-                mode, "_create_ec2_instance", side_effect=create_mock_instance
-            ):
-                with patch.object(
-                    mode, "_create_ec2_instances_as_block"
-                ) as mock_create_block:
-                    # Call the actual implementation but with our mock
-                    mock_create_block.side_effect = lambda *args, **kwargs: (
-                        mode._create_ec2_instances_as_block_impl(*args, **kwargs)
-                    )
-                    with patch.object(mode, "_create_ssm_parameter"):
-                        # Should create one block with 4 nodes
-                        mode._init_blocks()
-
-                        # Verify block was created
-                        assert len(mode.resources) == 1
-
-                        # Get the resource ID of the block
-                        block_resource_id = list(mode.resources.keys())[0]
-
-                        # Verify block has 4 nodes
-                        assert (
-                            len(mode.resources[block_resource_id].get("instances", []))
-                            == 4
-                        )
-
-                        # Verify each node has an instance ID
-                        for instance in mode.resources[block_resource_id]["instances"]:
-                            assert "instance_id" in instance
-                            assert instance["instance_id"].startswith("i-")
-
-            # Test MPI job submission to the multi-node block
-            job_id = f"mpi-job-{uuid.uuid4().hex[:8]}"
-            mpi_command = "mpirun -n 16 -ppn 4 python /path/to/mpi_script.py"
-
-            # Submit the MPI job with orchestrator parameters
-            with patch.object(mode, "_create_ssm_parameter"):
-                resource_id = mode.submit_job(
-                    job_id, mpi_command, 4
-                )  # 4 nodes requested
-
-            # Verify job was assigned to the block
-            assert resource_id == block_resource_id
-            assert mode.resources[resource_id]["job_id"] == job_id
-
-            # Verify the job has SSM parameters for orchestration
-            assert mode.resources[resource_id].get("ssm_parameter_name") is not None
-
-            # Clean up
-            with patch.object(mode, "_delete_ec2_instance"):
-                with patch.object(mode, "_delete_ssm_parameter"):
-                    with patch.object(mode, "_delete_security_group"):
-                        with patch.object(mode, "_delete_subnet"):
-                            with patch.object(mode, "_delete_vpc"):
-                                mode.preserve_bastion = (
-                                    False  # Ensure bastion is cleaned up
-                                )
-                                mode.cleanup_infrastructure()
-
-    @pytest.mark.substrate
-    def test_standard_mode_with_different_launchers(
-        self, substrate_session, file_state_store
-    ):
-        """Test different launchers in StandardMode."""
-        # Create a StandardMode instance
-        provider_id = f"test-provider-{uuid.uuid4().hex[:8]}"
-
-        # Test different launchers
-        launchers = [
-            (SimpleLauncher(), "simple"),
-            (SingleNodeLauncher(), "single-node"),
-            (MpiExecLauncher(), "mpi"),
+    ``terminated`` and ``shutting-down`` are excluded: a torn-down instance
+    lingers in ``describe_instances`` for a while.
+    """
+    reservations = session.client("ec2").describe_instances(
+        Filters=[
+            {"Name": f"tag:{tag}", "Values": [value]},
+            {
+                "Name": "instance-state-name",
+                "Values": ["pending", "running", "stopping", "stopped"],
+            },
         ]
+    )["Reservations"]
+    return [
+        instance["InstanceId"]
+        for reservation in reservations
+        for instance in reservation["Instances"]
+    ]
 
-        for launcher, launcher_type in launchers:
-            # Set up mocks for AWS services using substrate
-            with patch("boto3.Session", return_value=substrate_session):
-                # Create standard mode with specific launcher
-                mode = StandardMode(
-                    provider_id=f"{provider_id}-{launcher_type}",
-                    session=substrate_session,
-                    state_store=file_state_store,
-                    region="us-east-1",
-                    instance_type="c5.large",
-                    image_id="ami-12345678",  # Dummy AMI
-                    nodes_per_block=2
-                    if launcher_type == "mpi"
-                    else 1,  # Multi-node only for MPI
-                    init_blocks=1,
-                    max_blocks=2,
-                    launcher=launcher,
-                )
 
-                # Initialize mode
-                with patch.object(mode, "_create_vpc", return_value="vpc-12345"):
-                    with patch.object(
-                        mode, "_create_subnet", return_value="subnet-12345"
-                    ):
-                        with patch.object(
-                            mode, "_create_security_group", return_value="sg-12345"
-                        ):
-                            mode.initialize()
+class TestFleetTargetCapacity:
+    """The one path where ``nodes_per_block`` is honoured."""
 
-                # Mock instance creation
-                instance_id_counter = 0
+    def test_nodes_per_block_becomes_the_fleets_target_capacity(
+        self, substrate_session, substrate_network, state_store
+    ):
+        """One block is one fleet holding ``nodes_per_block`` instances.
 
-                def create_mock_instance(*args, **kwargs):
-                    nonlocal instance_id_counter
-                    # For multi-node, handle multiple instances
-                    min_count = kwargs.get("min_count", 1)
-                    instances = []
+        Asserted against EC2 as well as against the block map, because the two
+        can disagree: substrate honours ``TotalTargetCapacity`` (substrate#387),
+        whereas moto launches exactly one instance no matter what is requested,
+        which is why this cannot be covered there at all.
+        """
+        mode = _fleet_mode(substrate_session, state_store, substrate_network)
+        try:
+            mode.initialize()
+            block_id = mode.submit_job(job_name(), MPI_COMMAND, NODES)
 
-                    for i in range(min_count):
-                        instance_id_counter += 1
-                        instances.append(
-                            {
-                                "instance_id": f"i-{instance_id_counter:05d}",
-                                "private_ip": f"10.0.0.{instance_id_counter}",
-                                "public_ip": f"54.123.456.{instance_id_counter}",
-                                "dns_name": f"ec2-54-123-456-{instance_id_counter}.compute-1.amazonaws.com",
-                            }
-                        )
+            block = mode.spot_fleet_manager.blocks[block_id]
+            assert len(block["instance_ids"]) == NODES
 
-                    if min_count == 1:
-                        return instances[0]
-                    return instances
+            capacity = substrate_session.client("ec2").describe_fleets(
+                FleetIds=[block["fleet_request_id"]]
+            )["Fleets"][0]["TargetCapacitySpecification"]
+            assert capacity["TotalTargetCapacity"] == NODES
+            assert capacity["DefaultTargetCapacityType"] == "spot"
 
-                # Test block creation
-                with patch.object(
-                    mode, "_create_ec2_instance", side_effect=create_mock_instance
-                ):
-                    with patch.object(
-                        mode, "_create_ec2_instances_as_block"
-                    ) as mock_create_block:
-                        mock_create_block.side_effect = lambda *args, **kwargs: (
-                            mode._create_ec2_instances_as_block_impl(*args, **kwargs)
-                        )
+            # Every node exists, not just every ID: a fleet that only partially
+            # filled would still report the capacity that was requested.
+            live = live_instance_ids(substrate_session, "BlockId", block_id)
+            assert sorted(live) == sorted(block["instance_ids"])
+        finally:
+            mode.cleanup_infrastructure()
 
-                        # Create initial blocks
-                        mode._init_blocks()
+    def test_a_multi_node_block_is_tracked_as_one_resource(
+        self, substrate_session, substrate_network, state_store
+    ):
+        """One resource per block, keyed by block ID -- not one per node.
 
-                        # Verify block creation
-                        assert len(mode.resources) == 1
+        This is the shape the old tests got wrong: they expected
+        ``resources[block]["instances"]`` to hold a list of per-node dicts. The
+        node IDs live on the manager's block map instead, and reach the state
+        document through ``spot_fleet_state`` rather than through ``resources``.
+        A provider resumed from state needs them from there, so the round-trip is
+        asserted too.
+        """
+        mode = _fleet_mode(substrate_session, state_store, substrate_network)
+        try:
+            mode.initialize()
+            block_id = mode.submit_job(job_name(), MPI_COMMAND, NODES)
 
-                # Test job submission with the specific launcher
-                job_id = f"{launcher_type}-job-{uuid.uuid4().hex[:8]}"
+            assert list(mode.resources) == [block_id]
+            record = mode.resources[block_id]
+            assert record["type"] == RESOURCE_TYPE_SPOT_FLEET
+            assert record["fleet_request_id"].startswith("fleet-")
+            assert "instances" not in record
 
-                # Different commands based on launcher type
-                if launcher_type == "mpi":
-                    command = "mpirun -n 8 -ppn 4 python /path/to/mpi_script.py"
-                else:
-                    command = "python /path/to/script.py"
+            with open(state_store.file_path) as handle:
+                saved = json.load(handle)["_states"]["mode"]
+            saved_block = saved["spot_fleet_state"]["blocks"][block_id]
+            assert len(saved_block["instance_ids"]) == NODES
+        finally:
+            mode.cleanup_infrastructure()
 
-                # Submit the job
-                resource_id = mode.submit_job(job_id, command, 1)
+    def test_the_fleet_manager_inherits_the_modes_session(
+        self, substrate_session, substrate_network, state_store
+    ):
+        """The manager must not build its own session from the environment.
 
-                # Verify submission
-                assert resource_id in mode.resources
-                assert mode.resources[resource_id]["job_id"] == job_id
+        ``resolve_manager_session()`` prefers ``provider.session`` and falls back
+        to ambient environment credentials only when there is none (#117). The
+        stand-in ``StandardMode`` builds for the manager carried no ``session``,
+        so the fallback always fired: every fleet went to the default account for
+        the region while the rest of the mode used the session the caller
+        configured. The endpoint is the visible symptom here; against real AWS it
+        would be the account, which is why this is asserted rather than left to
+        the fleet tests above -- they would keep passing while the fleet was
+        created somewhere else entirely.
+        """
+        mode = _fleet_mode(substrate_session, state_store, substrate_network)
 
-                # Verify launcher was applied to command
-                submitted_command = mode.resources[resource_id]["command"]
-
-                if launcher_type == "mpi":
-                    assert "mpirun" in submitted_command
-                elif launcher_type == "single-node":
-                    # SingleNodeLauncher may add node-specific prefixes
-                    assert command in submitted_command
-                else:  # SimpleLauncher
-                    # SimpleLauncher doesn't modify the command
-                    assert command == submitted_command
-
-                # Clean up
-                with patch.object(mode, "_delete_ec2_instance"):
-                    with patch.object(mode, "_delete_security_group"):
-                        with patch.object(mode, "_delete_subnet"):
-                            with patch.object(mode, "_delete_vpc"):
-                                mode.cleanup_infrastructure()
-
-    @pytest.mark.substrate
-    def test_provider_multinode_integration(self, substrate_session, file_state_store):
-        """Test multi-node integration through provider interface."""
-        # Create a provider for multi-node execution
-        provider_id = f"test-provider-{uuid.uuid4().hex[:8]}"
-
-        # Create a provider to handle both the test and implementation
-        provider = EphemeralAWSProvider(
-            provider_id=provider_id,
-            region="us-east-1",
-            mode="standard",
-            instance_type="c5.xlarge",
-            image_id="ami-12345678",  # Dummy AMI
-            nodes_per_block=4,
-            init_blocks=1,
-            max_blocks=2,
-            launcher=MpiExecLauncher(),
-            # Inject our session and state store for testing
-            _test_session=substrate_session,
-            _test_state_store=file_state_store,
+        assert mode.spot_fleet_manager.aws_session is substrate_session
+        assert (
+            mode.spot_fleet_manager.ec2_client.meta.endpoint_url
+            == get_substrate_endpoint()
         )
 
-        # Initialize the internal operating mode directly
-        with patch.object(provider, "_initialize_operating_mode"):
-            # Mock the operating mode
-            mode = StandardMode(
-                provider_id=provider_id,
-                session=substrate_session,
-                state_store=file_state_store,
-                region="us-east-1",
-                instance_type="c5.xlarge",
-                image_id="ami-12345678",  # Dummy AMI
-                nodes_per_block=4,
-                init_blocks=1,
-                max_blocks=2,
-                launcher=MpiExecLauncher(),
+    def test_the_price_cap_is_fleet_wide_so_it_scales_with_capacity(
+        self, substrate_session, substrate_network, state_store
+    ):
+        """``MaxTotalPrice`` covers the whole fleet, unlike the legacy ``SpotPrice``.
+
+        The legacy per-instance-hour ``SpotPrice`` needed no scaling; sending that
+        same number as a fleet-wide maximum would cap a 4-node fleet at one node's
+        budget and it would never fill. Asserted as a ratio rather than an
+        absolute because the figure derives from live spot-price history.
+
+        Read off the manager rather than off the created fleet: substrate accepts
+        ``SpotOptions`` but omits it from ``describe_fleets``, so the value is not
+        observable on the fleet itself.
+        """
+        mode = _fleet_mode(
+            substrate_session,
+            state_store,
+            substrate_network,
+            spot_max_price_percentage=50,
+        )
+        resolve = mode.spot_fleet_manager._resolve_max_total_price
+
+        single = float(resolve(1))
+        assert single > 0
+        assert float(resolve(NODES)) == pytest.approx(single * NODES)
+
+    def test_no_cap_is_sent_when_none_was_asked_for(
+        self, substrate_session, substrate_network, state_store
+    ):
+        """The default, and the configuration AWS recommends: no maximum at all."""
+        mode = _fleet_mode(substrate_session, state_store, substrate_network)
+
+        assert mode.spot_fleet_manager._resolve_max_total_price(NODES) is None
+
+
+class TestSingleInstancePathsIgnoreNodesPerBlock:
+    """The other half of the contract, and the half that surprises people."""
+
+    def test_standard_mode_launches_one_instance_per_block(
+        self, substrate_session, substrate_network, state_store
+    ):
+        """``nodes_per_block=4`` on the on-demand path still launches one.
+
+        Not a defect to fix here -- ``_create_instance`` hardcodes
+        ``MinCount=1, MaxCount=1`` and ``docs/examples.md`` documents the
+        limitation -- but worth a test that fails the day someone wires the value
+        into those counts without also teaching ``get_job_status`` and
+        ``cleanup_resources`` about a multi-instance record.
+        """
+        mode = _standard(
+            substrate_session, state_store, substrate_network, nodes_per_block=NODES
+        )
+        try:
+            mode.initialize()
+            instance_id = mode.submit_job(job_name(), MPI_COMMAND, NODES)
+
+            assert list(mode.resources) == [instance_id]
+            assert mode.resources[instance_id]["type"] == RESOURCE_TYPE_EC2
+            assert live_instance_ids(
+                substrate_session, "ProviderId", mode.provider_id
+            ) == [instance_id]
+        finally:
+            mode.cleanup_infrastructure()
+
+    def test_detached_mode_delegates_the_value_rather_than_acting_on_it(
+        self, substrate_session, substrate_network, state_store
+    ):
+        """The value is written into the work order; the bastion acts on it.
+
+        ``DetachedMode.submit_job`` launches no workers -- it writes a JSON work
+        order to Parameter Store and returns. The bastion manager script polls
+        that path and calls ``launch_spot_fleet()``, which reads
+        ``nodes_per_block`` as the fleet's target capacity
+        (``modes/detached.py:965``). So the mode's whole obligation is to *carry*
+        the value, and the only instance in the account after a submit is the
+        bastion -- both halves asserted, since a driver that quietly launched
+        workers too would double the bill.
+
+        ``bastion_host_type="direct"``: the default CloudFormation path needs a
+        service substrate does not emulate, and the real stack is covered in
+        ``tests/aws/``.
+        """
+        workflow_id = f"test-workflow-{uuid.uuid4().hex[:8]}"
+        mode = DetachedMode(
+            provider_id=f"test-provider-{uuid.uuid4().hex[:8]}",
+            session=substrate_session,
+            state_store=state_store,
+            region=substrate_session.region_name,
+            workflow_id=workflow_id,
+            bastion_host_type="direct",
+            bastion_instance_type="t3.micro",
+            preserve_bastion=False,
+            image_id="ami-12345678",
+            instance_type="c5.large",
+            nodes_per_block=NODES,
+            use_spot_fleet=True,
+            instance_types=["c5.large", "c5.xlarge"],
+            vpc_id=substrate_network["vpc_id"],
+            subnet_id=substrate_network["subnet_id"],
+            security_group_id=substrate_network["security_group_id"],
+        )
+        try:
+            mode.initialize()
+            job_id = job_name()
+            resource_id = mode.submit_job(job_id, MPI_COMMAND, NODES)
+
+            work_order = json.loads(
+                substrate_session.client("ssm").get_parameter(
+                    Name=f"/parsl/workflows/{workflow_id}/jobs/{job_id}"
+                )["Parameter"]["Value"]
+            )
+            assert work_order["nodes_per_block"] == NODES
+            assert work_order["use_spot_fleet"] is True
+            assert work_order["instance_types"] == ["c5.large", "c5.xlarge"]
+
+            assert mode.resources[resource_id]["type"] == RESOURCE_TYPE_EC2
+            assert live_instance_ids(
+                substrate_session, "ProviderId", mode.provider_id
+            ) == [mode.bastion_id]
+        finally:
+            mode.cleanup_infrastructure()
+
+
+class TestServerlessFleetCapacity:
+    """The serverless mode carries its own copy of the capacity semantics."""
+
+    def test_the_ecs_fleet_path_honours_nodes_per_block(
+        self, substrate_session, substrate_network, state_store
+    ):
+        """``use_spot_fleet`` on the ECS worker type trades Fargate for a fleet.
+
+        A second, independent implementation of the same behaviour --
+        ``ServerlessMode._create_job_fleet`` builds its own launch template and
+        calls ``create_ec2_fleet`` directly instead of going through
+        ``SpotFleetManager`` -- so it needs its own coverage. The instance IDs
+        land on the resource record here, not on a block map, and there is no
+        stack: ``get_job_status`` and ``cleanup_resources`` both branch on
+        ``stack_name``, so recording one would send them down the CloudFormation
+        path for a fleet that has none.
+        """
+        mode = ServerlessMode(
+            provider_id=f"test-provider-{uuid.uuid4().hex[:8]}",
+            session=substrate_session,
+            state_store=state_store,
+            region=substrate_session.region_name,
+            worker_type=WORKER_TYPE_ECS,
+            image_id="ami-12345678",
+            instance_types=["t3.micro", "t3.small"],
+            nodes_per_block=NODES,
+            use_spot_fleet=True,
+            vpc_id=substrate_network["vpc_id"],
+            subnet_id=substrate_network["subnet_id"],
+            security_group_id=substrate_network["security_group_id"],
+        )
+        try:
+            mode.initialize()
+            resource_id = mode.submit_job(job_name(), MPI_COMMAND, NODES)
+
+            record = mode.resources[resource_id]
+            assert record["resource_type"] == RESOURCE_TYPE_SPOT_FLEET
+            assert len(record["instance_ids"]) == NODES
+            assert record["use_spot_fleet"] is True
+            assert "stack_name" not in record
+
+            capacity = substrate_session.client("ec2").describe_fleets(
+                FleetIds=[record["fleet_request_id"]]
+            )["Fleets"][0]["TargetCapacitySpecification"]
+            assert capacity["TotalTargetCapacity"] == NODES
+        finally:
+            mode.cleanup_infrastructure()
+
+
+class TestThroughTheProvider:
+    """The same behaviour, reached the way a Parsl config reaches it."""
+
+    def test_nodes_per_block_reaches_the_fleet_through_the_provider(
+        self, substrate_session, substrate_network, tmp_path
+    ):
+        """Three hops, each of which has been broken before.
+
+        The provider's ``common_params`` (the fleet path was unreachable through
+        the provider at all until #105), the mode's constructor, and the stand-in
+        the mode builds for the manager. Only the last hop is what the fleet
+        actually reads, so the assertion follows the value all the way to the
+        instances rather than stopping at ``provider.nodes_per_block``.
+        """
+        provider = EphemeralAWSProvider(
+            provider_id=f"test-provider-{uuid.uuid4().hex[:8]}",
+            region=substrate_session.region_name,
+            endpoint_url=get_substrate_endpoint(),
+            state_file_path=str(tmp_path / "state.json"),
+            mode="standard",
+            image_id="ami-12345678",
+            instance_type="c5.large",
+            nodes_per_block=NODES,
+            use_spot_fleet=True,
+            instance_types=["c5.large", "c5.xlarge"],
+            max_blocks=2,
+            vpc_id=substrate_network["vpc_id"],
+            subnet_id=substrate_network["subnet_id"],
+            security_group_id=substrate_network["security_group_id"],
+        )
+        try:
+            job_id = provider.submit(MPI_COMMAND, tasks_per_node=NODES)
+
+            mode = provider.operating_mode
+            assert mode.nodes_per_block == NODES
+            assert mode.spot_fleet_manager.provider.nodes_per_block == NODES
+
+            block_id = provider.job_map[job_id]["resource_id"]
+            block = mode.spot_fleet_manager.blocks[block_id]
+            assert len(block["instance_ids"]) == NODES
+
+            # One block, not NODES of them: max_blocks counts blocks, so a
+            # provider that conflated the two would refuse the first submit.
+            assert len(provider.resources) == 1
+        finally:
+            provider.shutdown()
+
+    def test_a_launcher_is_not_a_provider_option(self, substrate_network, tmp_path):
+        """``launcher`` is a Parsl executor concept this provider does not take.
+
+        The old tests passed ``MpiExecLauncher()`` to both the provider and the
+        modes, then asserted the launcher had rewritten the submitted command. No
+        launcher wiring exists -- the command goes into UserData or over SSM
+        verbatim -- and since #105 an unrecognised kwarg is refused rather than
+        dropped. That refusal is the behaviour worth pinning: a config that looks
+        like it requests MPI fails loudly instead of running single-node and
+        reporting success.
+        """
+        with pytest.raises(ProviderConfigurationError, match="launcher"):
+            EphemeralAWSProvider(
+                region="us-west-2",
+                endpoint_url=get_substrate_endpoint(),
+                state_file_path=str(tmp_path / "state.json"),
+                image_id="ami-12345678",
+                launcher="MpiExecLauncher",
+                vpc_id=substrate_network["vpc_id"],
+                subnet_id=substrate_network["subnet_id"],
+                security_group_id=substrate_network["security_group_id"],
             )
 
-            # Initialize infrastructure
-            with patch.object(mode, "_create_vpc", return_value="vpc-12345"):
-                with patch.object(mode, "_create_subnet", return_value="subnet-12345"):
-                    with patch.object(
-                        mode, "_create_security_group", return_value="sg-12345"
-                    ):
-                        mode.initialize()
 
-            # Replace provider's operating mode with our mocked one
-            provider._operating_mode = mode
+class TestMultiNodeTeardown:
+    """Cancelling one block must reclaim all of its nodes."""
 
-            # Mock instance creation for a multi-node block
-            instance_id_counter = 0
+    def test_cancelling_a_block_terminates_every_node(
+        self, substrate_session, substrate_network, state_store
+    ):
+        """A partial teardown leaves billed instances nothing points at.
 
-            def create_mock_instance(*args, **kwargs):
-                nonlocal instance_id_counter
-                # For multi-node, handle multiple instances
-                min_count = kwargs.get("min_count", 1)
-                instances = []
+        Deleting the fleet is what terminates the instances; ``cancel_jobs`` does
+        no per-node bookkeeping. So this asserts that the block-level operation
+        really covers all ``nodes_per_block`` of them, which is the failure that
+        would otherwise show up only on an AWS bill.
+        """
+        mode = _fleet_mode(substrate_session, state_store, substrate_network)
+        try:
+            mode.initialize()
+            block_id = mode.submit_job("mpi-job", MPI_COMMAND, NODES)
+            instance_ids = list(
+                mode.spot_fleet_manager.blocks[block_id]["instance_ids"]
+            )
+            assert len(instance_ids) == NODES
 
-                for i in range(min_count):
-                    instance_id_counter += 1
-                    instances.append(
-                        {
-                            "instance_id": f"i-{instance_id_counter:05d}",
-                            "private_ip": f"10.0.0.{instance_id_counter}",
-                            "public_ip": f"54.123.456.{instance_id_counter}",
-                            "dns_name": f"ec2-54-123-456-{instance_id_counter}.compute-1.amazonaws.com",
-                        }
-                    )
+            assert mode.cancel_jobs([block_id]) == {block_id: STATUS_CANCELED}
 
-                if min_count == 1:
-                    return instances[0]
-                return instances
-
-            # Test block creation
-            with patch.object(
-                mode, "_create_ec2_instance", side_effect=create_mock_instance
-            ):
-                with patch.object(
-                    mode, "_create_ec2_instances_as_block"
-                ) as mock_create_block:
-                    mock_create_block.side_effect = lambda *args, **kwargs: (
-                        mode._create_ec2_instances_as_block_impl(*args, **kwargs)
-                    )
-
-                    # Initialize through provider interface
-                    provider.initialize_blocks()
-
-                    # Verify block creation
-                    assert len(mode.resources) == 1
-
-                    # Get the resource ID of the block
-                    block_resource_id = list(mode.resources.keys())[0]
-
-                    # Verify block has 4 nodes
-                    assert (
-                        len(mode.resources[block_resource_id].get("instances", [])) == 4
-                    )
-
-            # Test job submission through provider interface
-            job_id = f"mpi-job-{uuid.uuid4().hex[:8]}"
-            mpi_command = "mpirun -n 16 -ppn 4 python /path/to/mpi_script.py"
-
-            # Submit job through provider interface
-            with patch.object(provider, "status"):  # Mock status calls
-                resource_id = provider.submit(job_id, mpi_command)
-
-            # Verify submission through provider interface
-            assert resource_id in mode.resources
-            assert mode.resources[resource_id]["job_id"] == job_id
-
-            # Test status check through provider interface
-            with patch.object(mode, "get_job_status") as mock_status:
-                mock_status.return_value = {resource_id: "running"}
-
-                # Check status
-                status = provider.status([job_id])
-
-                # Verify status
-                assert job_id in status
-                assert status[job_id] == "running"
-
-            # Test scaling through provider interface
-            with patch.object(mode, "scale_out") as mock_scale_out:
-                mock_scale_out.return_value = 1
-
-                # Scale out
-                scaled = provider.scale_out(blocks=1)
-
-                # Verify scaling
-                assert scaled == 1
-                mock_scale_out.assert_called_with(1)
-
-            # Clean up through provider interface
-            with patch.object(mode, "cleanup_infrastructure"):
-                provider.shutdown()
-
-                # Verify cleanup was called
-                mode.cleanup_infrastructure.assert_called_once()
+            assert instance_states(substrate_session, instance_ids) <= {
+                "shutting-down",
+                "terminated",
+            }
+        finally:
+            mode.cleanup_infrastructure()

--- a/tests/integration/test_provider_lifecycle.py
+++ b/tests/integration/test_provider_lifecycle.py
@@ -1,29 +1,43 @@
 """Integration tests for provider lifecycle.
 
-These tests verify the complete lifecycle of the EphemeralAWSProvider, including
-initialization, usage, and cleanup across different operating modes.
+These tests drive ``EphemeralAWSProvider`` through construction, submit, status,
+cancel and shutdown against the substrate emulator, with the operating mode
+replaced by a double so no instances are launched.
+
+Every test here previously passed ``_test_session=``/``_test_state_store=``,
+kwargs that never existed in the package (``git log -S`` finds no commit adding
+them) and which #105 turned from silently-ignored into hard errors. They are
+replaced by the real seams: ``endpoint_url`` binds the session to the emulator,
+and ``_initialize_operating_mode`` is patched the way the unit suite does it.
+
+That mattered more than a kwarg rename. The old tests also assigned
+``provider._operating_mode``, an attribute the provider never reads -- it uses
+``operating_mode`` -- so the doubles were inert and every assertion about them
+was vacuous. Several also asserted an API this provider does not have:
+``initialize_blocks()``, ``save_state()``, ``load_state()``, a dict-returning
+``status()``, and ``submit(job_id, command)``. The real contract is
+``submit(command, tasks_per_node)`` returning a job ID, ``status()`` returning
+``List[JobStatus]`` and ``cancel()`` returning ``List[bool]`` (the Parsl
+compliance fix), so the assertions are rewritten against that.
 
 SPDX-License-Identifier: Apache-2.0
 SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
 """
 
-import os
 import uuid
-import pytest
-import tempfile
-from unittest.mock import MagicMock, PropertyMock
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
 
-from parsl_ephemeral_aws.provider import EphemeralAWSProvider
-from parsl_ephemeral_aws.modes.standard import StandardMode
+import pytest
+from parsl.jobs.states import JobState
+
+from parsl_ephemeral_aws.exceptions import ProviderConfigurationError
 from parsl_ephemeral_aws.modes.detached import DetachedMode
 from parsl_ephemeral_aws.modes.serverless import ServerlessMode
+from parsl_ephemeral_aws.modes.standard import StandardMode
+from parsl_ephemeral_aws.provider import EphemeralAWSProvider
 from parsl_ephemeral_aws.state.file import FileStateStore
-from tests.substrate_support import (
-    get_substrate_session,
-    is_substrate_available,
-)
-from parsl_ephemeral_aws.exceptions import ProviderConfigurationError
-
+from tests.substrate_support import get_substrate_endpoint, is_substrate_available
 
 # Skip all tests if the substrate emulator is not available
 pytestmark = pytest.mark.skipif(
@@ -32,525 +46,274 @@ pytestmark = pytest.mark.skipif(
 )
 
 
+@contextmanager
+def build_provider(mode_spec, state_file, network, **config):
+    """Construct a provider whose operating mode is a double, and yield both.
+
+    The mode is substituted through ``_initialize_operating_mode`` rather than by
+    assigning the attribute afterwards, because ``__init__`` itself calls
+    ``operating_mode.initialize()`` -- a post-hoc swap lets the real mode
+    provision infrastructure first, which is what the previous version of these
+    tests did.
+
+    ``spec=`` is deliberate: a bare ``MagicMock`` answers to any attribute, so a
+    test asserting on a method the mode no longer has would keep passing. The
+    state store is real, backed by ``tmp_path``, since the provider round-trips
+    ``provider_id`` through it during construction.
+    """
+    mode = MagicMock(spec=mode_spec)
+    mode.submit_job.return_value = "resource-1"
+    mode.get_job_status.return_value = {}
+    mode.cancel_jobs.return_value = {}
+    mode.list_resources.return_value = {}
+
+    provider_id = config.pop("provider_id", f"test-provider-{uuid.uuid4().hex[:8]}")
+    store = FileStateStore(file_path=str(state_file), provider_id=provider_id)
+
+    with (
+        patch.object(
+            EphemeralAWSProvider, "_initialize_state_store", return_value=store
+        ),
+        patch.object(
+            EphemeralAWSProvider, "_initialize_operating_mode", return_value=mode
+        ),
+    ):
+        provider = EphemeralAWSProvider(
+            provider_id=provider_id,
+            region="us-east-1",
+            endpoint_url=get_substrate_endpoint(),
+            state_file_path=str(state_file),
+            vpc_id=network["vpc_id"],
+            subnet_id=network["subnet_id"],
+            security_group_id=network["security_group_id"],
+            **config,
+        )
+    try:
+        yield provider, mode
+    finally:
+        provider.shutdown()
+
+
 @pytest.mark.integration
+@pytest.mark.substrate
 class TestProviderLifecycle:
     """Integration tests for provider lifecycle."""
 
-    @pytest.fixture(scope="class")
-    def substrate_session(self):
-        """Create a session connected to substrate."""
-        return get_substrate_session()
-
     @pytest.fixture
-    def temp_dir(self):
-        """Create a temporary directory for state files."""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            yield tmp_dir
+    def state_file(self, tmp_path):
+        """Path for the provider's state document, inside the test's sandbox."""
+        return tmp_path / f"state-{uuid.uuid4().hex[:8]}.json"
 
-    @pytest.fixture
-    def state_file_path(self, temp_dir):
-        """Create a path for the state file."""
-        return os.path.join(temp_dir, f"test-state-{uuid.uuid4().hex[:8]}.json")
-
-    @pytest.fixture
-    def file_state_store(self, state_file_path):
-        """Create a FileStateStore instance."""
-        provider_id = f"test-provider-{uuid.uuid4().hex[:8]}"
-        return FileStateStore(file_path=state_file_path, provider_id=provider_id)
-
-    @pytest.mark.substrate
-    def test_standard_mode_full_lifecycle(self, substrate_session, file_state_store):
-        """Test complete lifecycle of provider in standard mode."""
-        # Configuration for standard mode
-        config = {
-            "provider_id": f"test-provider-{uuid.uuid4().hex[:8]}",
-            "region": "us-east-1",
-            "instance_type": "t2.micro",
-            "image_id": "ami-12345678",  # Dummy AMI
-            "mode": "standard",
-            "max_blocks": 2,
-            "min_blocks": 0,
-            "init_blocks": 1,
-            # Inject test session
-            "_test_session": substrate_session,
-            "_test_state_store": file_state_store,
-        }
-
-        # Create provider
-        provider = EphemeralAWSProvider(**config)
-
-        # Replace provider's operating mode with a mocked StandardMode
-        mock_mode = MagicMock(spec=StandardMode)
-        mock_mode.initialize.return_value = None
-        mock_mode.cleanup_infrastructure.return_value = None
-        provider._operating_mode = mock_mode
-
-        try:
-            # Step a: Initialize provider
-            provider.initialize_blocks()
-            mock_mode.initialize.assert_called_once()
-            mock_mode._init_blocks.assert_called_once()
-
-            # Step b: Submit a job
-            job_id = f"test-job-{uuid.uuid4().hex[:8]}"
-            command = "echo 'hello world'"
-
-            mock_mode.submit_job.return_value = "resource-1"
-            mock_resource_job_mapping = PropertyMock(
-                return_value={"resource-1": job_id}
-            )
-            type(mock_mode).resource_job_mapping = mock_resource_job_mapping
-
-            resource_id = provider.submit(job_id, command)
-            assert resource_id == "resource-1"
-            mock_mode.submit_job.assert_called_with(job_id, command, 1)
-
-            # Step c: Check job status
-            mock_mode.get_job_status.return_value = {"resource-1": "running"}
-            status = provider.status([job_id])
-            assert job_id in status
-            assert status[job_id] == "running"
-
-            # Step d: Scale out
-            mock_mode.scale_out.return_value = 1
-            scaled = provider.scale_out(blocks=1)
-            assert scaled == 1
-            mock_mode.scale_out.assert_called_with(1)
-
-            # Step e: Scale in
-            mock_mode.scale_in.return_value = 1
-            scaled = provider.scale_in(blocks=1)
-            assert scaled == 1
-            mock_mode.scale_in.assert_called_with(1)
-
-            # Step f: Cancel job
-            mock_mode.cancel_jobs.return_value = {"resource-1": "cancelled"}
-            cancel_status = provider.cancel([job_id])
-            assert job_id in cancel_status
-            assert cancel_status[job_id] == "cancelled"
-
-            # Step g: Shutdown provider
-            provider.shutdown()
-            mock_mode.cleanup_infrastructure.assert_called_once()
-
-        finally:
-            # Ensure cleanup even if test fails
-            if (
-                hasattr(provider, "_operating_mode")
-                and provider._operating_mode is not None
-            ):
-                provider.shutdown()
-
-    @pytest.mark.substrate
-    def test_detached_mode_full_lifecycle(self, substrate_session, file_state_store):
-        """Test complete lifecycle of provider in detached mode."""
-        # Configuration for detached mode
-        workflow_id = f"test-workflow-{uuid.uuid4().hex[:8]}"
-        config = {
-            "provider_id": f"test-provider-{uuid.uuid4().hex[:8]}",
-            "region": "us-east-1",
-            "instance_type": "t2.micro",
-            "image_id": "ami-12345678",  # Dummy AMI
-            "mode": "detached",
-            "workflow_id": workflow_id,
-            "bastion_instance_type": "t2.micro",
-            "max_blocks": 2,
-            "min_blocks": 0,
-            "init_blocks": 1,
-            # Inject test session
-            "_test_session": substrate_session,
-            "_test_state_store": file_state_store,
-        }
-
-        # Create provider
-        provider = EphemeralAWSProvider(**config)
-
-        # Replace provider's operating mode with a mocked DetachedMode
-        mock_mode = MagicMock(spec=DetachedMode)
-        mock_mode.initialize.return_value = None
-        mock_mode.cleanup_infrastructure.return_value = None
-        provider._operating_mode = mock_mode
-
-        try:
-            # Step a: Initialize provider
-            provider.initialize_blocks()
-            mock_mode.initialize.assert_called_once()
-            mock_mode._init_blocks.assert_called_once()
-
-            # Step b: Submit a job
-            job_id = f"test-job-{uuid.uuid4().hex[:8]}"
-            command = "echo 'hello world'"
-
-            mock_mode.submit_job.return_value = "resource-1"
-            mock_resource_job_mapping = PropertyMock(
-                return_value={"resource-1": job_id}
-            )
-            type(mock_mode).resource_job_mapping = mock_resource_job_mapping
-
-            resource_id = provider.submit(job_id, command)
-            assert resource_id == "resource-1"
-            mock_mode.submit_job.assert_called_with(job_id, command, 1)
-
-            # Step c: Check job status
-            mock_mode.get_job_status.return_value = {"resource-1": "running"}
-            status = provider.status([job_id])
-            assert job_id in status
-            assert status[job_id] == "running"
-
-            # Step d: Test save_state and load_state specific to detached mode
-            mock_mode.save_state.return_value = None
-            provider.save_state()
-            mock_mode.save_state.assert_called_once()
-
-            mock_mode.load_state.return_value = None
-            provider.load_state()
-            mock_mode.load_state.assert_called_once()
-
-            # Step e: Shutdown provider with preserve_bastion
-            # First set preserve_bastion = True
-            provider.preserve_bastion = True
-            provider.shutdown()
-            # Detached mode should have preserve_bastion set to True
-            mock_mode.preserve_bastion = True
-            mock_mode.cleanup_infrastructure.assert_called_once()
-
-            # Reset for next test
-            mock_mode.cleanup_infrastructure.reset_mock()
-
-            # Now test with preserve_bastion = False
-            provider.preserve_bastion = False
-            provider.shutdown()
-            # Detached mode should have preserve_bastion set to False
-            mock_mode.preserve_bastion = False
-            mock_mode.cleanup_infrastructure.assert_called_once()
-
-        finally:
-            # Ensure cleanup even if test fails
-            if (
-                hasattr(provider, "_operating_mode")
-                and provider._operating_mode is not None
-            ):
-                provider.shutdown()
-
-    @pytest.mark.substrate
-    def test_serverless_mode_full_lifecycle(self, substrate_session, file_state_store):
-        """Test complete lifecycle of provider in serverless mode."""
-        # Configuration for serverless mode
-        config = {
-            "provider_id": f"test-provider-{uuid.uuid4().hex[:8]}",
-            "region": "us-east-1",
-            "mode": "serverless",
-            "worker_type": "lambda",
-            "lambda_memory": 128,
-            "lambda_timeout": 60,
-            "max_blocks": 10,
-            "min_blocks": 0,
-            "init_blocks": 0,  # No initial blocks for serverless
-            # Inject test session
-            "_test_session": substrate_session,
-            "_test_state_store": file_state_store,
-        }
-
-        # Create provider
-        provider = EphemeralAWSProvider(**config)
-
-        # Replace provider's operating mode with a mocked ServerlessMode
-        mock_mode = MagicMock(spec=ServerlessMode)
-        mock_mode.initialize.return_value = None
-        mock_mode.cleanup_infrastructure.return_value = None
-        provider._operating_mode = mock_mode
-
-        try:
-            # Step a: Initialize provider (no blocks for serverless)
-            provider.initialize_blocks()
-            mock_mode.initialize.assert_called_once()
-            # Serverless mode should not call _init_blocks
-            mock_mode._init_blocks.assert_not_called()
-
-            # Step b: Submit a job
-            job_id = f"test-job-{uuid.uuid4().hex[:8]}"
-            command = "echo 'hello world'"
-
-            mock_mode.submit_job.return_value = "resource-1"
-            mock_resource_job_mapping = PropertyMock(
-                return_value={"resource-1": job_id}
-            )
-            type(mock_mode).resource_job_mapping = mock_resource_job_mapping
-
-            resource_id = provider.submit(job_id, command)
-            assert resource_id == "resource-1"
-            mock_mode.submit_job.assert_called_with(job_id, command, 1)
-
-            # Step c: Check job status
-            mock_mode.get_job_status.return_value = {"resource-1": "running"}
-            status = provider.status([job_id])
-            assert job_id in status
-            assert status[job_id] == "running"
-
-            # Step d: Scaling should be a no-op in serverless mode
-            mock_mode.scale_out.return_value = 0
-            scaled = provider.scale_out(blocks=1)
-            assert scaled == 0
-            mock_mode.scale_out.assert_called_with(1)
-
-            mock_mode.scale_in.return_value = 0
-            scaled = provider.scale_in(blocks=1)
-            assert scaled == 0
-            mock_mode.scale_in.assert_called_with(1)
-
-            # Step e: Shutdown provider
-            provider.shutdown()
-            mock_mode.cleanup_infrastructure.assert_called_once()
-
-        finally:
-            # Ensure cleanup even if test fails
-            if (
-                hasattr(provider, "_operating_mode")
-                and provider._operating_mode is not None
-            ):
-                provider.shutdown()
-
-    @pytest.mark.substrate
-    def test_provider_validation(self):
-        """Test validation of provider configuration."""
-        # Test 1: Invalid mode
-        with pytest.raises(ProviderConfigurationError):
-            provider = EphemeralAWSProvider(
-                region="us-east-1",
-                instance_type="t2.micro",
-                image_id="ami-12345678",
-                mode="invalid_mode",
-            )
-
-        # Test 2: Missing required parameter for standard mode
-        with pytest.raises(ProviderConfigurationError):
-            provider = EphemeralAWSProvider(
-                region="us-east-1",
-                mode="standard",
-                # Missing instance_type and image_id
-            )
-
-        # Test 3: Missing required parameter for detached mode
-        with pytest.raises(ProviderConfigurationError):
-            provider = EphemeralAWSProvider(
-                region="us-east-1",
-                instance_type="t2.micro",
-                image_id="ami-12345678",
-                mode="detached",
-                # Missing workflow_id
-            )
-
-        # Test 4: Invalid configuration for serverless mode
-        with pytest.raises(ProviderConfigurationError):
-            provider = EphemeralAWSProvider(
-                region="us-east-1", mode="serverless", worker_type="invalid_worker"
-            )
-
-        # Test 5: Incompatible parameters
-        with pytest.raises(ProviderConfigurationError):
-            provider = EphemeralAWSProvider(
-                region="us-east-1",
-                instance_type="t2.micro",
-                image_id="ami-12345678",
-                mode="standard",
-                use_spot_fleet=True,
-                # Missing instance_types for spot fleet
-            )
-
-    @pytest.mark.substrate
-    def test_configuration_defaults(self, substrate_session, file_state_store):
-        """Test provider default configuration values."""
-        # Create provider with minimal configuration
-        provider = EphemeralAWSProvider(
-            region="us-east-1",
-            instance_type="t2.micro",
+    def test_standard_mode_full_lifecycle(self, substrate_network, state_file):
+        """Submit, poll, cancel and shut down in standard mode."""
+        with build_provider(
+            StandardMode,
+            state_file,
+            substrate_network,
+            instance_type="t3.micro",
             image_id="ami-12345678",
-            # Inject test session
-            _test_session=substrate_session,
-            _test_state_store=file_state_store,
-        )
+            mode="standard",
+            max_blocks=2,
+        ) as (provider, mode):
+            # __init__ initializes the mode; no separate call exists.
+            mode.initialize.assert_called_once()
 
-        # Replace provider's operating mode with a mock
-        mock_mode = MagicMock(spec=StandardMode)
-        provider._operating_mode = mock_mode
+            job_id = provider.submit("echo hello", tasks_per_node=1)
+            assert mode.submit_job.called
+            assert job_id in provider.job_map
 
-        try:
-            # Verify defaults
-            assert provider.mode == "standard"  # Default mode is standard
-            assert provider.max_blocks == 1  # Default max_blocks is 1
-            assert provider.min_blocks == 0  # Default min_blocks is 0
-            assert provider.init_blocks == 0  # Default init_blocks is 0
-            assert not provider.use_spot  # Default use_spot is False
-            assert not provider.use_spot_fleet  # Default use_spot_fleet is False
-            assert (
-                not provider.spot_interruption_handling
-            )  # Default spot_interruption_handling is False
+            mode.get_job_status.return_value = {"resource-1": "RUNNING"}
+            statuses = provider.status([job_id])
+            assert [s.state for s in statuses] == [JobState.RUNNING]
 
-            # Test default label is set
-            assert provider.label.startswith("ephemeral-aws")
+            mode.cancel_jobs.return_value = {"resource-1": "CANCELED"}
+            assert provider.cancel([job_id]) == [True]
 
-        finally:
-            # Ensure cleanup even if test fails
-            if (
-                hasattr(provider, "_operating_mode")
-                and provider._operating_mode is not None
-            ):
-                provider.shutdown()
+        mode.cleanup_infrastructure.assert_called_once()
 
-    @pytest.mark.substrate
-    def test_state_persistence_configuration(self, substrate_session, file_state_store):
-        """Test state persistence configuration options."""
-        # Create provider with file state store
-        provider_id = f"test-provider-{uuid.uuid4().hex[:8]}"
+    def test_detached_mode_full_lifecycle(self, substrate_network, state_file):
+        """Detached mode carries a workflow_id and cleans up on shutdown."""
         workflow_id = f"test-workflow-{uuid.uuid4().hex[:8]}"
-
-        provider = EphemeralAWSProvider(
-            provider_id=provider_id,
-            region="us-east-1",
-            instance_type="t2.micro",
+        with build_provider(
+            DetachedMode,
+            state_file,
+            substrate_network,
+            instance_type="t3.micro",
             image_id="ami-12345678",
             mode="detached",
             workflow_id=workflow_id,
-            bastion_instance_type="t2.micro",
-            state_store="file",
-            state_file_path=file_state_store.file_path,
-            # Inject test session
-            _test_session=substrate_session,
-            _test_state_store=file_state_store,
-        )
+            bastion_instance_type="t3.micro",
+            max_blocks=2,
+        ) as (provider, mode):
+            assert provider.workflow_id == workflow_id
+            mode.initialize.assert_called_once()
 
-        # Replace provider's operating mode with a mock
-        mock_mode = MagicMock(spec=DetachedMode)
-        provider._operating_mode = mock_mode
+            job_id = provider.submit("echo hello", tasks_per_node=1)
+            mode.get_job_status.return_value = {"resource-1": "RUNNING"}
+            assert [s.state for s in provider.status([job_id])] == [JobState.RUNNING]
 
-        try:
-            # Verify state store configuration
-            assert provider.state_store_type == "file"
-            assert provider.state_file_path == file_state_store.file_path
+        mode.cleanup_infrastructure.assert_called_once()
 
-            # Test save_state and load_state
-            provider.save_state()
-            mock_mode.save_state.assert_called_once()
+    def test_serverless_mode_full_lifecycle(self, substrate_network, state_file):
+        """Serverless mode submits without provisioning blocks.
 
-            provider.load_state()
-            mock_mode.load_state.assert_called_once()
+        No network IDs are required for Lambda-only serverless -- functions run in
+        the Lambda-managed VPC -- but passing them is harmless and keeps one
+        construction helper for all three modes.
+        """
+        with build_provider(
+            ServerlessMode,
+            state_file,
+            substrate_network,
+            mode="serverless",
+            max_blocks=10,
+            init_blocks=0,
+        ) as (provider, mode):
+            mode.initialize.assert_called_once()
 
-        finally:
-            # Ensure cleanup even if test fails
-            if (
-                hasattr(provider, "_operating_mode")
-                and provider._operating_mode is not None
-            ):
-                provider.shutdown()
+            job_id = provider.submit("echo hello", tasks_per_node=1)
+            mode.get_job_status.return_value = {"resource-1": "RUNNING"}
+            assert [s.state for s in provider.status([job_id])] == [JobState.RUNNING]
 
-    @pytest.mark.substrate
-    def test_job_status_mapping(self, substrate_session, file_state_store):
-        """Test job status mapping in the provider."""
-        # Create provider
-        provider_id = f"test-provider-{uuid.uuid4().hex[:8]}"
+            # scale_out is Parsl's strategy's job, not the provider's.
+            assert provider.scale_out(blocks=1) == []
 
-        provider = EphemeralAWSProvider(
-            provider_id=provider_id,
-            region="us-east-1",
-            instance_type="t2.micro",
-            image_id="ami-12345678",
-            # Inject test session
-            _test_session=substrate_session,
-            _test_state_store=file_state_store,
-        )
+        mode.cleanup_infrastructure.assert_called_once()
 
-        # Replace provider's operating mode with a mock
-        mock_mode = MagicMock(spec=StandardMode)
-        provider._operating_mode = mock_mode
+    @pytest.mark.parametrize(
+        "config,expected_message",
+        [
+            ({"mode": "invalid_mode"}, "Invalid operating mode"),
+            ({"region": "mars-west-9"}, "Invalid region"),
+            ({"state_store_type": "quantum"}, "Invalid state store type"),
+            ({"state_store_type": "s3"}, "s3_bucket is required"),
+            ({"min_blocks": 5, "max_blocks": 1}, "cannot be less than min_blocks"),
+            # A detached-only option on standard mode: refused rather than
+            # half-honoured, since the mode would ignore it (#136).
+            ({"idle_timeout": 5}, "supported only by mode='detached'"),
+            # #105: an unknown kwarg is an error, not silently dropped. This is
+            # what retired the _test_session injection these tests used to do.
+            ({"nonexistent_option": True}, "Unknown configuration option"),
+        ],
+    )
+    def test_provider_validation(self, substrate_network, config, expected_message):
+        """Invalid configuration is refused at construction, with a reason.
 
-        try:
-            # Set up test data
-            resource_ids = ["resource-1", "resource-2", "resource-3", "resource-4"]
-            job_ids = ["job-1", "job-2", "job-3", "job-4"]
+        The message is asserted, not just the type: every case below raises
+        ``ProviderConfigurationError``, so matching only the class would let a
+        config error pass this test for the wrong reason.
+        """
+        base = {
+            "region": "us-east-1",
+            "instance_type": "t3.micro",
+            "image_id": "ami-12345678",
+            "endpoint_url": get_substrate_endpoint(),
+            "vpc_id": substrate_network["vpc_id"],
+            "subnet_id": substrate_network["subnet_id"],
+            "security_group_id": substrate_network["security_group_id"],
+        }
+        with pytest.raises(ProviderConfigurationError, match=expected_message):
+            EphemeralAWSProvider(**{**base, **config})
 
-            # Map resource IDs to job IDs
-            mock_resource_job_mapping = {}
-            for i, resource_id in enumerate(resource_ids):
-                mock_resource_job_mapping[resource_id] = job_ids[i]
-
-            # Set the mapping in the mock mode
-            type(mock_mode).resource_job_mapping = PropertyMock(
-                return_value=mock_resource_job_mapping
+    def test_network_ids_are_required(self, substrate_network):
+        """Omitting the network IDs is refused (#69 removed VPC creation)."""
+        with pytest.raises(
+            ValueError, match="vpc_id, subnet_id, and security_group_id"
+        ):
+            EphemeralAWSProvider(
+                region="us-east-1",
+                instance_type="t3.micro",
+                image_id="ami-12345678",
+                endpoint_url=get_substrate_endpoint(),
             )
 
-            # Set up status responses with different statuses
-            mock_mode.get_job_status.return_value = {
-                "resource-1": "running",  # Already Parsl status
-                "resource-2": "PENDING",  # AWS-style status (upper case)
-                "resource-3": "terminated",  # AWS status needing translation
-                "resource-4": "nonsense",  # Invalid status
+    def test_configuration_defaults(self, substrate_network, state_file):
+        """Defaults are what the constants declare, not what a docstring claims."""
+        with build_provider(
+            StandardMode,
+            state_file,
+            substrate_network,
+            instance_type="t3.micro",
+            image_id="ami-12345678",
+        ) as (provider, _mode):
+            assert provider.mode_type.value == "standard"
+            assert provider.max_blocks == 10  # DEFAULT_MAX_BLOCKS
+            assert provider.min_blocks == 0
+            assert provider.init_blocks == 0
+            assert not provider.use_spot
+            assert not provider.use_spot_fleet
+            assert not provider.spot_interruption_handling
+            assert provider.label.startswith("ephemeral-aws")
+
+    def test_state_persistence_configuration(self, substrate_network, state_file):
+        """The file state store is wired to the path the caller gave."""
+        with build_provider(
+            DetachedMode,
+            state_file,
+            substrate_network,
+            instance_type="t3.micro",
+            image_id="ami-12345678",
+            mode="detached",
+            workflow_id=f"test-workflow-{uuid.uuid4().hex[:8]}",
+            state_store_type="file",
+        ) as (provider, _mode):
+            assert provider.state_store_type.value == "file"
+            assert provider.state_file_path == str(state_file)
+
+            # submit() persists; the document must land at that path.
+            provider.submit("echo hello", tasks_per_node=1)
+            assert state_file.exists()
+
+    def test_job_status_mapping(self, substrate_network, state_file):
+        """Mode status strings map onto Parsl's JobState enum.
+
+        Asserted through the real ``_STRING_TO_JOB_STATE`` table rather than
+        against strings: ``status()`` returns ``List[JobStatus]`` positionally, so
+        an unknown status must resolve to ``UNKNOWN`` rather than raise.
+        """
+        with build_provider(
+            StandardMode,
+            state_file,
+            substrate_network,
+            instance_type="t3.micro",
+            image_id="ami-12345678",
+            max_blocks=5,
+        ) as (provider, mode):
+            wanted = ["RUNNING", "PENDING", "COMPLETED", "nonsense"]
+            job_ids = []
+            for i, status in enumerate(wanted):
+                mode.submit_job.return_value = f"resource-{i}"
+                job_ids.append(provider.submit(f"echo {i}", tasks_per_node=1))
+
+            mode.get_job_status.return_value = {
+                f"resource-{i}": status for i, status in enumerate(wanted)
             }
 
-            # Test status mapping
-            status = provider.status(job_ids)
+            states = [s.state for s in provider.status(job_ids)]
+            assert states == [
+                JobState.RUNNING,
+                JobState.PENDING,
+                JobState.COMPLETED,
+                JobState.UNKNOWN,
+            ]
 
-            # Verify correct status mapping
-            assert status["job-1"] == "running"
-            # Upper case statuses should be normalized
-            assert status["job-2"] == "pending"
-            # AWS 'terminated' should be mapped to 'failed'
-            assert status["job-3"] == "failed"
-            # Invalid status should be mapped to 'unknown'
-            assert status["job-4"] == "unknown"
+            # An ID this provider never issued resolves to UNKNOWN, not KeyError.
+            assert provider.status(["never-issued"])[0].state == JobState.UNKNOWN
 
-        finally:
-            # Ensure cleanup even if test fails
-            if (
-                hasattr(provider, "_operating_mode")
-                and provider._operating_mode is not None
-            ):
-                provider.shutdown()
-
-    @pytest.mark.substrate
-    def test_provider_tags(self, substrate_session, file_state_store):
-        """Test provider tags configuration."""
-        # Create provider with custom tags
-        provider_id = f"test-provider-{uuid.uuid4().hex[:8]}"
+    def test_provider_tags(self, substrate_network, state_file):
+        """Caller tags survive alongside the provider's own defaults."""
         custom_tags = {
             "Project": "TestProject",
             "Environment": "Testing",
             "CostCenter": "R&D-123",
         }
-
-        provider = EphemeralAWSProvider(
-            provider_id=provider_id,
-            region="us-east-1",
-            instance_type="t2.micro",
+        with build_provider(
+            StandardMode,
+            state_file,
+            substrate_network,
+            instance_type="t3.micro",
             image_id="ami-12345678",
             additional_tags=custom_tags,
-            # Inject test session
-            _test_session=substrate_session,
-            _test_state_store=file_state_store,
-        )
-
-        # Replace provider's operating mode with a StandardMode mock
-        mock_mode = MagicMock(spec=StandardMode)
-        provider._operating_mode = mock_mode
-
-        try:
-            # Initialize provider to verify tags are passed to the mode
-            provider.initialize_blocks()
-
-            # Verify provider tags were set correctly
+        ) as (provider, _mode):
             for key, value in custom_tags.items():
-                assert key in provider.additional_tags
                 assert provider.additional_tags[key] == value
-
-            # Provider should also include default tags
-            assert "CreatedBy" in provider.additional_tags
-            assert provider.additional_tags["CreatedBy"] == "EphemeralAWSProvider"
-            assert "Provider" in provider.additional_tags
-            assert provider.additional_tags["Provider"] == "Parsl"
-
-        finally:
-            # Ensure cleanup even if test fails
-            if (
-                hasattr(provider, "_operating_mode")
-                and provider._operating_mode is not None
-            ):
-                provider.shutdown()

--- a/tests/integration/test_serverless_mode_spot_fleet_integration.py
+++ b/tests/integration/test_serverless_mode_spot_fleet_integration.py
@@ -42,6 +42,7 @@ from parsl_ephemeral_aws.constants import (
     WORKER_TYPE_ECS,
     WORKER_TYPE_LAMBDA,
     STATUS_CANCELLED,
+    STATUS_COMPLETED,
     STATUS_PENDING,
     STATUS_RUNNING,
 )
@@ -271,38 +272,132 @@ class TestServerlessModeSpotFleetIntegration:
         # remove it again -- otherwise a phantom job would be polled forever.
         assert serverless_mode.resources == {}
 
-    def test_get_spot_fleet_status_reads_the_nested_capacity(
+    def test_an_active_fleet_with_live_instances_reports_running(
         self, serverless_mode, network
     ):
-        """An active, fully fulfilled fleet reports RUNNING.
+        """An active fleet still holding instances reports RUNNING.
 
-        `FulfilledCapacity` lives only inside `SpotFleetRequestConfig`, beside
-        `TargetCapacity`. Reading it from the entry's top level always yielded
-        the 0 default, so `0 >= target` was false and a fully provisioned fleet
-        reported PENDING forever -- never terminal, so Parsl polled it and never
-        freed the block (#114).
+        The status comes from the *instances*, not from capacity counters. An
+        instant fleet does not maintain capacity, so its ``FleetState`` stays
+        ``active`` for the fleet's whole life regardless of what became of the
+        instances, and the counters only ever reflect the original launch.
+
+        This is the site of #114, though not in the way the old test described.
+        That version read `FulfilledCapacity` from the wrong nesting level -- it
+        lives inside `SpotFleetRequestConfig`, beside `TargetCapacity` -- so the
+        0 default made `0 >= target` false and a fully provisioned fleet reported
+        PENDING forever, never terminal, so Parsl polled it and never freed the
+        block. The capacity comparison is gone entirely now; instance state
+        replaced it.
+
+        The old test also created its fleet with ``request_spot_fleet``, the
+        legacy API #86 removed. ``_get_spot_fleet_status`` calls
+        ``describe_fleets``, which knows nothing about an ``sfr-`` request, so it
+        took the "EC2 has forgotten this fleet" branch and returned COMPLETED --
+        the assertion was against an API the code no longer calls.
         """
         serverless_mode.initialize()
         ec2 = serverless_mode.session.client("ec2")
-        fleet_request_id = ec2.request_spot_fleet(
-            SpotFleetRequestConfig={
-                "IamFleetRole": "arn:aws:iam::123456789012:role/parsl-test-fleet",
-                "AllocationStrategy": "priceCapacityOptimized",
-                "TargetCapacity": 2,
-                "LaunchSpecifications": [
-                    {
-                        "ImageId": "ami-12345678",
-                        "InstanceType": "t3.small",
-                        "SubnetId": network["subnet_id"],
-                        "SecurityGroups": [{"GroupId": network["security_group_id"]}],
-                    }
-                ],
-            }
-        )["SpotFleetRequestId"]
+        template = ec2.create_launch_template(
+            LaunchTemplateName="parsl-test-fleet-template",
+            LaunchTemplateData={
+                "ImageId": "ami-12345678",
+                "InstanceType": "t3.small",
+            },
+        )["LaunchTemplate"]
+        fleet = ec2.create_fleet(
+            Type="instant",
+            LaunchTemplateConfigs=[
+                {
+                    "LaunchTemplateSpecification": {
+                        "LaunchTemplateId": template["LaunchTemplateId"],
+                        "Version": str(template["LatestVersionNumber"]),
+                    },
+                    "Overrides": [
+                        {
+                            "InstanceType": "t3.small",
+                            "SubnetId": network["subnet_id"],
+                        }
+                    ],
+                }
+            ],
+            TargetCapacitySpecification={
+                "TotalTargetCapacity": 2,
+                "DefaultTargetCapacityType": "spot",
+            },
+        )
+        fleet_id = fleet["FleetId"]
+
+        # Real EC2 tags every fleet-launched instance with `aws:ec2:fleet-id`,
+        # and that tag is the only supported way to enumerate an instant fleet's
+        # instances: DescribeFleetInstances rejects this fleet type outright, and
+        # DescribeFleets reports the original launch without dropping instances
+        # that have since terminated. Neither moto nor substrate applies it
+        # (substrate#443), so it is set here -- otherwise the lookup comes back
+        # empty and a running fleet reports COMPLETED for want of a tag rather
+        # than for any behaviour of the code under test.
+        instance_ids = [i for g in fleet["Instances"] for i in g["InstanceIds"]]
+        assert instance_ids, "fleet launched nothing; nothing to assert about"
+        ec2.create_tags(
+            Resources=instance_ids,
+            Tags=[{"Key": "aws:ec2:fleet-id", "Value": fleet_id}],
+        )
+
+        assert serverless_mode._get_spot_fleet_status(fleet_id) == STATUS_RUNNING
+
+    def test_a_fleet_whose_instances_are_gone_reports_completed(
+        self, serverless_mode, network
+    ):
+        """A terminal status, so Parsl can free the block.
+
+        The counterpart to the test above, and the reason instance state is what
+        decides: the fleet below stays ``active`` throughout, so anything reading
+        ``FleetState`` alone would report it RUNNING forever.
+        """
+        serverless_mode.initialize()
+        ec2 = serverless_mode.session.client("ec2")
+        template = ec2.create_launch_template(
+            LaunchTemplateName="parsl-test-fleet-template-2",
+            LaunchTemplateData={
+                "ImageId": "ami-12345678",
+                "InstanceType": "t3.small",
+            },
+        )["LaunchTemplate"]
+        fleet = ec2.create_fleet(
+            Type="instant",
+            LaunchTemplateConfigs=[
+                {
+                    "LaunchTemplateSpecification": {
+                        "LaunchTemplateId": template["LaunchTemplateId"],
+                        "Version": str(template["LatestVersionNumber"]),
+                    },
+                    "Overrides": [
+                        {
+                            "InstanceType": "t3.small",
+                            "SubnetId": network["subnet_id"],
+                        }
+                    ],
+                }
+            ],
+            TargetCapacitySpecification={
+                "TotalTargetCapacity": 1,
+                "DefaultTargetCapacityType": "spot",
+            },
+        )
+        fleet_id = fleet["FleetId"]
+        instance_ids = [i for g in fleet["Instances"] for i in g["InstanceIds"]]
+        ec2.create_tags(  # see substrate#443, above
+            Resources=instance_ids,
+            Tags=[{"Key": "aws:ec2:fleet-id", "Value": fleet_id}],
+        )
+
+        ec2.terminate_instances(InstanceIds=instance_ids)
 
         assert (
-            serverless_mode._get_spot_fleet_status(fleet_request_id) == STATUS_RUNNING
+            ec2.describe_fleets(FleetIds=[fleet_id])["Fleets"][0]["FleetState"]
+            == "active"
         )
+        assert serverless_mode._get_spot_fleet_status(fleet_id) == STATUS_COMPLETED
 
     def test_cancel_job_deletes_the_stack(self, serverless_mode):
         """Cancelling a job marks it CANCELLED and deletes its stack."""

--- a/tests/integration/test_spot_fleet_integration.py
+++ b/tests/integration/test_spot_fleet_integration.py
@@ -1,195 +1,255 @@
-"""Integration tests for the SpotFleetManager class.
+"""Integration tests for SpotFleetManager against the substrate emulator.
 
-These tests use the moto library to mock AWS services for realistic integration
-testing: moto intercepts the HTTP layer, so the manager builds its own boto3
-session and issues real API calls against a simulated AWS.
+These drive the manager's real ``CreateFleet`` path end to end: it resolves the
+network, builds a per-block launch template, issues ``CreateFleet``, reads back
+the instances, and deletes the fleet on teardown. Nothing on the manager is
+stubbed.
+
+This file used to run on moto and was written against the *legacy*
+``RequestSpotFleet`` API that #86 removed -- it asserted ``sfr-``-prefixed
+request IDs, read state back with ``describe_spot_fleet_requests``, and checked
+that an IAM fleet service role had been created with the
+``AmazonEC2SpotFleetTaggingRole`` policy attached. ``CreateFleet`` has no
+``IamFleetRole`` member at all, so ``iam_fleet_role_arn`` is now only retained to
+clean up a role named by a pre-#86 state document, and nothing sets it. Those
+assertions could not pass against the shipping code.
+
+Substrate rather than moto because substrate grew a ``CreateFleet`` handler in
+its 0.82.0 (substrate#387) and models the parts that matter here, where moto does
+not:
+
+* **Target capacity is honoured.** A request for ``nodes_per_block`` instances
+  yields that many. moto's ``create_fleet`` launches exactly one instance
+  regardless of ``TotalTargetCapacity`` -- verified -- so a multi-node fleet was
+  indistinguishable from a single-instance one and the one path where
+  ``nodes_per_block`` has any effect could not be tested.
+* **``Lifecycle`` reflects the request.** A spot fleet reports ``spot``; moto
+  reports ``on-demand`` for the same request.
+* **The override's ``SubnetId`` is applied**, so instances are findable by
+  subnet.
+
+``RequestSpotFleet`` and ``RequestSpotInstances`` remain unimplemented in
+substrate and are not needed: #86 moved this provider onto ``CreateFleet``, so
+nothing calls them.
 
 SPDX-License-Identifier: Apache-2.0
 SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
 """
 
-import unittest
 from types import SimpleNamespace
-from unittest.mock import patch
 
-import boto3
 import pytest
-
-try:
-    # moto 5 replaced the per-service decorators (mock_ec2, mock_iam, ...) with a
-    # single mock_aws. Importing the removed names made this whole module
-    # uncollectable while moto was installed and working.
-    from moto import mock_aws
-
-    MOTO_AVAILABLE = True
-except ImportError:
-    MOTO_AVAILABLE = False
 
 from parsl_ephemeral_aws.compute.spot_fleet import SpotFleetManager
 from parsl_ephemeral_aws.constants import STATUS_CANCELLED, STATUS_RUNNING
 from parsl_ephemeral_aws.exceptions import ResourceCreationError
+from tests.substrate_support import is_substrate_available
 
-
-# Skip all tests if moto is not installed
 pytestmark = [
     pytest.mark.integration,
-    pytest.mark.skipif(not MOTO_AVAILABLE, reason="moto not installed"),
+    pytest.mark.substrate,
+    pytest.mark.skipif(
+        not is_substrate_available(),
+        reason="substrate not available - start with 'make substrate-up'",
+    ),
 ]
 
 
-@mock_aws
-class TestSpotFleetManagerIntegration(unittest.TestCase):
-    """Integration tests for SpotFleetManager using moto."""
+@pytest.fixture
+def manager(substrate_session, substrate_network):
+    """A SpotFleetManager whose clients are bound to the emulator.
 
-    def setUp(self):
-        """Set up test environment."""
-        self.ec2_client = boto3.client("ec2", region_name="us-east-1")
-        self.iam_client = boto3.client("iam", region_name="us-east-1")
+    The manager builds its own session in ``__init__`` from the provider's region
+    and credentials, which would reach real AWS, so ``aws_session`` and
+    ``ec2_client`` are replaced with the fixture's endpoint-bound pair
+    afterwards. Every fleet this creates is deleted on teardown.
+    """
+    manager = SpotFleetManager(_provider(substrate_session, substrate_network))
+    manager.aws_session = substrate_session
+    manager.ec2_client = substrate_session.client("ec2")
+    try:
+        yield manager
+    finally:
+        for block_id in list(manager.blocks):
+            try:
+                manager.terminate_block(block_id)
+            except Exception:  # noqa: BLE001 - teardown must not mask a failure
+                pass
 
-        # Network resources are pre-provisioned by the caller since #69; the
-        # manager only ever adopts the IDs it is handed.
-        self.vpc_id = self.ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"][
-            "VpcId"
-        ]
-        self.subnet_id = self.ec2_client.create_subnet(
-            VpcId=self.vpc_id, CidrBlock="10.0.0.0/24"
-        )["Subnet"]["SubnetId"]
-        self.security_group_id = self.ec2_client.create_security_group(
-            GroupName="test-sg", Description="Test security group", VpcId=self.vpc_id
-        )["GroupId"]
 
-    def _provider(self, **overrides):
-        """Build the provider object the manager reads its configuration from.
+def _provider(session, network, **overrides):
+    """Build the object the manager reads its configuration from.
 
-        A ``SimpleNamespace``, not a ``MagicMock``. ``_setup_security_config()``
-        reads ``vpc_cidr``/``security_environment``/``admin_cidr_blocks``/
-        ``strict_security_mode`` with ``getattr(..., <default>)``, and a MagicMock
-        answers all four -- so the defaults never apply and ``SecurityConfig``
-        rejects the mock with ``ValueError: Invalid VPC CIDR: <MagicMock ...>``
-        before the constructor returns.
-        """
-        attrs = {
-            "workflow_id": "test-workflow-id",
-            "region": "us-east-1",
-            "aws_access_key_id": "testing",
-            "aws_secret_access_key": "testing",
-            "aws_session_token": None,
-            "aws_profile": None,
-            "vpc_id": self.vpc_id,
-            "subnet_id": self.subnet_id,
-            "security_group_id": self.security_group_id,
-            "image_id": "ami-12345678",
-            "instance_type": "t2.micro",
-            "instance_types": [],
-            # Required: _create_spot_fleet_request builds each launch spec inside a
-            # blanket `except Exception: logger.warning("Skipping instance type")`,
-            # so a missing attribute here yields *zero* launch specifications and
-            # the fleet request goes out empty rather than failing loudly.
-            "key_name": None,
-            "use_public_ips": True,
-            "nodes_per_block": 1,
-            "tags": {"ProjectTag": "TestProject"},
-            "spot_max_price_percentage": 100,
-            "worker_init": "echo 'Worker init script'",
-        }
-        attrs.update(overrides)
-        return SimpleNamespace(**attrs)
+    A ``SimpleNamespace``, not a ``MagicMock``. ``_setup_security_config()`` reads
+    ``vpc_cidr``/``security_environment``/``admin_cidr_blocks``/
+    ``strict_security_mode`` with ``getattr(..., <default>)``, and a MagicMock
+    answers all four -- so the defaults never apply and ``SecurityConfig`` rejects
+    the mock with ``ValueError: Invalid VPC CIDR: <MagicMock ...>`` before the
+    constructor returns.
+    """
+    attrs = {
+        "workflow_id": "test-workflow-id",
+        "region": session.region_name,
+        "aws_access_key_id": "substrate-test",
+        "aws_secret_access_key": "substrate-test-secret",  # nosec B106
+        "aws_session_token": None,
+        "aws_profile": None,
+        "vpc_id": network["vpc_id"],
+        "subnet_id": network["subnet_id"],
+        "security_group_id": network["security_group_id"],
+        "image_id": "ami-12345678",
+        "instance_type": "t3.micro",
+        "instance_types": [],
+        # Required: each launch-template override is built inside a blanket
+        # `except Exception`, so a missing attribute here yields zero overrides
+        # and the fleet goes out empty rather than failing loudly.
+        "key_name": None,
+        "use_public_ips": True,
+        "nodes_per_block": 1,
+        "tags": {"ProjectTag": "TestProject"},
+        "spot_max_price_percentage": 100,
+        "worker_init": "echo 'Worker init script'",
+        "iam_instance_profile_arn": None,
+    }
+    attrs.update(overrides)
+    return SimpleNamespace(**attrs)
 
-    def test_setup_network_resources_with_existing(self):
-        """The caller's VPC, subnet, and security group are adopted verbatim."""
-        manager = SpotFleetManager(self._provider())
 
+class TestNetworkResolution:
+    """What the manager does with the network IDs it is handed."""
+
+    def test_the_callers_ids_are_adopted_verbatim(self, manager, substrate_network):
+        """No network is created; the supplied IDs are passed straight through."""
         network = manager._setup_network_resources()
 
-        self.assertEqual(network["vpc_id"], self.vpc_id)
-        self.assertEqual(network["subnet_id"], self.subnet_id)
-        self.assertEqual(network["security_group_id"], self.security_group_id)
+        assert network["vpc_id"] == substrate_network["vpc_id"]
+        assert network["subnet_id"] == substrate_network["subnet_id"]
+        assert network["security_group_id"] == substrate_network["security_group_id"]
 
-    def test_setup_network_resources_requires_all_three_ids(self):
-        """A missing ID is a configuration error, not a silent create."""
-        manager = SpotFleetManager(self._provider(subnet_id=None))
+    def test_a_missing_id_is_a_configuration_error(
+        self, substrate_session, substrate_network
+    ):
+        """Since #69 a missing ID fails loudly rather than creating a VPC."""
+        manager = SpotFleetManager(
+            _provider(substrate_session, substrate_network, subnet_id=None)
+        )
+        manager.aws_session = substrate_session
+        manager.ec2_client = substrate_session.client("ec2")
 
-        with self.assertRaises(ResourceCreationError) as ctx:
+        with pytest.raises(ResourceCreationError, match="subnet_id"):
             manager._setup_network_resources()
 
-        self.assertIn("subnet_id", str(ctx.exception))
 
-    @patch("parsl_ephemeral_aws.compute.spot_fleet.time.sleep")
-    def test_create_blocks(self, mock_sleep):
-        """Each block becomes a real Spot Fleet request.
+class TestCreateBlocks:
+    """Each block becomes one real EC2 Fleet."""
 
-        Nothing on the manager is stubbed out here: ``create_blocks`` resolves the
-        network, creates the IAM fleet role, and issues ``RequestSpotFleet`` twice
-        against moto. Only ``time.sleep`` is patched, because
-        ``_get_iam_fleet_role`` waits 10 seconds for IAM propagation.
-        """
-        manager = SpotFleetManager(self._provider())
-
+    def test_each_block_becomes_a_fleet_that_exists_in_ec2(self, manager):
+        """Two blocks, two fleets, both active and holding an instance."""
         blocks = manager.create_blocks(2)
 
-        self.assertEqual(len(blocks), 2)
-        for block_info in blocks.values():
-            # A block is recorded PENDING and promoted by
-            # _wait_for_fleet_instances, which runs before create_blocks returns;
-            # moto reports the fleet active immediately, so RUNNING is reached
-            # here rather than the initial PENDING.
-            self.assertEqual(block_info["status"], STATUS_RUNNING)
-            self.assertIn("created_at", block_info)
-            self.assertTrue(block_info["fleet_request_id"].startswith("sfr-"))
-            self.assertTrue(block_info["instance_ids"])
+        assert len(blocks) == 2
+        for block in blocks.values():
+            # An instant fleet returns its instance IDs synchronously, so the
+            # block is RUNNING by the time create_blocks returns rather than
+            # sitting at the initial PENDING.
+            assert block["status"] == STATUS_RUNNING
+            assert "created_at" in block
+            # A fleet ID, not the legacy `sfr-` spot-fleet-request ID (#86).
+            assert block["fleet_request_id"].startswith("fleet-")
+            assert block["instance_ids"]
 
-        # The requests exist in EC2, not just in the manager's bookkeeping.
-        fleet_request_ids = sorted(
-            block["fleet_request_id"] for block in blocks.values()
+        fleet_ids = sorted(b["fleet_request_id"] for b in blocks.values())
+        fleets = manager.ec2_client.describe_fleets(FleetIds=fleet_ids)["Fleets"]
+        assert len(fleets) == 2
+        assert {f["FleetState"] for f in fleets} == {"active"}
+
+    def test_nodes_per_block_becomes_the_fleets_target_capacity(
+        self, substrate_session, substrate_network
+    ):
+        """The one path where nodes_per_block has any effect.
+
+        The single-instance launch paths ignore it and launch one instance per
+        block -- ``docs/spot_fleet.md`` says so -- so this is the only place the
+        value is observable.
+        """
+        manager = SpotFleetManager(
+            _provider(substrate_session, substrate_network, nodes_per_block=3)
         )
-        configs = self.ec2_client.describe_spot_fleet_requests(
-            SpotFleetRequestIds=fleet_request_ids
-        )["SpotFleetRequestConfigs"]
-        self.assertEqual(len(configs), 2)
-        for config in configs:
-            self.assertEqual(config["SpotFleetRequestState"], "active")
+        manager.aws_session = substrate_session
+        manager.ec2_client = substrate_session.client("ec2")
 
-        # And the fleet role was created with the AWS-managed tagging policy
-        # attached -- which needs MOTO_IAM_LOAD_MANAGED_POLICIES (set session-wide
-        # in tests/conftest.py), or attach_role_policy fails with NoSuchEntity.
-        role_name = manager.iam_fleet_role_arn.split("/")[-1]
-        attached = self.iam_client.list_attached_role_policies(RoleName=role_name)[
-            "AttachedPolicies"
-        ]
-        self.assertEqual(
-            [p["PolicyName"] for p in attached], ["AmazonEC2SpotFleetTaggingRole"]
-        )
+        try:
+            block = next(iter(manager.create_blocks(1).values()))
 
-    @patch("parsl_ephemeral_aws.compute.spot_fleet.time.sleep")
-    def test_terminate_block_cancels_the_fleet_request(self, mock_sleep):
-        """Terminating a block cancels its fleet request and its instances."""
-        manager = SpotFleetManager(self._provider())
+            assert len(block["instance_ids"]) == 3
+
+            fleet = manager.ec2_client.describe_fleets(
+                FleetIds=[block["fleet_request_id"]]
+            )["Fleets"][0]
+            assert fleet["TargetCapacitySpecification"]["TotalTargetCapacity"] == 3
+            assert (
+                fleet["TargetCapacitySpecification"]["DefaultTargetCapacityType"]
+                == "spot"
+            )
+
+            described = manager.ec2_client.describe_instances(
+                InstanceIds=block["instance_ids"]
+            )["Reservations"]
+            launched = [i for r in described for i in r["Instances"]]
+            assert len(launched) == 3
+            assert {i["SubnetId"] for i in launched} == {substrate_network["subnet_id"]}
+        finally:
+            for block_id in list(manager.blocks):
+                manager.terminate_block(block_id)
+
+    def test_no_iam_fleet_service_role_is_created(self, manager):
+        """CreateFleet has no IamFleetRole, so none is fetched or made (#86).
+
+        The attribute survives only so that a workflow resumed from a pre-#86
+        state document can still delete the role that document names.
+        """
+        manager.create_blocks(1)
+
+        assert manager.iam_fleet_role_arn is None
+
+
+class TestTerminateBlock:
+    """Deleting a block's fleet, which is what stops the instances."""
+
+    def test_terminating_a_block_deletes_its_fleet_and_instances(self, manager):
+        """Instance termination is not optional for an instant fleet."""
         blocks = manager.create_blocks(1)
         block_id, block = next(iter(blocks.items()))
+        fleet_id = block["fleet_request_id"]
         instance_ids = block["instance_ids"]
 
         manager.terminate_block(block_id)
 
-        self.assertEqual(manager.blocks[block_id]["status"], STATUS_CANCELLED)
-        self.assertEqual(
-            manager.fleet_requests[block["fleet_request_id"]]["status"], "cancelled"
+        assert manager.blocks[block_id]["status"] == STATUS_CANCELLED
+        assert manager.fleet_requests[fleet_id]["status"] == STATUS_CANCELLED
+
+        fleet = manager.ec2_client.describe_fleets(FleetIds=[fleet_id])["Fleets"][0]
+        assert fleet["FleetState"] in (
+            "deleted",
+            "deleted_terminating",
+            "deleted_running",
         )
 
-        # The manager cancels with TerminateInstances=True, and moto drops the
-        # fleet record entirely in that case rather than leaving a cancelled one.
-        self.assertEqual(
-            self.ec2_client.describe_spot_fleet_requests()["SpotFleetRequestConfigs"],
-            [],
-        )
+        described = manager.ec2_client.describe_instances(InstanceIds=instance_ids)
         states = {
-            instance["State"]["Name"]
-            for reservation in self.ec2_client.describe_instances(
-                InstanceIds=instance_ids
-            )["Reservations"]
-            for instance in reservation["Instances"]
+            i["State"]["Name"]
+            for r in described["Reservations"]
+            for i in r["Instances"]
         }
-        self.assertTrue(states <= {"shutting-down", "terminated"}, states)
+        assert states <= {"shutting-down", "terminated"}, states
 
+    def test_the_blocks_launch_template_is_reclaimed(self, manager):
+        """One template is built per block (#85); it goes with the block."""
+        block_id = next(iter(manager.create_blocks(1)))
+        # Read before terminating: the entry is popped as it is deleted.
+        template_id = manager.launch_templates[block_id]
 
-if __name__ == "__main__":
-    unittest.main()
+        manager.terminate_block(block_id)
+
+        remaining = manager.ec2_client.describe_launch_templates()["LaunchTemplates"]
+        assert template_id not in [t["LaunchTemplateId"] for t in remaining]

--- a/tests/integration/test_state_persistence_integration.py
+++ b/tests/integration/test_state_persistence_integration.py
@@ -3,6 +3,20 @@
 These tests verify that each state persistence implementation works correctly
 with real storage backends (file system, substrate for AWS services).
 
+Each AWS-backed store is built from conftest's ``substrate_session``, whose
+``client`` is wrapped to bind ``endpoint_url``. The three classes here each used
+to declare a class-scoped ``substrate_session`` of their own from
+``get_substrate_session()``, which binds *no* endpoint -- so ``resolve_session``
+handed the store a session whose clients reach real AWS, and every S3 test
+skipped on ``InvalidAccessKeyId`` from the fixture's ``create_bucket``. That skip
+read as "substrate can't do this" while the cause was the shadowing fixture.
+
+Those same three classes also patched ``boto3.Session`` to inject the session,
+which has never been necessary: ``state/base.resolve_session`` prefers a
+``session`` attribute on the provider object when one is present (#77), so the
+provider stub simply carries it. The patch was also the reason two tests *errored*
+rather than failed -- ``patch`` was used without being imported.
+
 SPDX-License-Identifier: Apache-2.0
 SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
 """
@@ -11,17 +25,15 @@ import os
 import uuid
 import pytest
 import tempfile
-import boto3
+from types import SimpleNamespace
 from botocore.exceptions import ClientError
 
+from parsl_ephemeral_aws.exceptions import StateError
 from parsl_ephemeral_aws.state.base import STATE_KEY_PROVIDER
 from parsl_ephemeral_aws.state.file import FileStateStore
 from parsl_ephemeral_aws.state.parameter_store import ParameterStoreState
 from parsl_ephemeral_aws.state.s3 import S3State
-from tests.substrate_support import (
-    get_substrate_session,
-    is_substrate_available,
-)
+from tests.substrate_support import is_substrate_available
 
 
 # Skip all tests if the substrate emulator is not available
@@ -29,6 +41,29 @@ pytestmark = pytest.mark.skipif(
     not is_substrate_available(),
     reason="substrate not available - start with 'make substrate-up'",
 )
+
+
+def _provider_stub(session, **overrides):
+    """The minimum a state store reads off a provider.
+
+    ``resolve_session`` takes the ``session`` attribute when it is a real
+    ``boto3.Session`` and only falls back to assembling one from the credential
+    attributes otherwise -- so passing the endpoint-bound session here is what
+    keeps the store on the emulator, with no patching.
+
+    A ``SimpleNamespace`` rather than a ``MagicMock``: ``resolve_session`` reads
+    five optional attributes with ``getattr(..., None)`` and treats any truthy
+    value as credentials to build a *new* session from, which a MagicMock would
+    supply -- silently replacing the bound session with an unbound one.
+    """
+    attrs = {
+        "session": session,
+        "provider_id": f"test-provider-{uuid.uuid4().hex[:8]}",
+        "workflow_id": f"test-workflow-{uuid.uuid4().hex[:8]}",
+        "region": session.region_name,
+    }
+    attrs.update(overrides)
+    return SimpleNamespace(**attrs)
 
 
 class TestFileStateStoreIntegration:
@@ -163,64 +198,45 @@ class TestFileStateStoreIntegration:
 class TestParameterStoreStateIntegration:
     """Integration tests for ParameterStoreState using substrate."""
 
-    @pytest.fixture(scope="class")
-    def substrate_session(self):
-        """Create a session connected to substrate."""
-        return get_substrate_session()
-
     @pytest.fixture
-    def mock_provider(self):
-        """Create a provider-like object."""
-
-        class MockProvider:
-            def __init__(self):
-                self.workflow_id = f"test-workflow-{uuid.uuid4().hex[:8]}"
-                self.region = "us-east-1"
-                self.aws_access_key_id = "test"
-                self.aws_secret_access_key = "test"
-                self.aws_session_token = None
-                self.aws_profile = None
-
-        return MockProvider()
+    def mock_provider(self, substrate_session):
+        """A provider stub carrying the endpoint-bound session."""
+        return _provider_stub(substrate_session)
 
     @pytest.fixture
     def parameter_store_state(self, mock_provider, substrate_session):
         """Create a ParameterStoreState instance with substrate."""
         state_prefix = f"/parsl/test/{uuid.uuid4().hex[:8]}"
 
-        # Override session creation to use our substrate session
-        with patch.object(boto3, "Session", return_value=substrate_session):
-            state_store = ParameterStoreState(
-                provider=mock_provider, prefix=state_prefix
+        state_store = ParameterStoreState(provider=mock_provider, prefix=state_prefix)
+        yield state_store
+
+        # Cleanup
+        try:
+            # Find all parameters under our prefix
+            paginator = substrate_session.client("ssm").get_paginator(
+                "get_parameters_by_path"
             )
-            yield state_store
+            page_iterator = paginator.paginate(
+                Path=state_prefix, Recursive=True, WithDecryption=True
+            )
 
-            # Cleanup
-            try:
-                # Find all parameters under our prefix
-                paginator = substrate_session.client("ssm").get_paginator(
-                    "get_parameters_by_path"
-                )
-                page_iterator = paginator.paginate(
-                    Path=state_prefix, Recursive=True, WithDecryption=True
-                )
+            parameters_to_delete = []
+            for page in page_iterator:
+                for param in page.get("Parameters", []):
+                    parameters_to_delete.append(param["Name"])
 
-                parameters_to_delete = []
-                for page in page_iterator:
-                    for param in page.get("Parameters", []):
-                        parameters_to_delete.append(param["Name"])
-
-                # Delete in batches
-                ssm_client = substrate_session.client("ssm")
-                for i in range(0, len(parameters_to_delete), 10):
-                    batch = parameters_to_delete[i : i + 10]
-                    if batch:
-                        try:
-                            ssm_client.delete_parameters(Names=batch)
-                        except Exception as e:
-                            print(f"Error cleaning up parameters: {e}")
-            except Exception as e:
-                print(f"Error during cleanup: {e}")
+            # Delete in batches
+            ssm_client = substrate_session.client("ssm")
+            for i in range(0, len(parameters_to_delete), 10):
+                batch = parameters_to_delete[i : i + 10]
+                if batch:
+                    try:
+                        ssm_client.delete_parameters(Names=batch)
+                    except Exception as e:
+                        print(f"Error cleaning up parameters: {e}")
+        except Exception as e:
+            print(f"Error during cleanup: {e}")
 
     @pytest.fixture
     def complex_state(self):
@@ -325,21 +341,23 @@ class TestParameterStoreStateIntegration:
 class TestS3StateIntegration:
     """Integration tests for S3State using substrate."""
 
-    @pytest.fixture(scope="class")
-    def substrate_session(self):
-        """Create a session connected to substrate."""
-        return get_substrate_session()
-
     @pytest.fixture
     def s3_bucket_name(self, substrate_session):
-        """Create a unique S3 bucket name and ensure it exists."""
+        """Create a unique S3 bucket name and ensure it exists.
+
+        ``CreateBucketConfiguration`` is required outside ``us-east-1`` and
+        rejected inside it, and this session follows ``AWS_TEST_REGION``
+        (default ``us-west-2``) -- so the constraint is passed conditionally
+        rather than omitted, which is what made this fixture fail before.
+        """
         bucket_name = f"test-bucket-{uuid.uuid4().hex[:16]}"
         s3_client = substrate_session.client("s3")
+        region = substrate_session.region_name
 
-        try:
-            s3_client.create_bucket(Bucket=bucket_name)
-        except Exception as e:
-            pytest.skip(f"Failed to create test bucket: {e}")
+        kwargs = {"Bucket": bucket_name}
+        if region and region != "us-east-1":
+            kwargs["CreateBucketConfiguration"] = {"LocationConstraint": region}
+        s3_client.create_bucket(**kwargs)
 
         yield bucket_name
 
@@ -359,32 +377,18 @@ class TestS3StateIntegration:
             print(f"Error cleaning up test bucket: {e}")
 
     @pytest.fixture
-    def mock_provider(self):
-        """Create a provider-like object."""
-
-        class MockProvider:
-            def __init__(self):
-                self.workflow_id = f"test-workflow-{uuid.uuid4().hex[:8]}"
-                self.region = "us-east-1"
-                self.aws_access_key_id = "test"
-                self.aws_secret_access_key = "test"
-                self.aws_session_token = None
-                self.aws_profile = None
-
-        return MockProvider()
+    def mock_provider(self, substrate_session):
+        """A provider stub carrying the endpoint-bound session."""
+        return _provider_stub(substrate_session)
 
     @pytest.fixture
-    def s3_state(self, mock_provider, s3_bucket_name, substrate_session):
+    def s3_state(self, mock_provider, s3_bucket_name):
         """Create an S3State instance with substrate."""
-        key_prefix = f"parsl/test/{uuid.uuid4().hex[:8]}"
-
-        # Override session creation to use our substrate session
-        with patch.object(boto3, "Session", return_value=substrate_session):
-            return S3State(
-                provider=mock_provider,
-                bucket_name=s3_bucket_name,
-                key_prefix=key_prefix,
-            )
+        return S3State(
+            provider=mock_provider,
+            bucket_name=s3_bucket_name,
+            key_prefix=f"parsl/test/{uuid.uuid4().hex[:8]}",
+        )
 
     @pytest.fixture
     def complex_state(self):
@@ -515,46 +519,126 @@ class TestS3StateIntegration:
 
     @pytest.mark.substrate
     def test_create_bucket_if_not_exists(self, mock_provider, substrate_session):
-        """Test creating a bucket if it doesn't exist."""
+        """A missing bucket is created, blocked from public access, and usable.
+
+        Blocking public access is the part worth asserting rather than the
+        creation: the provider writes provider state -- instance IDs, network
+        IDs, and whatever the workflow put in its tags -- into this bucket, and it
+        replaced a deprecated ``ACL="private"`` with the modern equivalent. A
+        bucket created without it would be world-readable if any later policy
+        allowed it.
+
+        ``xfail`` on substrate#446 rather than skip: ``?publicAccessBlock`` is
+        unrouted there, so ``PUT`` falls through to the ``CreateBucket`` handler
+        and answers ``BucketAlreadyExists`` for the bucket that was just made.
+        The provider wraps that as ``StateError: Failed to create S3 bucket``, so
+        the whole constructor fails. xfail keeps the test running -- it will
+        report ``XPASS`` the moment substrate routes the subresource, where a skip
+        would sit silently forever.
+
+        Creation itself is covered under moto in
+        ``tests/unit/test_aws_mocking.py::test_bucket_is_created_when_requested``.
+        Nothing covers it against real S3: ``tests/aws`` pre-creates the bucket in
+        its ``s3_state_bucket`` fixture, so the provider takes the
+        already-exists branch there, and no E2E test passes
+        ``create_bucket_if_not_exists``. The public-access assertions below are
+        therefore unverified against AWS until substrate#446 lands.
+        """
         bucket_name = f"auto-create-bucket-{uuid.uuid4().hex[:16]}"
         s3_client = substrate_session.client("s3")
 
-        # Verify bucket doesn't exist
-        try:
+        with pytest.raises(ClientError) as excinfo:
             s3_client.head_bucket(Bucket=bucket_name)
-            bucket_exists = True
-        except ClientError:
-            bucket_exists = False
+        assert excinfo.value.response["Error"]["Code"] == "404"
 
-        assert not bucket_exists
-
-        # Create S3State with create_bucket_if_not_exists=True
-        with patch.object(boto3, "Session", return_value=substrate_session):
+        try:
             s3_state = S3State(
                 provider=mock_provider,
                 bucket_name=bucket_name,
                 create_bucket_if_not_exists=True,
             )
+        except StateError as exc:
+            if "BucketAlreadyExists" in str(exc):
+                pytest.xfail(
+                    "substrate#446: PUT ?publicAccessBlock is routed to "
+                    "CreateBucket, so the provider cannot lock down a bucket it "
+                    "just created."
+                )
+            raise
 
-        # Verify bucket was created
         try:
+            # Created, and no longer publicly reachable.
             s3_client.head_bucket(Bucket=bucket_name)
-            bucket_exists = True
-        except ClientError:
-            bucket_exists = False
+            blocked = s3_client.get_public_access_block(Bucket=bucket_name)[
+                "PublicAccessBlockConfiguration"
+            ]
+            assert blocked["BlockPublicAcls"] is True
+            assert blocked["IgnorePublicAcls"] is True
+            assert blocked["BlockPublicPolicy"] is True
+            assert blocked["RestrictPublicBuckets"] is True
 
-        assert bucket_exists
+            # Tagged so an operator can tell which workflow owns it.
+            tags = {
+                t["Key"]: t["Value"]
+                for t in s3_client.get_bucket_tagging(Bucket=bucket_name)["TagSet"]
+            }
+            assert tags["ParslManagedBucket"] == "true"
+            assert tags["ParslWorkflowId"] == mock_provider.workflow_id
 
-        # Test saving and loading state in the new bucket
-        test_state = {"created": "auto", "test": True}
-        s3_state.save_state("test_key", test_state)
+            s3_state.save_state("test_key", {"created": "auto", "test": True})
+            assert s3_state.load_state("test_key")["created"] == "auto"
+        finally:
+            s3_state.delete_state("test_key")
+            try:
+                s3_client.delete_bucket(Bucket=bucket_name)
+            except Exception as e:
+                print(f"Error cleaning up bucket: {e}")
 
-        loaded_state = s3_state.load_state("test_key")
-        assert loaded_state["created"] == "auto"
+    @pytest.mark.substrate
+    def test_an_existing_bucket_is_adopted_rather_than_recreated(
+        self, mock_provider, s3_bucket_name
+    ):
+        """``create_bucket_if_not_exists`` must be idempotent.
 
-        # Cleanup
-        s3_state.delete_state("test_key")
-        try:
-            s3_client.delete_bucket(Bucket=bucket_name)
-        except Exception as e:
-            print(f"Error cleaning up bucket: {e}")
+        A provider resumed from a state file constructs its store again, so this
+        runs against a bucket that already exists on every restart. ``CreateBucket``
+        is not reached at all in that case -- which is also why this test passes
+        where the one above cannot.
+        """
+        s3_state = S3State(
+            provider=mock_provider,
+            bucket_name=s3_bucket_name,
+            create_bucket_if_not_exists=True,
+        )
+
+        s3_state.save_state("adopted", {"ok": True})
+        assert s3_state.load_state("adopted") == {"ok": True}
+        s3_state.delete_state("adopted")
+
+    @pytest.mark.substrate
+    def test_an_empty_bucket_is_reclaimed_and_a_used_one_is_not(
+        self, mock_provider, s3_bucket_name
+    ):
+        """``delete_bucket_if_empty`` must not destroy state it still holds.
+
+        Called on shutdown, where the bucket may be shared with another provider
+        or hold state a resumed run still needs. Emptiness is the only signal
+        available, so the check has to be right in both directions.
+        """
+        s3_state = S3State(
+            provider=mock_provider,
+            bucket_name=s3_bucket_name,
+            key_prefix=f"parsl/test/{uuid.uuid4().hex[:8]}",
+        )
+        s3_state.save_state("still-needed", {"ok": True})
+
+        assert s3_state.delete_bucket_if_empty() is False
+        assert s3_state.load_state("still-needed") == {"ok": True}
+
+        s3_state.delete_state("still-needed")
+
+        assert s3_state.delete_bucket_if_empty() is True
+        # The bucket is gone, so the fixture's teardown has nothing to do -- and
+        # the store now fails loudly rather than silently returning None.
+        with pytest.raises(StateError, match="NoSuchBucket"):
+            s3_state.load_state("still-needed")

--- a/tests/integration/test_substrate_modes.py
+++ b/tests/integration/test_substrate_modes.py
@@ -1,47 +1,36 @@
 """Integration tests for operating modes using substrate.
 
-These tests run against substrate, which emulates AWS services locally.
-They verify that the operating modes can create resources, submit jobs, and clean up
-properly in an environment that mimics AWS APIs.
+These drive each mode's real lifecycle -- initialize, submit, status, cancel,
+cleanup -- against the emulator, with no mocking of the mode itself.
+
+Two things had kept the whole file from running. ``FileStateStore(file_path=...)``
+omitted the required ``provider_id``, so every test errored during fixture setup;
+and the assertions described the pre-#69 provider, which created its own VPC,
+subnet and security group. It no longer does: the caller supplies them, so
+``initialize()`` verifies rather than creates, and ``cleanup_infrastructure()``
+leaves them alone -- deleting a caller's network would be the same class of bug as
+the serverless security-group deletion fixed in #100. The old
+``assert mode.vpc_id is None`` after cleanup asserted the opposite.
 
 SPDX-License-Identifier: Apache-2.0
 SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
 """
 
 import os
-import pytest
 import uuid
-from unittest.mock import patch
 
-from parsl_ephemeral_aws.modes.standard import StandardMode
+import pytest
+
 from parsl_ephemeral_aws.modes.detached import DetachedMode
 from parsl_ephemeral_aws.modes.serverless import ServerlessMode
+from parsl_ephemeral_aws.modes.standard import StandardMode
 from parsl_ephemeral_aws.state.file import FileStateStore
-from tests.substrate_support import (
-    get_substrate_session,
-    is_substrate_available,
+from tests.substrate_support import is_substrate_available
+
+pytestmark = pytest.mark.skipif(
+    not is_substrate_available(),
+    reason="substrate not available - start with 'make substrate-up'",
 )
-
-
-@pytest.fixture(scope="session")
-def substrate_available():
-    """Check if substrate is available for testing."""
-    if not is_substrate_available():
-        pytest.skip("substrate not available - start with 'make substrate-up'")
-    return True
-
-
-@pytest.fixture(scope="session")
-def substrate_session(substrate_available):
-    """Create a session connected to substrate."""
-    return get_substrate_session()
-
-
-@pytest.fixture
-def temp_state_store(tmpdir):
-    """Create a temporary state store for testing."""
-    state_file = tmpdir.join("state.json")
-    return FileStateStore(file_path=str(state_file))
 
 
 @pytest.fixture
@@ -50,295 +39,207 @@ def provider_id():
     return f"test-provider-{uuid.uuid4().hex[:8]}"
 
 
+@pytest.fixture
+def temp_state_store(tmp_path, provider_id):
+    """Create a temporary state store for testing.
+
+    ``provider_id`` is required (``state/file.py``): it is the key the document is
+    written under, so a store without one cannot address its own state.
+    """
+    return FileStateStore(
+        file_path=str(tmp_path / "state.json"), provider_id=provider_id
+    )
+
+
 @pytest.mark.integration
+@pytest.mark.substrate
 class TestStandardModeSubstrate:
     """Integration tests for StandardMode using substrate."""
 
-    @pytest.mark.substrate
     def test_initialize_and_cleanup(
-        self, substrate_session, temp_state_store, provider_id
+        self, substrate_session, substrate_network, temp_state_store, provider_id
     ):
-        """Test that StandardMode can initialize resources and clean them up."""
-        # Create StandardMode instance
+        """initialize() verifies the caller's network and builds a launch template."""
         mode = StandardMode(
             provider_id=provider_id,
             session=substrate_session,
             state_store=temp_state_store,
             region="us-east-1",
-            instance_type="t2.micro",
-            image_id="ami-12345678",  # Dummy AMI ID for testing
+            instance_type="t3.micro",
+            image_id="ami-12345678",
+            vpc_id=substrate_network["vpc_id"],
+            subnet_id=substrate_network["subnet_id"],
+            security_group_id=substrate_network["security_group_id"],
         )
 
         try:
-            # Initialize mode - this should create VPC, subnet, security group
             mode.initialize()
 
-            # Verify resources were created
-            assert mode.vpc_id is not None
-            assert mode.subnet_id is not None
-            assert mode.security_group_id is not None
             assert mode.initialized is True
+            # The launch template is the mode's own resource, unlike the network.
+            assert mode._launch_template_id is not None
 
-            # Verify resources exist in substrate
             ec2 = substrate_session.client("ec2")
-            vpcs = ec2.describe_vpcs(VpcIds=[mode.vpc_id])
-            assert len(vpcs["Vpcs"]) == 1
-
-            subnets = ec2.describe_subnets(SubnetIds=[mode.subnet_id])
-            assert len(subnets["Subnets"]) == 1
-
-            security_groups = ec2.describe_security_groups(
-                GroupIds=[mode.security_group_id]
+            templates = ec2.describe_launch_templates(
+                LaunchTemplateIds=[mode._launch_template_id]
             )
-            assert len(security_groups["SecurityGroups"]) == 1
+            assert len(templates["LaunchTemplates"]) == 1
 
-            # Verify state was saved
             assert os.path.exists(temp_state_store.file_path)
 
         finally:
-            # Clean up resources
             mode.cleanup_infrastructure()
 
-            # Verify resources were cleaned up
-            assert mode.vpc_id is None
-            assert mode.subnet_id is None
-            assert mode.security_group_id is None
-            assert mode.initialized is False
+        assert mode.initialized is False
+        # The network belongs to the caller and must survive cleanup (#69).
+        assert mode.vpc_id == substrate_network["vpc_id"]
+        ec2 = substrate_session.client("ec2")
+        assert len(ec2.describe_vpcs(VpcIds=[mode.vpc_id])["Vpcs"]) == 1
 
-    @pytest.mark.substrate
     def test_submit_job_and_status(
-        self, substrate_session, temp_state_store, provider_id
+        self, substrate_session, substrate_network, temp_state_store, provider_id
     ):
-        """Test job submission and status checking."""
-        # Create StandardMode instance
+        """A submitted job launches a tracked instance and can be cancelled."""
         mode = StandardMode(
             provider_id=provider_id,
             session=substrate_session,
             state_store=temp_state_store,
             region="us-east-1",
-            instance_type="t2.micro",
-            image_id="ami-12345678",  # Dummy AMI ID for testing
+            instance_type="t3.micro",
+            image_id="ami-12345678",
+            vpc_id=substrate_network["vpc_id"],
+            subnet_id=substrate_network["subnet_id"],
+            security_group_id=substrate_network["security_group_id"],
         )
 
         try:
-            # Initialize mode
             mode.initialize()
 
-            # Submit a job
             job_id = f"test-job-{uuid.uuid4().hex[:8]}"
-            command = "echo hello"
-            resource_id = mode.submit_job(job_id, command, 1)
+            resource_id = mode.submit_job(job_id, "echo hello", 1)
 
-            # Verify job was tracked
             assert resource_id in mode.resources
             assert mode.resources[resource_id]["job_id"] == job_id
 
-            # Check job status
-            status = mode.get_job_status([resource_id])
-            assert resource_id in status
+            assert mode.get_job_status([resource_id])[resource_id] == "RUNNING"
+            assert mode.cancel_jobs([resource_id])[resource_id] == "CANCELED"
 
-            # Cancel job
-            cancel_status = mode.cancel_jobs([resource_id])
-            assert resource_id in cancel_status
-
-            # Cleanup specific resource
             mode.cleanup_resources([resource_id])
             assert resource_id not in mode.resources
 
         finally:
-            # Clean up all resources
             mode.cleanup_infrastructure()
 
 
 @pytest.mark.integration
+@pytest.mark.substrate
 class TestDetachedModeSubstrate:
-    """Integration tests for DetachedMode using substrate."""
+    """Integration tests for DetachedMode using substrate.
 
-    @pytest.mark.substrate
-    def test_initialize_and_cleanup(
-        self, substrate_session, temp_state_store, provider_id
-    ):
-        """Test that DetachedMode can initialize resources and clean them up."""
-        # Create DetachedMode instance
-        mode = DetachedMode(
+    ``bastion_host_type="direct"`` throughout: the CloudFormation bastion is not
+    reachable here, since substrate serves no ``cloudformation`` endpoint. That
+    path is covered against real AWS in ``tests/aws/``.
+    """
+
+    def _mode(self, session, network, store, provider_id, **overrides):
+        return DetachedMode(
             provider_id=provider_id,
-            session=substrate_session,
-            state_store=temp_state_store,
+            session=session,
+            state_store=store,
             region="us-east-1",
-            instance_type="t2.micro",
+            instance_type="t3.micro",
+            image_id="ami-12345678",
             workflow_id=f"test-workflow-{uuid.uuid4().hex[:8]}",
-            bastion_instance_type="t2.micro",
-            image_id="ami-12345678",  # Dummy AMI ID for testing
-            bastion_host_type="direct",  # Use direct mode for simpler testing
+            bastion_instance_type="t3.micro",
+            bastion_host_type="direct",
+            vpc_id=network["vpc_id"],
+            subnet_id=network["subnet_id"],
+            security_group_id=network["security_group_id"],
+            **overrides,
+        )
+
+    def test_initialize_and_cleanup(
+        self, substrate_session, substrate_network, temp_state_store, provider_id
+    ):
+        """A direct-mode bastion launches with no key pair, and is torn down.
+
+        No ``key_name`` is passed, which is the ordinary configuration -- SSM is
+        how you reach the bastion, and it needs no key. That combination used to
+        fail botocore's parameter validation before any API call, so this mode
+        could not start at all (#158).
+        """
+        mode = self._mode(
+            substrate_session, substrate_network, temp_state_store, provider_id
         )
 
         try:
-            # Initialize mode
             mode.initialize()
 
-            # Verify resources were created
-            assert mode.vpc_id is not None
-            assert mode.subnet_id is not None
-            assert mode.security_group_id is not None
-            assert mode.bastion_id is not None
             assert mode.initialized is True
+            assert mode.bastion_id is not None
 
-            # Verify resources exist in substrate
             ec2 = substrate_session.client("ec2")
-            vpcs = ec2.describe_vpcs(VpcIds=[mode.vpc_id])
-            assert len(vpcs["Vpcs"]) == 1
-
-            subnets = ec2.describe_subnets(SubnetIds=[mode.subnet_id])
-            assert len(subnets["Subnets"]) == 1
-
-            security_groups = ec2.describe_security_groups(
-                GroupIds=[mode.security_group_id]
-            )
-            assert len(security_groups["SecurityGroups"]) == 1
-
-            # Check bastion instance
-            instances = ec2.describe_instances(InstanceIds=[mode.bastion_id])
-            assert len(instances["Reservations"]) > 0
+            reservations = ec2.describe_instances(InstanceIds=[mode.bastion_id])
+            assert len(reservations["Reservations"]) == 1
 
         finally:
-            # Clean up resources
-            # Note: Set preserve_bastion to False to ensure bastion cleanup
             mode.preserve_bastion = False
             mode.cleanup_infrastructure()
 
-            # Verify resources were cleaned up
-            assert mode.vpc_id is None
-            assert mode.subnet_id is None
-            assert mode.security_group_id is None
-            assert mode.bastion_id is None
-            assert mode.initialized is False
+        assert mode.initialized is False
+        assert mode.bastion_id is None
+        # Again, the caller's network outlives the mode.
+        assert mode.vpc_id == substrate_network["vpc_id"]
 
-    @pytest.mark.substrate
     def test_submit_job_and_status(
-        self, substrate_session, temp_state_store, provider_id
+        self, substrate_session, substrate_network, temp_state_store, provider_id
     ):
-        """Test job submission and status checking in detached mode."""
-        # Create DetachedMode instance
-        workflow_id = f"test-workflow-{uuid.uuid4().hex[:8]}"
-        mode = DetachedMode(
-            provider_id=provider_id,
-            session=substrate_session,
-            state_store=temp_state_store,
-            region="us-east-1",
-            instance_type="t2.micro",
-            workflow_id=workflow_id,
-            bastion_instance_type="t2.micro",
-            image_id="ami-12345678",  # Dummy AMI ID for testing
-            bastion_host_type="direct",  # Use direct mode for simpler testing
+        """The bastion records the job in SSM Parameter Store when submitted."""
+        mode = self._mode(
+            substrate_session, substrate_network, temp_state_store, provider_id
         )
 
         try:
-            # Initialize mode
             mode.initialize()
 
-            # Submit a job
             job_id = f"test-job-{uuid.uuid4().hex[:8]}"
-            command = "echo hello"
-            resource_id = mode.submit_job(job_id, command, 1)
+            resource_id = mode.submit_job(job_id, "echo hello", 1)
 
-            # Verify job was tracked
             assert resource_id in mode.resources
             assert mode.resources[resource_id]["job_id"] == job_id
 
-            # Verify SSM parameters were created
+            # Jobs are handed to the bastion through Parameter Store, so the
+            # parameter existing is what proves the dispatch happened.
             ssm = substrate_session.client("ssm")
-            try:
-                job_param = ssm.get_parameter(
-                    Name=f"/parsl/workflows/{workflow_id}/jobs/{job_id}"
-                )
-                assert (
-                    job_param["Parameter"]["Name"]
-                    == f"/parsl/workflows/{workflow_id}/jobs/{job_id}"
-                )
-            except ssm.exceptions.ParameterNotFound:
-                pytest.fail("SSM parameter for job was not created")
+            prefix = f"/parsl/workflows/{mode.workflow_id}"
+            described = ssm.describe_parameters(
+                ParameterFilters=[
+                    {"Key": "Name", "Option": "BeginsWith", "Values": [prefix]}
+                ]
+            )
+            assert described["Parameters"], f"no SSM parameters under {prefix}"
 
-            # Check job status
-            status = mode.get_job_status([resource_id])
-            assert resource_id in status
-
-            # Cancel job
-            cancel_status = mode.cancel_jobs([resource_id])
-            assert resource_id in cancel_status
-
-            # Cleanup specific resource
-            mode.cleanup_resources([resource_id])
-            assert resource_id not in mode.resources
+            assert resource_id in mode.get_job_status([resource_id])
+            assert resource_id in mode.cancel_jobs([resource_id])
 
         finally:
-            # Clean up all resources
-            mode.preserve_bastion = False  # Ensure bastion cleanup
+            mode.preserve_bastion = False
             mode.cleanup_infrastructure()
 
 
 @pytest.mark.integration
+@pytest.mark.substrate
 class TestServerlessModeSubstrate:
     """Integration tests for ServerlessMode using substrate."""
 
-    @pytest.mark.substrate
-    def test_initialize_and_cleanup(
+    def test_lambda_mode_needs_no_network(
         self, substrate_session, temp_state_store, provider_id
     ):
-        """Test that ServerlessMode can initialize resources and clean them up."""
-        # Create ServerlessMode instance
-        mode = ServerlessMode(
-            provider_id=provider_id,
-            session=substrate_session,
-            state_store=temp_state_store,
-            region="us-east-1",
-            worker_type="lambda",  # Use Lambda for simplicity
-            lambda_memory=128,
-            lambda_timeout=30,
-        )
+        """Lambda-only serverless initializes without any caller network.
 
-        try:
-            # Initialize mode - serverless Lambda-only mode won't create network resources
-            mode.initialize()
-
-            # Verify initialization
-            assert mode.initialized is True
-
-            # Lambda mode should not create VPC resources
-            assert mode.vpc_id is None
-            assert mode.subnet_id is None
-            assert mode.security_group_id is None
-
-            # For ECS mode, test with network resources
-            mode_ecs = ServerlessMode(
-                provider_id=f"{provider_id}-ecs",
-                session=substrate_session,
-                state_store=temp_state_store,
-                region="us-east-1",
-                worker_type="ecs",
-                ecs_task_cpu=256,
-                ecs_task_memory=512,
-                ecs_container_image="amazon/amazon-ecs-sample",
-            )
-
-            mode_ecs.initialize()
-            assert mode_ecs.vpc_id is not None
-            assert mode_ecs.subnet_id is not None
-            assert mode_ecs.security_group_id is not None
-
-            # Clean up ECS mode resources
-            mode_ecs.cleanup_infrastructure()
-
-        finally:
-            # Clean up resources
-            mode.cleanup_infrastructure()
-
-            # Verify resources were cleaned up
-            assert mode.initialized is False
-
-    @pytest.mark.substrate
-    def test_submit_lambda_job(self, substrate_session, temp_state_store, provider_id):
-        """Test Lambda job submission with CloudFormation stacks."""
-        # Create ServerlessMode instance for Lambda
+        Functions run in the Lambda-managed VPC, which is why the provider's
+        network guard exempts this combination.
+        """
         mode = ServerlessMode(
             provider_id=provider_id,
             session=substrate_session,
@@ -349,39 +250,86 @@ class TestServerlessModeSubstrate:
             lambda_timeout=30,
         )
 
-        # Mock the Lambda code generation since we can't actually create it in tests
-        mock_lambda_manager = mode.lambda_manager
-        mock_lambda_manager._generate_lambda_code.return_value = b"mock_lambda_code"
-
         try:
-            # Initialize mode
             mode.initialize()
 
-            # Submit a job
+            assert mode.initialized is True
+            assert mode.vpc_id is None
+            assert mode.subnet_id is None
+            assert mode.security_group_id is None
+
+        finally:
+            mode.cleanup_infrastructure()
+
+        assert mode.initialized is False
+
+    def test_ecs_mode_uses_the_supplied_network(
+        self, substrate_session, substrate_network, temp_state_store, provider_id
+    ):
+        """ECS/Fargate tasks run in the caller's subnet, so the IDs are kept."""
+        mode = ServerlessMode(
+            provider_id=provider_id,
+            session=substrate_session,
+            state_store=temp_state_store,
+            region="us-east-1",
+            worker_type="ecs",
+            ecs_task_cpu=256,
+            ecs_task_memory=512,
+            ecs_container_image="python:3.12-slim",
+            vpc_id=substrate_network["vpc_id"],
+            subnet_id=substrate_network["subnet_id"],
+            security_group_id=substrate_network["security_group_id"],
+        )
+
+        try:
+            mode.initialize()
+
+            assert mode.initialized is True
+            assert mode.vpc_id == substrate_network["vpc_id"]
+            assert mode.subnet_id == substrate_network["subnet_id"]
+            assert mode.security_group_id == substrate_network["security_group_id"]
+
+        finally:
+            mode.cleanup_infrastructure()
+
+    def test_submit_lambda_job(
+        self,
+        substrate_session,
+        temp_state_store,
+        provider_id,
+        requires_cloudformation,
+    ):
+        """Submitting a Lambda job provisions its function through a stack.
+
+        Skipped rather than failed while the emulator serves no CloudFormation:
+        ``_submit_lambda_job`` deploys the worker as a stack, so this exercises the
+        emulator's gap, not the provider. Covered for real in ``tests/aws/``.
+        """
+        mode = ServerlessMode(
+            provider_id=provider_id,
+            session=substrate_session,
+            state_store=temp_state_store,
+            region="us-east-1",
+            worker_type="lambda",
+            lambda_memory=128,
+            lambda_timeout=30,
+        )
+
+        try:
+            mode.initialize()
+
             job_id = f"test-job-{uuid.uuid4().hex[:8]}"
-            command = "echo hello"
+            resource_id = mode.submit_job(job_id, "echo hello", 1)
 
-            # Mock writing to temp file
-            with patch("builtins.open", create=True) as mock_open:
-                resource_id = mode.submit_job(job_id, command, 1)
-
-            # Verify job was tracked
             assert resource_id in mode.resources
             assert mode.resources[resource_id]["job_id"] == job_id
             assert mode.resources[resource_id]["worker_type"] == "lambda"
 
-            # Check job status
-            status = mode.get_job_status([resource_id])
-            assert resource_id in status
+            assert resource_id in mode.get_job_status([resource_id])
+            assert resource_id in mode.cancel_jobs([resource_id])
 
-            # Cancel job
-            cancel_status = mode.cancel_jobs([resource_id])
-            assert resource_id in cancel_status
-
-            # Cleanup specific resource
             mode.cleanup_resources([resource_id])
             assert resource_id not in mode.resources
 
         finally:
-            # Clean up all resources
             mode.cleanup_infrastructure()

--- a/tests/integration/test_workflow_error_scenarios.py
+++ b/tests/integration/test_workflow_error_scenarios.py
@@ -1,35 +1,66 @@
 """Integration tests for error handling in workflow scenarios.
 
-These tests simulate error conditions that might occur during real-world
-workflows to verify proper recovery mechanisms and error handling.
+Each test drives a *real* mode against the emulator, makes one thing fail, and
+asserts on what survived: whether the mode is usable afterwards, whether a
+partially created resource was released, and whether the failure reached the
+caller as the right exception type. Nothing about the recovery path is mocked --
+only the failure itself is injected, and always at the boundary the real error
+would arrive at.
+
+The previous version of this file could not test any of that. Every test patched
+methods that do not exist on any mode -- ``_create_vpc``, ``_create_subnet``,
+``_create_security_group``, ``_create_ec2_instance``, ``_delete_ec2_instance``,
+``_delete_vpc``, ``_delete_subnet``, ``_delete_security_group``,
+``_create_bastion_host``, ``_create_tags`` -- and ``patch.object`` raises
+``AttributeError`` for a missing attribute, so each was a hard error rather than
+a passing test. The shape they described was removed in #69: no mode creates
+network resources, and all three IDs are now required in the constructor, which
+is where the six failures actually stopped.
+
+Two smaller faults went with it. ``ResourceDeletionError`` was referenced at line
+452 but never imported, so that test could only ever raise ``NameError``. And a
+class-scoped ``substrate_session`` fixture shadowed conftest's: it came from
+``get_substrate_session()``, which binds no endpoint, so clients built from it
+reach real AWS and fail on auth. conftest's wraps ``session.client`` to inject
+``endpoint_url``, which is what makes code under test hit the emulator.
+
+Two failure modes are deliberately *not* exercised here:
+
+* **Mode-level retry does not exist.** Nothing in ``modes/`` uses
+  ``error_handling.py`` -- ``grep`` for ``retry_with_backoff`` finds no hit
+  outside ``compute/`` -- so there is no mode-level backoff to test. Adopting the
+  framework in ``modes/`` is #91, deferred to v0.9.0. What does retry today is
+  botocore, and ``TestThrottling`` tests that, at the layer it happens.
+* **A serverless submit needs CloudFormation**, which substrate does not serve,
+  so its failure path is asserted through the injected error rather than a real
+  stack rollback.
 
 SPDX-License-Identifier: Apache-2.0
 SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
 """
 
-import os
 import uuid
+from unittest.mock import patch
+
 import pytest
-import tempfile
-from unittest.mock import MagicMock, patch
+from botocore.awsrequest import AWSResponse
+from botocore.config import Config
 from botocore.exceptions import ClientError
 
-from parsl_ephemeral_aws.modes.standard import StandardMode
+from parsl_ephemeral_aws.constants import RESOURCE_TYPE_EC2
+from parsl_ephemeral_aws.exceptions import (
+    BastionHostError,
+    EC2InstanceError,
+    LambdaFunctionError,
+    OperatingModeError,
+    ResourceCreationError,
+    ResourceNotFoundError,
+)
 from parsl_ephemeral_aws.modes.detached import DetachedMode
 from parsl_ephemeral_aws.modes.serverless import ServerlessMode
+from parsl_ephemeral_aws.modes.standard import StandardMode
 from parsl_ephemeral_aws.state.file import FileStateStore
-from parsl_ephemeral_aws.exceptions import (
-    ResourceCreationError,
-    JobExecutionError,
-    BastionHostError,
-    LambdaFunctionError,
-    EC2InstanceError,
-)
-from tests.substrate_support import (
-    get_substrate_session,
-    is_substrate_available,
-)
-
+from tests.substrate_support import is_substrate_available
 
 # A marker only *selects* tests; it never skips them. Every sibling
 # emulator-backed file pairs its markers with this skipif, and this one did not --
@@ -44,458 +75,622 @@ pytestmark = [
     ),
 ]
 
+#: A well-formed ID that names nothing. Substrate distinguishes the two failures
+#: real EC2 does -- a short ID answers `InvalidSubnetID.Malformed`, this one
+#: answers `InvalidSubnetID.NotFound` -- and `_verify_resources` treats both as
+#: unusable, so the ID has to be shaped correctly for the test to be about
+#: absence rather than syntax.
+GHOST_SUBNET_ID = "subnet-0123456789abcdef0"
 
-@pytest.mark.integration
-class TestWorkflowErrorScenarios:
-    """Integration tests for workflow error scenarios."""
 
-    @pytest.fixture(scope="class")
-    def substrate_session(self):
-        """Create a session connected to substrate."""
-        return get_substrate_session()
+@pytest.fixture
+def state_store(tmp_path):
+    """A real file-backed state store inside the test's sandbox.
 
-    @pytest.fixture
-    def temp_dir(self):
-        """Create a temporary directory for state files."""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            yield tmp_dir
+    Real rather than mocked: every mode saves state on the success *and* failure
+    paths this file exercises, and a MagicMock store hides a serialization error
+    behind a recorded call. It also keeps ``state/file.py``'s ``fcntl.flock`` on
+    a genuine file descriptor -- a mocked handle raises "fileno() returned a
+    non-integer".
+    """
+    provider_id = f"test-provider-{uuid.uuid4().hex[:8]}"
+    return FileStateStore(
+        file_path=str(tmp_path / f"state-{provider_id}.json"), provider_id=provider_id
+    )
 
-    @pytest.fixture
-    def state_file_path(self, temp_dir):
-        """Create a path for the state file."""
-        return os.path.join(temp_dir, f"test-state-{uuid.uuid4().hex[:8]}.json")
 
-    @pytest.fixture
-    def file_state_store(self, state_file_path):
-        """Create a FileStateStore instance."""
-        provider_id = f"test-provider-{uuid.uuid4().hex[:8]}"
-        return FileStateStore(file_path=state_file_path, provider_id=provider_id)
+def _standard(session, state_store, network, **overrides):
+    """A StandardMode bound to the emulator, with the caller's network."""
+    kwargs = dict(
+        provider_id=f"test-provider-{uuid.uuid4().hex[:8]}",
+        session=session,
+        state_store=state_store,
+        region=session.region_name,
+        instance_type="t3.micro",
+        image_id="ami-12345678",
+        vpc_id=network["vpc_id"],
+        subnet_id=network["subnet_id"],
+        security_group_id=network["security_group_id"],
+    )
+    kwargs.update(overrides)
+    return StandardMode(**kwargs)
 
-    @pytest.mark.substrate
-    def test_infrastructure_failure_recovery(self, substrate_session, file_state_store):
-        """Test recovery after infrastructure creation failure."""
-        # Create a StandardMode instance
-        provider_id = f"test-provider-{uuid.uuid4().hex[:8]}"
 
-        # Set up mocks for AWS services using substrate
-        with patch("boto3.Session", return_value=substrate_session):
-            # Create a standard mode
-            mode = StandardMode(
-                provider_id=provider_id,
-                session=substrate_session,
-                state_store=file_state_store,
-                region="us-east-1",
-                instance_type="t2.micro",
-                image_id="ami-12345678",  # Dummy AMI
-            )
+def _detached(session, state_store, network, **overrides):
+    """A DetachedMode with a direct bastion.
 
-            # Set up a mock VPC creation that fails
-            with patch.object(mode, "_create_vpc") as mock_create_vpc:
-                mock_create_vpc.side_effect = ResourceCreationError(
-                    "VPC creation failed"
-                )
+    ``bastion_host_type="direct"``, not the "cloudformation" default: the stack
+    path needs an endpoint substrate does not serve. The direct path launches
+    with ``run_instances`` and is a real bastion in the emulator, which is what
+    these tests need in order to check it was cleaned up.
+    """
+    kwargs = dict(
+        workflow_id=f"test-workflow-{uuid.uuid4().hex[:8]}",
+        bastion_host_type="direct",
+        bastion_instance_type="t3.micro",
+        preserve_bastion=False,
+    )
+    kwargs.update(overrides)
+    return _detached_mode(session, state_store, network, **kwargs)
 
-                # Initialize should fail
-                with pytest.raises(ResourceCreationError):
-                    mode.initialize()
 
-                # Verify mode is not initialized
-                assert not mode.initialized
-                assert mode.vpc_id is None
+def _detached_mode(session, state_store, network, **kwargs):
+    return DetachedMode(
+        provider_id=f"test-provider-{uuid.uuid4().hex[:8]}",
+        session=session,
+        state_store=state_store,
+        region=session.region_name,
+        instance_type="t3.micro",
+        image_id="ami-12345678",
+        vpc_id=network["vpc_id"],
+        subnet_id=network["subnet_id"],
+        security_group_id=network["security_group_id"],
+        **kwargs,
+    )
 
-            # Now let's make it succeed
-            with patch.object(mode, "_create_vpc", return_value="vpc-12345"):
-                with patch.object(mode, "_create_subnet", return_value="subnet-12345"):
-                    with patch.object(
-                        mode, "_create_security_group", return_value="sg-12345"
-                    ):
-                        mode.initialize()
 
-            # Verify mode is now initialized
-            assert mode.initialized
-            assert mode.vpc_id == "vpc-12345"
-            assert mode.subnet_id == "subnet-12345"
-            assert mode.security_group_id == "sg-12345"
+def instance_state(session, instance_id):
+    """Return an instance's state name, or None if EC2 has forgotten it."""
+    try:
+        described = session.client("ec2").describe_instances(InstanceIds=[instance_id])
+    except ClientError:
+        return None
+    for reservation in described["Reservations"]:
+        for instance in reservation["Instances"]:
+            return str(instance["State"]["Name"])
+    return None
 
-            # Clean up
-            with patch.object(mode, "_delete_security_group"):
-                with patch.object(mode, "_delete_subnet"):
-                    with patch.object(mode, "_delete_vpc"):
-                        mode.cleanup_infrastructure()
 
-    @pytest.mark.substrate
-    def test_instance_creation_failure_recovery(
-        self, substrate_session, file_state_store
+class TestNetworkVerificationFailure:
+    """A network ID that names nothing must fail before anything is launched."""
+
+    def test_a_missing_subnet_stops_initialize_naming_it(
+        self, substrate_session, substrate_network, state_store
     ):
-        """Test recovery after instance creation failures."""
-        # Create a StandardMode instance
-        provider_id = f"test-provider-{uuid.uuid4().hex[:8]}"
+        """The error names the unusable resource, and nothing is created.
 
-        # Set up mocks for AWS services using substrate
-        with patch("boto3.Session", return_value=substrate_session):
-            # Create a standard mode
-            mode = StandardMode(
-                provider_id=provider_id,
-                session=substrate_session,
-                state_store=file_state_store,
-                region="us-east-1",
-                instance_type="t2.micro",
-                image_id="ami-12345678",  # Dummy AMI
-            )
+        Before #69 each mode nulled the attribute out here so that
+        ``initialize()`` would create a replacement. Nothing creates one now, so
+        the ``None`` propagated into ``run_instances`` and surfaced as an opaque
+        ``InvalidParameterValue`` far from the missing subnet.
+        """
+        mode = _standard(
+            substrate_session,
+            state_store,
+            {**substrate_network, "subnet_id": GHOST_SUBNET_ID},
+        )
 
-            # Initialize mode to create basic infrastructure (VPC, etc.)
-            with patch.object(mode, "_create_vpc", return_value="vpc-12345"):
-                with patch.object(mode, "_create_subnet", return_value="subnet-12345"):
-                    with patch.object(
-                        mode, "_create_security_group", return_value="sg-12345"
-                    ):
-                        mode.initialize()
-
-            # Mock instance creation that fails
-            with patch.object(mode, "_create_ec2_instance") as mock_create_instance:
-                # Simulate instance creation failure
-                mock_create_instance.side_effect = EC2InstanceError(
-                    "Instance creation failed"
-                )
-
-                # Submit job should fail
-                job_id = f"test-job-{uuid.uuid4().hex[:8]}"
-                with pytest.raises(JobExecutionError):
-                    mode.submit_job(job_id, "echo 'Test job'", 1)
-
-                # Verify no resources were created
-                assert len(mode.resources) == 0
-
-            # Now let's make it succeed
-            with patch.object(mode, "_create_ec2_instance") as mock_create_instance:
-                mock_create_instance.return_value = {
-                    "instance_id": f"i-{uuid.uuid4().hex[:12]}",
-                    "private_ip": "10.0.0.1",
-                    "public_ip": "54.123.456.789",
-                    "dns_name": "ec2-54-123-456-789.compute-1.amazonaws.com",
-                }
-
-                # Submit should succeed
-                job_id = f"test-job-{uuid.uuid4().hex[:8]}"
-                resource_id = mode.submit_job(job_id, "echo 'Test job'", 1)
-
-                # Verify resource was created
-                assert resource_id in mode.resources
-                assert mode.resources[resource_id]["job_id"] == job_id
-
-            # Clean up
-            with patch.object(mode, "_delete_ec2_instance"):
-                with patch.object(mode, "_delete_security_group"):
-                    with patch.object(mode, "_delete_subnet"):
-                        with patch.object(mode, "_delete_vpc"):
-                            mode.cleanup_infrastructure()
-
-    @pytest.mark.substrate
-    def test_bastion_failure_recovery(self, substrate_session, file_state_store):
-        """Test recovery after bastion host creation failure."""
-        # Create a DetachedMode instance
-        provider_id = f"test-provider-{uuid.uuid4().hex[:8]}"
-        workflow_id = f"test-workflow-{uuid.uuid4().hex[:8]}"
-
-        # Set up mocks for AWS services using substrate
-        with patch("boto3.Session", return_value=substrate_session):
-            # Create a detached mode
-            mode = DetachedMode(
-                provider_id=provider_id,
-                session=substrate_session,
-                state_store=file_state_store,
-                region="us-east-1",
-                instance_type="t2.micro",
-                image_id="ami-12345678",  # Dummy AMI
-                workflow_id=workflow_id,
-                bastion_instance_type="t2.micro",
-                bastion_host_type="direct",
-            )
-
-            # Set up mocks for network resources
-            with patch.object(mode, "_create_vpc", return_value="vpc-12345"):
-                with patch.object(mode, "_create_subnet", return_value="subnet-12345"):
-                    with patch.object(
-                        mode, "_create_security_group", return_value="sg-12345"
-                    ):
-                        # Mock bastion creation that fails
-                        with patch.object(
-                            mode, "_create_bastion_host"
-                        ) as mock_create_bastion:
-                            mock_create_bastion.side_effect = BastionHostError(
-                                "Bastion host creation failed"
-                            )
-
-                            # Initialize should fail
-                            with pytest.raises(BastionHostError):
-                                with patch.object(mode, "_create_tags"):
-                                    mode.initialize()
-
-                            # Verify mode is not fully initialized
-                            assert not mode.initialized
-                            assert (
-                                mode.vpc_id == "vpc-12345"
-                            )  # These were created before the failure
-                            assert mode.subnet_id == "subnet-12345"
-                            assert mode.security_group_id == "sg-12345"
-                            assert mode.bastion_id is None  # This failed
-
-                        # Now let's make bastion creation succeed
-                        with patch.object(
-                            mode, "_create_bastion_host"
-                        ) as mock_create_bastion:
-                            mock_create_bastion.return_value = {
-                                "instance_id": f"i-bastion-{uuid.uuid4().hex[:8]}",
-                                "private_ip": "10.0.0.2",
-                                "public_ip": "54.123.456.789",
-                                "dns_name": "ec2-54-123-456-789.compute-1.amazonaws.com",
-                            }
-
-                            # Initialize should succeed
-                            with patch.object(mode, "_create_tags"):
-                                mode.initialize()
-
-                            # Verify mode is now initialized
-                            assert mode.initialized
-                            assert mode.bastion_id is not None
-
-            # Clean up
-            with patch.object(mode, "_delete_ec2_instance"):
-                with patch.object(mode, "_delete_security_group"):
-                    with patch.object(mode, "_delete_subnet"):
-                        with patch.object(mode, "_delete_vpc"):
-                            mode.preserve_bastion = (
-                                False  # Ensure bastion is cleaned up
-                            )
-                            mode.cleanup_infrastructure()
-
-    @pytest.mark.substrate
-    def test_lambda_failure_recovery(self, substrate_session, file_state_store):
-        """Test recovery after Lambda function creation failure."""
-        # Create a ServerlessMode instance
-        provider_id = f"test-provider-{uuid.uuid4().hex[:8]}"
-
-        # Set up mocks for AWS services using substrate
-        with patch("boto3.Session", return_value=substrate_session):
-            # Create a serverless mode
-            mode = ServerlessMode(
-                provider_id=provider_id,
-                session=substrate_session,
-                state_store=file_state_store,
-                region="us-east-1",
-                worker_type="lambda",  # Use Lambda for simplicity
-                lambda_memory=128,
-                lambda_timeout=30,
-            )
-
-            # Initialize mode - Lambda-only mode won't create network resources
+        with pytest.raises(ResourceNotFoundError, match=GHOST_SUBNET_ID):
             mode.initialize()
 
-            # Verify mode is initialized
+        assert not mode.initialized
+        # Verification runs ahead of everything else, so no template was built.
+        assert mode._launch_template_id is None
+
+    def test_a_usable_network_initializes_and_builds_a_template(
+        self, substrate_session, substrate_network, state_store
+    ):
+        """The counterpart: the same construction succeeds once the ID is real.
+
+        Without this, the test above would also pass if ``initialize()`` were
+        broken for every input.
+        """
+        mode = _standard(substrate_session, state_store, substrate_network)
+
+        try:
+            mode.initialize()
+
             assert mode.initialized
-
-            # Mock Lambda function creation that fails
-            mode.lambda_manager = MagicMock()
-            mode.lambda_manager._create_lambda_function.side_effect = (
-                LambdaFunctionError("Lambda function creation failed")
-            )
-
-            # Submit job should fail
-            job_id = f"test-job-{uuid.uuid4().hex[:8]}"
-            with pytest.raises(JobExecutionError):
-                # Mock writing to temp file for Lambda code
-                with patch("builtins.open", MagicMock()):
-                    mode.submit_job(job_id, "echo 'Test job'", 1)
-
-            # Verify no resources were created
-            assert len(mode.resources) == 0
-
-            # Now let's make it succeed
-            mode.lambda_manager._create_lambda_function.side_effect = None
-            mode.lambda_manager._create_lambda_function.return_value = {
-                "FunctionName": f"lambda-{uuid.uuid4().hex[:8]}",
-                "FunctionArn": f"arn:aws:lambda:us-east-1:123456789012:function:lambda-{uuid.uuid4().hex[:8]}",
-            }
-
-            mode.lambda_manager.invoke_lambda_function.return_value = {
-                "StatusCode": 200,
-                "Payload": {"statusCode": 200, "body": "Success"},
-            }
-
-            # Submit should succeed
-            job_id = f"test-job-{uuid.uuid4().hex[:8]}"
-            # Mock writing to temp file for Lambda code
-            with patch("builtins.open", MagicMock()):
-                resource_id = mode.submit_job(job_id, "echo 'Test job'", 1)
-
-            # Verify resource was created
-            assert resource_id in mode.resources
-            assert mode.resources[resource_id]["job_id"] == job_id
-
-            # Clean up
-            mode.lambda_manager.delete_lambda_function.return_value = None
+            assert mode._launch_template_id is not None
+        finally:
             mode.cleanup_infrastructure()
 
-    @pytest.mark.substrate
-    def test_retry_after_throttling(self, substrate_session, file_state_store):
-        """Test retry logic after AWS API throttling."""
-        # Create a StandardMode instance
-        provider_id = f"test-provider-{uuid.uuid4().hex[:8]}"
 
-        # Set up mocks for AWS services using substrate
-        with patch("boto3.Session", return_value=substrate_session):
-            # Create a standard mode
-            mode = StandardMode(
-                provider_id=provider_id,
-                session=substrate_session,
-                state_store=file_state_store,
-                region="us-east-1",
-                instance_type="t2.micro",
-                image_id="ami-12345678",  # Dummy AMI
-            )
+class TestSubmitFailure:
+    """What a failed submit leaves behind."""
 
-            # Initialize mode to create infrastructure
-            with patch.object(mode, "_create_vpc", return_value="vpc-12345"):
-                with patch.object(mode, "_create_subnet", return_value="subnet-12345"):
-                    with patch.object(
-                        mode, "_create_security_group", return_value="sg-12345"
-                    ):
-                        mode.initialize()
-
-            # Mock EC2 instance creation that gets throttled first, then succeeds
-            with patch.object(mode, "_create_ec2_instance") as mock_create_instance:
-                # First call gets throttled
-                throttle_error = ClientError(
-                    {
-                        "Error": {
-                            "Code": "RequestLimitExceeded",
-                            "Message": "Request limit exceeded",
-                        }
-                    },
-                    "RunInstances",
-                )
-                # Second call succeeds
-                mock_create_instance.side_effect = [
-                    throttle_error,
-                    {
-                        "instance_id": f"i-{uuid.uuid4().hex[:12]}",
-                        "private_ip": "10.0.0.1",
-                        "public_ip": "54.123.456.789",
-                        "dns_name": "ec2-54-123-456-789.compute-1.amazonaws.com",
-                    },
-                ]
-
-                # Mock sleep to avoid actual waiting
-                with patch("time.sleep"):
-                    # Set up retries in the EC2 manager
-                    with patch.object(mode.ec2_manager, "max_retries", 3):
-                        with patch.object(mode.ec2_manager, "retry_base_delay", 0):
-                            # Submit job
-                            job_id = f"test-job-{uuid.uuid4().hex[:8]}"
-                            resource_id = mode.submit_job(job_id, "echo 'Test job'", 1)
-
-            # Verify resource was eventually created despite throttling
-            assert resource_id in mode.resources
-            assert mode.resources[resource_id]["job_id"] == job_id
-
-            # Verify create_instance was called twice (once with throttling, once success)
-            assert mock_create_instance.call_count == 2
-
-            # Clean up
-            with patch.object(mode, "_delete_ec2_instance"):
-                with patch.object(mode, "_delete_security_group"):
-                    with patch.object(mode, "_delete_subnet"):
-                        with patch.object(mode, "_delete_vpc"):
-                            mode.cleanup_infrastructure()
-
-    @pytest.mark.substrate
-    def test_partial_infrastructure_cleanup(self, substrate_session, file_state_store):
-        """Test partial infrastructure cleanup after some resources fail to delete."""
-        # Create a StandardMode instance
-        provider_id = f"test-provider-{uuid.uuid4().hex[:8]}"
-
-        # Set up mocks for AWS services using substrate
-        with patch("boto3.Session", return_value=substrate_session):
-            # Create a standard mode
-            mode = StandardMode(
-                provider_id=provider_id,
-                session=substrate_session,
-                state_store=file_state_store,
-                region="us-east-1",
-                instance_type="t2.micro",
-                image_id="ami-12345678",  # Dummy AMI
-            )
-
-            # Initialize mode to create basic infrastructure
-            with patch.object(mode, "_create_vpc", return_value="vpc-12345"):
-                with patch.object(mode, "_create_subnet", return_value="subnet-12345"):
-                    with patch.object(
-                        mode, "_create_security_group", return_value="sg-12345"
-                    ):
-                        mode.initialize()
-
-            # Create an instance
-            with patch.object(mode, "_create_ec2_instance") as mock_create_instance:
-                mock_create_instance.return_value = {
-                    "instance_id": "i-12345",
-                    "private_ip": "10.0.0.1",
-                    "public_ip": "54.123.456.789",
-                    "dns_name": "ec2-54-123-456-789.compute-1.amazonaws.com",
-                }
-
-                # Submit a job
-                job_id = f"test-job-{uuid.uuid4().hex[:8]}"
-                resource_id = mode.submit_job(job_id, "echo 'Test job'", 1)
-
-            # Mock instance deletion to fail
-            with patch.object(mode, "_delete_ec2_instance") as mock_delete_instance:
-                mock_delete_instance.side_effect = ResourceDeletionError(
-                    "Instance deletion failed"
-                )
-
-                # Mock the other deletions to succeed
-                with patch.object(mode, "_delete_security_group"):
-                    with patch.object(mode, "_delete_subnet"):
-                        with patch.object(mode, "_delete_vpc"):
-                            # Cleanup should log the error but continue with other resources
-                            with patch("logging.Logger.error") as mock_error:
-                                mode.cleanup_infrastructure()
-
-                                # Verify error was logged
-                                mock_error.assert_called()
-
-            # Even though instance deletion failed, the mode should be marked as not initialized
-            assert not mode.initialized
-            assert mode.vpc_id is None
-            assert mode.subnet_id is None
-            assert mode.security_group_id is None
-
-    @pytest.mark.substrate
-    def test_a_spot_interruption_is_reported_as_a_failure(
-        self, substrate_session, file_state_store
+    def test_a_launch_failure_is_wrapped_and_tracks_nothing(
+        self, substrate_session, substrate_network, state_store
     ):
-        """A reclaim must surface as a failure, not a success.
+        """No half-tracked resource, and the caller gets OperatingModeError.
 
-        This is the error scenario this file is about: AWS takes the capacity
-        away mid-job. What made it dangerous was not that it went unhandled but
-        that it was reported *wrongly* -- a reclaimed instance reaches
-        ``shutting-down``, which ``EC2_STATUS_MAPPING`` renders COMPLETED, so the
-        block claimed success and its tasks were silently dropped rather than
-        re-run under Parsl's ``retries`` (#137).
+        ``InsufficientInstanceCapacity`` is the realistic failure for a launch
+        AWS accepted but could not satisfy. The mode wraps every submit failure
+        in ``OperatingModeError`` -- Parsl's provider contract -- but must not
+        leave a tracking entry for an instance that never existed, or cleanup
+        would later try to terminate it.
         """
-        provider_id = f"test-provider-{uuid.uuid4().hex[:8]}"
-        instance_id = "i-spot-12345"
+        mode = _standard(substrate_session, state_store, substrate_network)
+        try:
+            mode.initialize()
 
-        mode = StandardMode(
-            provider_id=provider_id,
-            session=substrate_session,
-            state_store=file_state_store,
-            region="us-east-1",
-            instance_type="t3.micro",
-            image_id="ami-12345678",
-            vpc_id="vpc-12345",
-            subnet_id="subnet-12345",
-            security_group_id="sg-12345",
+            no_capacity = ClientError(
+                {
+                    "Error": {
+                        "Code": "InsufficientInstanceCapacity",
+                        "Message": "There is no Spot capacity available.",
+                    }
+                },
+                "RunInstances",
+            )
+            with patch.object(mode, "_create_instance", side_effect=no_capacity):
+                with pytest.raises(
+                    OperatingModeError, match="InsufficientInstanceCapacity"
+                ):
+                    mode.submit_job("test-job", "echo hello", 1)
+
+            assert mode.resources == {}
+        finally:
+            mode.cleanup_infrastructure()
+
+    def test_the_mode_still_works_after_a_failed_submit(
+        self, substrate_session, substrate_network, state_store
+    ):
+        """Recovery, which is what this file is about.
+
+        A failed submit must not poison the mode: the next one launches a real
+        instance. Asserted against the emulator rather than the tracking dict,
+        so a submit that recorded a resource without launching anything fails
+        here.
+        """
+        mode = _standard(substrate_session, state_store, substrate_network)
+        try:
+            mode.initialize()
+
+            with patch.object(
+                mode, "_create_instance", side_effect=EC2InstanceError("transient")
+            ):
+                with pytest.raises(OperatingModeError):
+                    mode.submit_job("doomed-job", "echo hello", 1)
+
+            instance_id = mode.submit_job("good-job", "echo hello", 1)
+
+            assert instance_id in mode.resources
+            assert mode.resources[instance_id]["job_id"] == "good-job"
+            assert instance_state(substrate_session, instance_id) in (
+                "pending",
+                "running",
+            )
+        finally:
+            mode.cleanup_infrastructure()
+
+    def test_submitting_before_initialize_is_refused(
+        self, substrate_session, substrate_network, state_store
+    ):
+        """Refused outright rather than launching into an unbuilt mode."""
+        mode = _standard(substrate_session, state_store, substrate_network)
+
+        with pytest.raises(OperatingModeError, match="must be initialized"):
+            mode.submit_job("test-job", "echo hello", 1)
+
+        assert mode.resources == {}
+
+
+class TestBastionFailure:
+    """A bastion that cannot be created, and one that can be on the retry."""
+
+    def test_a_bastion_failure_fails_initialize_and_leaves_no_bastion(
+        self, substrate_session, substrate_network, state_store
+    ):
+        """The failure is wrapped, and the caller's network is untouched.
+
+        ``initialize()`` calls ``cleanup_infrastructure()`` on the way out. That
+        must release what the mode created and nothing else -- the VPC, subnet
+        and security group belong to the caller (#69), and deleting them would
+        be a far worse bug than the failure being recovered from.
+        """
+        mode = _detached(substrate_session, state_store, substrate_network)
+
+        with patch.object(
+            mode,
+            "_create_bastion_direct",
+            side_effect=BastionHostError("Bastion host creation failed"),
+        ):
+            with pytest.raises(ResourceCreationError, match="Bastion host creation"):
+                mode.initialize()
+
+        assert not mode.initialized
+        assert mode.bastion_id is None
+        # The caller's IDs are still set, and still real.
+        assert mode.vpc_id == substrate_network["vpc_id"]
+        assert mode.subnet_id == substrate_network["subnet_id"]
+        assert mode.security_group_id == substrate_network["security_group_id"]
+        substrate_session.client("ec2").describe_vpcs(
+            VpcIds=[substrate_network["vpc_id"]]
+        )
+
+    def test_initialize_succeeds_on_a_retry_after_a_bastion_failure(
+        self, substrate_session, substrate_network, state_store
+    ):
+        """The same mode object recovers, and the bastion really runs.
+
+        This is the recovery the old test claimed to check but could not: it
+        patched a ``_create_bastion_host`` that does not exist, so the mocked
+        return value -- a dict, where the real method returns an instance ID
+        string -- was never compared against anything.
+        """
+        mode = _detached(substrate_session, state_store, substrate_network)
+
+        with patch.object(
+            mode, "_create_bastion_direct", side_effect=BastionHostError("transient")
+        ):
+            with pytest.raises(ResourceCreationError):
+                mode.initialize()
+
+        try:
+            mode.initialize()
+
+            assert mode.initialized
+            assert mode.bastion_id is not None
+            assert instance_state(substrate_session, mode.bastion_id) in (
+                "pending",
+                "running",
+            )
+        finally:
+            bastion_id = mode.bastion_id
+            mode.cleanup_infrastructure()
+
+        # preserve_bastion=False, so it goes with the mode.
+        assert mode.bastion_id is None
+        assert instance_state(substrate_session, bastion_id) in (
+            "shutting-down",
+            "terminated",
+            None,
+        )
+
+
+class TestServerlessFailure:
+    """A Lambda deployment that fails, and what it leaves tracked."""
+
+    def _mode(self, session, state_store, **overrides):
+        """A Lambda-only ServerlessMode.
+
+        No network IDs: Lambda runs in the Lambda-managed VPC and needs none of
+        the three, and ``ServerlessMode`` only enforces the base class's
+        requirement when ECS is reachable.
+        """
+        kwargs = dict(
+            provider_id=f"test-provider-{uuid.uuid4().hex[:8]}",
+            session=session,
+            state_store=state_store,
+            region=session.region_name,
+            worker_type="lambda",
+            lambda_memory=128,
+            lambda_timeout=30,
+        )
+        kwargs.update(overrides)
+        return ServerlessMode(**kwargs)
+
+    def test_a_lambda_deployment_failure_tracks_nothing(
+        self, substrate_session, state_store
+    ):
+        """A failed submit leaves no tracking entry behind.
+
+        The record is created *before* dispatch on purpose -- both submit
+        helpers end by updating it, and creating it afterwards made every submit
+        raise ``KeyError`` from inside a blanket ``except``, leaving a live stack
+        nothing could clean up (#115). So the failure path has to remove it
+        again, which is what this asserts: an entry for a function that was never
+        deployed would make ``cancel``/``status`` report on a resource that does
+        not exist.
+        """
+        mode = self._mode(substrate_session, state_store)
+        mode.initialize()
+
+        with patch.object(
+            mode.lambda_manager,
+            "_generate_lambda_code",
+            side_effect=LambdaFunctionError("Lambda function creation failed"),
+        ):
+            with pytest.raises(OperatingModeError, match="Lambda function creation"):
+                mode.submit_job("test-job", "echo hello", 1)
+
+        assert mode.resources == {}
+
+        mode.cleanup_infrastructure()
+        assert not mode.initialized
+
+    def test_a_lambda_only_mode_needs_no_network(self, substrate_session, state_store):
+        """Initialization succeeds with no VPC, and builds only the Lambda manager.
+
+        Pins the asymmetry the test above depends on: ECS/Fargate requires a
+        subnet and security group for its mandatory ``awsvpcConfiguration``, and
+        Lambda requires none, so the base class's network check is conditional on
+        the worker type.
+        """
+        mode = self._mode(substrate_session, state_store)
+        try:
+            mode.initialize()
+
+            assert mode.initialized
+            assert mode.lambda_manager is not None
+            assert mode.ecs_manager is None
+        finally:
+            mode.cleanup_infrastructure()
+
+
+class TestThrottling:
+    """Retry after an AWS API throttle.
+
+    Tested at the botocore layer because that is the only layer that retries.
+    Nothing in ``modes/`` uses ``error_handling.py`` -- adopting it there is #91,
+    deferred to v0.9.0 -- so the old test's ``patch.object(mode.ec2_manager,
+    "max_retries", 3)`` patched an attribute of an object the mode does not have.
+
+    Substrate cannot be asked to throttle, so the 503 is injected at
+    ``before-send``, which is inside the retry loop: botocore sees a genuine
+    throttled HTTP response and decides for itself whether to re-send.
+    """
+
+    #: What EC2 returns when it sheds load. `RequestLimitExceeded` at HTTP 503 is
+    #: the pair botocore's own retry policy for EC2 matches on -- see the
+    #: `request_limit_exceeded` entry in botocore's `_retry.json`.
+    THROTTLE_BODY = (
+        b'<?xml version="1.0" encoding="UTF-8"?>'
+        b"<Response><Errors><Error><Code>RequestLimitExceeded</Code>"
+        b"<Message>Request limit exceeded.</Message></Error></Errors></Response>"
+    )
+
+    class _RawBytes:
+        """The minimal stream ``AWSResponse.content`` will read from."""
+
+        def __init__(self, data):
+            self._data = data
+
+        def stream(self, **kwargs):
+            yield self._data
+
+    def _throttle_first(self, count):
+        """Return a before-send hook that throttles the first *count* sends.
+
+        The hook also records how many times it ran, which is the attempt count:
+        returning a response short-circuits the send, returning None lets the
+        real request through.
+        """
+        state = {"sends": 0}
+
+        def hook(request, **kwargs):
+            state["sends"] += 1
+            if state["sends"] <= count:
+                return AWSResponse(
+                    request.url, 503, {}, self._RawBytes(self.THROTTLE_BODY)
+                )
+            return None
+
+        return hook, state
+
+    def test_a_throttled_launch_is_retried_and_succeeds(
+        self, substrate_session, substrate_network
+    ):
+        """One throttle, one retry, and a real instance at the end."""
+        ec2 = substrate_session.client("ec2")
+        hook, state = self._throttle_first(1)
+        ec2.meta.events.register_first("before-send.ec2.RunInstances", hook)
+
+        response = ec2.run_instances(
+            ImageId="ami-12345678",
+            InstanceType="t3.micro",
+            MinCount=1,
+            MaxCount=1,
+            NetworkInterfaces=[
+                {
+                    "DeviceIndex": 0,
+                    "SubnetId": substrate_network["subnet_id"],
+                    "Groups": [substrate_network["security_group_id"]],
+                }
+            ],
+        )
+
+        instance_id = response["Instances"][0]["InstanceId"]
+        try:
+            assert state["sends"] == 2, "the throttled send was not retried"
+            assert response["ResponseMetadata"]["RetryAttempts"] == 1
+            assert instance_state(substrate_session, instance_id) in (
+                "pending",
+                "running",
+            )
+        finally:
+            ec2.terminate_instances(InstanceIds=[instance_id])
+
+    def test_sustained_throttling_eventually_surfaces_to_the_caller(
+        self, substrate_session, substrate_network
+    ):
+        """Retry is bounded: it does not mask a throttle that never lets up.
+
+        ``max_attempts=2`` keeps the test quick; the default is 5. What matters
+        is that the attempts are finite and the final failure reaches the caller
+        as ``RequestLimitExceeded`` rather than as a hang or a silent success.
+        """
+        ec2 = substrate_session.client(
+            "ec2", config=Config(retries={"max_attempts": 2, "mode": "legacy"})
+        )
+        hook, state = self._throttle_first(count=99)
+        ec2.meta.events.register_first("before-send.ec2.RunInstances", hook)
+
+        with pytest.raises(ClientError) as excinfo:
+            ec2.run_instances(
+                ImageId="ami-12345678", InstanceType="t3.micro", MinCount=1, MaxCount=1
+            )
+
+        assert excinfo.value.response["Error"]["Code"] == "RequestLimitExceeded"
+        # One initial send plus two retries, then it gives up.
+        assert state["sends"] == 3
+
+
+class TestPartialCleanup:
+    """A cleanup where one deletion fails must still do the rest."""
+
+    def test_a_failed_template_deletion_does_not_stop_cleanup(
+        self, substrate_session, substrate_network, state_store
+    ):
+        """The error is logged, the rest proceeds, and the ID is cleared.
+
+        Clearing it either way is deliberate: a template that could not be
+        deleted must not be referenced by a later launch, and cleanup is not
+        retried.
+        """
+        mode = _standard(substrate_session, state_store, substrate_network)
+        mode.initialize()
+        instance_id = mode.submit_job("test-job", "echo hello", 1)
+        assert mode._launch_template_id is not None
+
+        denied = ClientError(
+            {"Error": {"Code": "UnauthorizedOperation", "Message": "denied"}},
+            "DeleteLaunchTemplate",
+        )
+        with patch(
+            "parsl_ephemeral_aws.modes.standard.delete_launch_template",
+            side_effect=denied,
+        ):
+            with patch("logging.Logger.error") as mock_error:
+                mode.cleanup_infrastructure()
+
+        assert mock_error.called
+        assert mode._launch_template_id is None
+        assert not mode.initialized
+        # The instance was released despite the template failure.
+        assert mode.resources == {}
+        assert instance_state(substrate_session, instance_id) in (
+            "shutting-down",
+            "terminated",
+        )
+
+    def test_an_already_deleted_template_is_not_an_error(
+        self, substrate_session, substrate_network, state_store
+    ):
+        """Cleanup is idempotent, so a resumed provider can run it twice.
+
+        ``InvalidLaunchTemplateId.NotFound`` is swallowed by
+        ``utils/aws.delete_launch_template`` for exactly this case.
+        """
+        mode = _standard(substrate_session, state_store, substrate_network)
+        mode.initialize()
+        template_id = mode._launch_template_id
+
+        # Delete it out from under the mode, as a second cleanup pass or a
+        # concurrent operator would.
+        substrate_session.client("ec2").delete_launch_template(
+            LaunchTemplateId=template_id
+        )
+
+        with patch("logging.Logger.error") as mock_error:
+            mode.cleanup_infrastructure()
+
+        assert not mock_error.called
+        assert not mode.initialized
+
+    def test_a_failed_termination_keeps_the_resource_for_the_next_pass(
+        self, substrate_session, substrate_network, state_store
+    ):
+        """A resource that could not be released must stay tracked.
+
+        Dropping it would orphan a running, billed instance with nothing left
+        pointing at it. ``cleanup_resources`` is called directly rather than
+        through ``cleanup_infrastructure``, which would first spend its three
+        minutes in the ``instance_terminated`` waiter on an instance that, by
+        construction, never terminates.
+        """
+        mode = _standard(substrate_session, state_store, substrate_network)
+        mode.initialize()
+        instance_id = mode.submit_job("test-job", "echo hello", 1)
+
+        real_client = substrate_session.client
+
+        class TerminateDenied:
+            """An EC2 client that refuses only TerminateInstances."""
+
+            def __init__(self, inner):
+                self._inner = inner
+
+            def terminate_instances(self, **kwargs):
+                raise ClientError(
+                    {"Error": {"Code": "UnauthorizedOperation", "Message": "denied"}},
+                    "TerminateInstances",
+                )
+
+            def __getattr__(self, name):
+                return getattr(self._inner, name)
+
+        def denying_client(service_name, **kwargs):
+            client = real_client(service_name, **kwargs)
+            return TerminateDenied(client) if service_name == "ec2" else client
+
+        substrate_session.client = denying_client
+        try:
+            with patch("logging.Logger.error") as mock_error:
+                mode.cleanup_resources([instance_id])
+
+            assert mock_error.called
+            assert instance_id in mode.resources, "a live instance was forgotten"
+        finally:
+            substrate_session.client = real_client
+            mode.cleanup_infrastructure()
+
+    def test_an_instance_already_gone_is_dropped_from_tracking(
+        self, substrate_session, substrate_network, state_store
+    ):
+        """The other half of the removal policy.
+
+        ``InvalidInstanceID.NotFound`` means the instance is gone, so keeping the
+        entry would make every later cleanup pass retry a termination that can
+        never succeed. Only that code is treated this way -- see the test above.
+        """
+        mode = _standard(substrate_session, state_store, substrate_network)
+        mode.initialize()
+        try:
+            ghost = "i-0123456789abcdef0"
+            mode.resources[ghost] = {
+                "type": RESOURCE_TYPE_EC2,
+                "job_id": "vanished-job",
+                "status": "RUNNING",
+            }
+
+            mode.cleanup_resources([ghost])
+
+            assert ghost not in mode.resources
+        finally:
+            mode.cleanup_infrastructure()
+
+
+class TestSpotInterruption:
+    """A reclaim must surface as a failure, not a success."""
+
+    def test_a_spot_interruption_is_reported_as_a_failure(
+        self, substrate_session, substrate_network, state_store
+    ):
+        """The error scenario this file is about: AWS takes the capacity away.
+
+        What made it dangerous was not that it went unhandled but that it was
+        reported *wrongly* -- a reclaimed instance reaches ``shutting-down``,
+        which ``EC2_STATUS_MAPPING`` renders COMPLETED, so the block claimed
+        success and its tasks were silently dropped rather than re-run under
+        Parsl's ``retries`` (#137).
+        """
+        instance_id = "i-spot-12345"
+        mode = _standard(
+            substrate_session,
+            state_store,
+            substrate_network,
             use_spot=True,
             spot_interruption_handling=True,
         )

--- a/tests/integration/test_workflow_state_persistence.py
+++ b/tests/integration/test_workflow_state_persistence.py
@@ -1,415 +1,436 @@
 """Integration tests for state persistence in workflow scenarios.
 
-These tests verify that state persistence works correctly across different
-operating modes and scenarios, including interruptions and resumption.
+Each test runs a real mode against the emulator, saves, builds a *second* mode
+object from the same state store, and asserts the second one knows what the first
+one created. That second object is the whole point: it stands in for a restarted
+driver, and anything it fails to recover is a resource nothing will ever clean up.
+
+The three mode round-trips here used to patch ``_create_vpc``, ``_create_subnet``,
+``_create_security_group``, ``_create_ec2_instance``, ``_create_bastion_host``,
+``_create_ssm_parameter`` and five ``_delete_*`` counterparts. None of those
+methods exists on any mode, so ``patch.object`` raised ``AttributeError`` before
+reaching an assertion -- they described the pre-#69 design, where a mode created
+its own network. The serverless one also called ``mock_open()`` without importing
+it.
+
+Because the mocks never applied, the assertions behind them were never checked,
+and two of them were wrong in a way that matters:
+
+* ``cleanup_infrastructure()`` was expected to leave ``vpc_id``/``subnet_id``/
+  ``security_group_id`` as ``None``. Since #69 those IDs belong to the *caller*;
+  the mode neither creates nor deletes them, and nulling them would make a
+  resumed provider unusable. Verified: they survive cleanup.
+* The state file was expected to be gone or empty after cleanup. Cleanup *saves*
+  -- ``initialized: false`` with an empty ``resources`` map -- because deleting
+  the document is the provider's job at shutdown (``delete_state``), and a
+  cleanup that erased it would strand any resource the pass could not release.
+
+What is asserted instead is what each mode actually persists: the tracking map,
+the launch template (#85), the bastion (#111), and the two ownership flags that
+decide whether cleanup may delete a shared resource (#132, #100).
 
 SPDX-License-Identifier: Apache-2.0
 SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
 """
 
-import os
 import json
+import os
 import time
 import uuid
-import pytest
-import tempfile
 from unittest.mock import patch
 
-from parsl_ephemeral_aws.modes.standard import StandardMode
+import pytest
+
 from parsl_ephemeral_aws.modes.detached import DetachedMode
 from parsl_ephemeral_aws.modes.serverless import ServerlessMode
+from parsl_ephemeral_aws.modes.standard import StandardMode
 from parsl_ephemeral_aws.state.file import FileStateStore
-from tests.substrate_support import (
-    get_substrate_session,
-    is_substrate_available,
-)
+from tests.substrate_support import is_substrate_available
+
+# A marker only *selects* tests; the skipif is what makes a plain
+# `pytest tests/integration` skip rather than error when nothing is listening.
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.substrate,
+    pytest.mark.skipif(
+        not is_substrate_available(),
+        reason="substrate not available - start with 'make substrate-up'",
+    ),
+]
 
 
-# Skip all tests if the substrate emulator is not available
-pytestmark = pytest.mark.skipif(
-    not is_substrate_available(),
-    reason="substrate not available - start with 'make substrate-up'",
-)
+@pytest.fixture
+def provider_id():
+    """The identity a resumed provider is recognized by.
+
+    ``load_state`` ignores any document whose ``provider_id`` differs, so both
+    halves of a round-trip must share this and each test must have its own.
+    """
+    return f"test-provider-{uuid.uuid4().hex[:8]}"
 
 
-@pytest.mark.integration
-class TestWorkflowStatePersistence:
-    """Integration tests for workflow state persistence."""
+@pytest.fixture
+def state_store(tmp_path, provider_id):
+    """A real file-backed store in the test's own directory.
 
-    @pytest.fixture(scope="class")
-    def substrate_session(self):
-        """Create a session connected to substrate."""
-        return get_substrate_session()
+    Real, not mocked: the point of these tests is that a document written by one
+    object can be read by another, and a MagicMock store would satisfy every
+    assertion while serializing nothing. ``state/file.py`` also takes an
+    ``fcntl.flock`` on the handle, which a mock cannot provide -- it raises
+    "fileno() returned a non-integer".
+    """
+    return FileStateStore(
+        file_path=str(tmp_path / "state.json"), provider_id=provider_id
+    )
 
-    @pytest.fixture
-    def temp_dir(self):
-        """Create a temporary directory for state files."""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            yield tmp_dir
 
-    @pytest.fixture
-    def state_file_path(self, temp_dir):
-        """Create a path for the state file."""
-        return os.path.join(temp_dir, f"test-state-{uuid.uuid4().hex[:8]}.json")
+def _saved_mode_state(state_store):
+    """Read the mode's section of the state document straight off disk.
 
-    @pytest.fixture
-    def file_state_store(self, state_file_path):
-        """Create a FileStateStore instance."""
-        provider_id = f"test-provider-{uuid.uuid4().hex[:8]}"
-        return FileStateStore(file_path=state_file_path, provider_id=provider_id)
+    Used where a claim is about the document rather than the restored object --
+    the two can disagree, which is the failure these tests exist to catch.
+    """
+    with open(state_store.file_path) as handle:
+        return json.load(handle)["_states"]["mode"]
 
-    @pytest.fixture
-    def mock_ec2_client(self, substrate_session):
-        """Create a EC2 client connected to substrate."""
-        return substrate_session.client("ec2")
 
-    @pytest.fixture
-    def mock_ssm_client(self, substrate_session):
-        """Create a SSM client connected to substrate."""
-        return substrate_session.client("ssm")
+class TestStandardModeStatePersistence:
+    """StandardMode: what a restarted driver recovers, and what it must not lose."""
 
-    @pytest.fixture
-    def mock_s3_client(self, substrate_session):
-        """Create a S3 client connected to substrate."""
-        return substrate_session.client("s3")
+    def _build(self, session, state_store, provider_id, network, **overrides):
+        kwargs = dict(
+            provider_id=provider_id,
+            session=session,
+            state_store=state_store,
+            region=session.region_name,
+            instance_type="t3.micro",
+            image_id="ami-12345678",
+            vpc_id=network["vpc_id"],
+            subnet_id=network["subnet_id"],
+            security_group_id=network["security_group_id"],
+        )
+        kwargs.update(overrides)
+        return StandardMode(**kwargs)
 
-    @pytest.mark.substrate
-    def test_standard_mode_state_persistence(
-        self, substrate_session, file_state_store, mock_ec2_client
+    def test_resources_and_the_launch_template_survive_a_restart(
+        self, substrate_session, substrate_network, state_store, provider_id
     ):
-        """Test state persistence with StandardMode."""
-        # Create a StandardMode instance
-        provider_id = f"test-provider-{uuid.uuid4().hex[:8]}"
+        """A second mode object recovers the tracking map and the template.
 
-        # Set up mocks for AWS services using substrate
-        with patch("boto3.Session", return_value=substrate_session):
-            # Create a standard mode
-            mode = StandardMode(
-                provider_id=provider_id,
-                session=substrate_session,
-                state_store=file_state_store,
-                region="us-east-1",
-                instance_type="t2.micro",
-                image_id="ami-12345678",  # Dummy AMI
+        The template ID is the load-bearing part: a resumed provider that did not
+        recover it built a second template and leaked the first, since nothing
+        else records it (#85). The instances are real -- ``submit_job`` launches
+        them in the emulator -- so a document that describes them wrongly shows
+        up here rather than in production.
+        """
+        mode = self._build(
+            substrate_session, state_store, provider_id, substrate_network
+        )
+        mode.initialize()
+        resource_ids = [
+            mode.submit_job(f"job-{i}", f"echo 'Job {i}'", 1) for i in range(3)
+        ]
+        assert len(mode.resources) == 3
+        mode.save_state()
+
+        resumed = self._build(
+            substrate_session, state_store, provider_id, substrate_network
+        )
+        try:
+            assert resumed.load_state() is True
+
+            assert resumed.initialized
+            assert set(resumed.resources) == set(resource_ids)
+            for index, resource_id in enumerate(resource_ids):
+                assert resumed.resources[resource_id]["job_id"] == f"job-{index}"
+            # Recovered, not rebuilt: same template, and it still exists.
+            assert resumed._launch_template_id == mode._launch_template_id
+            assert resumed._launch_template_version is not None
+            substrate_session.client("ec2").describe_launch_templates(
+                LaunchTemplateIds=[resumed._launch_template_id]
             )
+        finally:
+            resumed.cleanup_infrastructure()
 
-            # Initialize mode to create basic infrastructure (VPC, etc.)
-            # Mock the actual infrastructure creation
-            with patch.object(mode, "_create_vpc", return_value="vpc-12345"):
-                with patch.object(mode, "_create_subnet", return_value="subnet-12345"):
-                    with patch.object(
-                        mode, "_create_security_group", return_value="sg-12345"
-                    ):
-                        mode.initialize()
+    def test_cleanup_releases_what_the_mode_made_and_keeps_the_rest(
+        self, substrate_session, substrate_network, state_store, provider_id
+    ):
+        """The caller's network outlives the mode; the mode's template does not.
 
-            # Verify mode is initialized
-            assert mode.initialized
-            assert mode.vpc_id == "vpc-12345"
-            assert mode.subnet_id == "subnet-12345"
-            assert mode.security_group_id == "sg-12345"
+        Asserted from the *resumed* object, so ownership is shown to survive
+        persistence: a provider restarted after a crash must still be able to
+        clean up, and must still know which resources are not its to delete.
+        """
+        mode = self._build(
+            substrate_session, state_store, provider_id, substrate_network
+        )
+        mode.initialize()
+        mode.submit_job("job-0", "echo hello", 1)
+        mode.save_state()
+        template_id = mode._launch_template_id
 
-            # Mock job submission
-            with patch.object(mode, "_create_ec2_instance") as mock_create_instance:
-                mock_create_instance.return_value = {
-                    "instance_id": f"i-{uuid.uuid4().hex[:12]}",
-                    "private_ip": "10.0.0.1",
-                    "public_ip": "54.123.456.789",
-                    "dns_name": "ec2-54-123-456-789.compute-1.amazonaws.com",
-                }
+        resumed = self._build(
+            substrate_session, state_store, provider_id, substrate_network
+        )
+        resumed.load_state()
+        resumed.cleanup_infrastructure()
 
-                # Submit some jobs
-                job_ids = []
-                resource_ids = []
-                for i in range(3):
-                    job_id = f"test-job-{i}-{uuid.uuid4().hex[:8]}"
-                    resource_id = mode.submit_job(job_id, f"echo 'Job {i}'", 1)
-                    job_ids.append(job_id)
-                    resource_ids.append(resource_id)
+        assert not resumed.initialized
+        assert resumed.resources == {}
+        assert resumed._launch_template_id is None
 
-            # Verify resources were created
-            assert len(mode.resources) == 3
-            for resource_id in resource_ids:
-                assert resource_id in mode.resources
+        ec2 = substrate_session.client("ec2")
+        templates = ec2.describe_launch_templates()["LaunchTemplates"]
+        assert template_id not in [t["LaunchTemplateId"] for t in templates]
 
-            # Save state
+        # The three IDs were supplied by the caller (#69). The mode did not
+        # create them, so it must not delete them or forget them.
+        assert resumed.vpc_id == substrate_network["vpc_id"]
+        assert resumed.subnet_id == substrate_network["subnet_id"]
+        assert resumed.security_group_id == substrate_network["security_group_id"]
+        ec2.describe_vpcs(VpcIds=[substrate_network["vpc_id"]])
+        ec2.describe_subnets(SubnetIds=[substrate_network["subnet_id"]])
+
+        # Cleanup saves rather than deletes: the document now says "nothing
+        # running", which is what a resumed provider needs to read. Deleting it
+        # is the provider's job at shutdown.
+        saved = _saved_mode_state(state_store)
+        assert saved["initialized"] is False
+        assert saved["resources"] == {}
+        assert saved["launch_template_id"] is None
+
+    def test_another_providers_document_is_not_adopted(
+        self, substrate_session, substrate_network, state_store, provider_id
+    ):
+        """State is keyed by provider ID, so one provider cannot inherit another's.
+
+        Without this guard a second provider sharing a state file would adopt
+        resources it did not create and terminate them on its own shutdown.
+        """
+        mode = self._build(
+            substrate_session, state_store, provider_id, substrate_network
+        )
+        mode.initialize()
+        try:
+            mode.submit_job("job-0", "echo hello", 1)
             mode.save_state()
 
-            # Verify state was saved to file
-            assert os.path.exists(file_state_store.file_path)
-
-            # Create a new mode instance
-            mode2 = StandardMode(
-                provider_id=provider_id,
-                session=substrate_session,
-                state_store=file_state_store,
-                region="us-east-1",
-                instance_type="t2.micro",
-                image_id="ami-12345678",  # Dummy AMI
+            stranger = self._build(
+                substrate_session,
+                state_store,
+                "a-different-provider",
+                substrate_network,
             )
 
-            # Load state
-            mode2.load_state()
+            assert stranger.load_state() is False
+            assert stranger.resources == {}
+            assert not stranger.initialized
+        finally:
+            mode.cleanup_infrastructure()
 
-            # Verify state was loaded correctly
-            assert mode2.initialized
-            assert mode2.vpc_id == "vpc-12345"
-            assert mode2.subnet_id == "subnet-12345"
-            assert mode2.security_group_id == "sg-12345"
-            assert len(mode2.resources) == 3
 
-            # Check that resources were loaded correctly
-            for resource_id in resource_ids:
-                assert resource_id in mode2.resources
-                assert mode2.resources[resource_id]["job_id"] in job_ids
+class TestDetachedModeStatePersistence:
+    """DetachedMode: the bastion and the workflow it serves must both come back."""
 
-            # Clean up - do not actually try to delete AWS resources in the emulator
-            with patch.object(mode2, "_delete_ec2_instance"):
-                with patch.object(mode2, "_delete_security_group"):
-                    with patch.object(mode2, "_delete_subnet"):
-                        with patch.object(mode2, "_delete_vpc"):
-                            mode2.cleanup_infrastructure()
+    def _build(self, session, state_store, provider_id, workflow_id, network):
+        return DetachedMode(
+            provider_id=provider_id,
+            session=session,
+            state_store=state_store,
+            region=session.region_name,
+            instance_type="t3.micro",
+            image_id="ami-12345678",
+            workflow_id=workflow_id,
+            # Not the "cloudformation" default: that path needs an endpoint
+            # substrate does not serve. The direct path uses run_instances, so
+            # the bastion here is a real instance whose fate can be checked.
+            bastion_host_type="direct",
+            bastion_instance_type="t3.micro",
+            preserve_bastion=False,
+            vpc_id=network["vpc_id"],
+            subnet_id=network["subnet_id"],
+            security_group_id=network["security_group_id"],
+        )
 
-            # Verify cleanup logic updated the state
-            assert not mode2.initialized
-            assert mode2.vpc_id is None
-            assert mode2.subnet_id is None
-            assert mode2.security_group_id is None
+    def test_the_bastion_and_workflow_id_survive_a_restart(
+        self, substrate_session, substrate_network, state_store, provider_id
+    ):
+        """Losing either one orphans a running instance.
 
-            # State file should be empty or reflect cleaned state
-            assert (
-                not os.path.exists(file_state_store.file_path)
-                or os.path.getsize(file_state_store.file_path) == 0
-            )
+        The bastion is a long-lived instance the driver does not hold a handle
+        to, and the workflow ID is the SSM prefix its work orders live under -- a
+        resumed provider that recovered neither would launch a second bastion and
+        bill for the first forever.
 
-    @pytest.mark.substrate
-    def test_detached_mode_state_persistence(self, substrate_session, file_state_store):
-        """Test state persistence with DetachedMode."""
-        # Create a DetachedMode instance
-        provider_id = f"test-provider-{uuid.uuid4().hex[:8]}"
+        Both attributes are cleared on the resumed object before loading, so a
+        constructor value cannot masquerade as a restored one.
+        """
         workflow_id = f"test-workflow-{uuid.uuid4().hex[:8]}"
+        mode = self._build(
+            substrate_session, state_store, provider_id, workflow_id, substrate_network
+        )
+        mode.initialize()
+        assert mode.bastion_id is not None
 
-        # Set up mocks for AWS services using substrate
-        with patch("boto3.Session", return_value=substrate_session):
-            # Create a detached mode
-            mode = DetachedMode(
-                provider_id=provider_id,
-                session=substrate_session,
-                state_store=file_state_store,
-                region="us-east-1",
-                instance_type="t2.micro",
-                image_id="ami-12345678",  # Dummy AMI
-                workflow_id=workflow_id,
-                bastion_instance_type="t2.micro",
-                bastion_host_type="direct",
-            )
+        resource_ids = [
+            mode.submit_job(f"job-{i}", f"echo 'Job {i}'", 1) for i in range(3)
+        ]
+        # The bastion is tracked alongside the jobs, so it is cleaned up with them.
+        assert len(mode.resources) == len(resource_ids) + 1
+        mode.save_state()
 
-            # Initialize mode - mock infrastructure creation
-            with patch.object(mode, "_create_vpc", return_value="vpc-12345"):
-                with patch.object(mode, "_create_subnet", return_value="subnet-12345"):
-                    with patch.object(
-                        mode, "_create_security_group", return_value="sg-12345"
-                    ):
-                        with patch.object(
-                            mode, "_create_bastion_host"
-                        ) as mock_create_bastion:
-                            mock_create_bastion.return_value = {
-                                "instance_id": f"i-bastion-{uuid.uuid4().hex[:8]}",
-                                "private_ip": "10.0.0.2",
-                                "public_ip": "54.123.456.789",
-                                "dns_name": "ec2-54-123-456-789.compute-1.amazonaws.com",
-                            }
-                            mode.initialize()
+        # The work orders the bastion polls are in SSM, keyed by workflow ID --
+        # which is why losing that ID is as bad as losing the instance.
+        ssm = substrate_session.client("ssm")
+        job_id = mode.resources[resource_ids[0]]["job_id"]
+        order = json.loads(
+            ssm.get_parameter(Name=f"/parsl/workflows/{workflow_id}/jobs/{job_id}")[
+                "Parameter"
+            ]["Value"]
+        )
+        assert order["command"] == "echo 'Job 0'"
 
-            # Verify mode is initialized with bastion
-            assert mode.initialized
-            assert mode.vpc_id == "vpc-12345"
-            assert mode.subnet_id == "subnet-12345"
-            assert mode.security_group_id == "sg-12345"
-            assert mode.bastion_id is not None
+        resumed = self._build(
+            substrate_session, state_store, provider_id, workflow_id, substrate_network
+        )
+        resumed.bastion_id = None
+        resumed.workflow_id = "never-restored"
 
-            # Mock job submission
-            with patch.object(mode, "_create_ec2_instance") as mock_create_instance:
-                mock_create_instance.return_value = {
-                    "instance_id": f"i-{uuid.uuid4().hex[:12]}",
-                    "private_ip": "10.0.0.5",
-                    "public_ip": None,  # No public IP in detached mode
-                    "dns_name": None,
-                }
+        assert resumed.load_state() is True
+        assert resumed.initialized
+        assert resumed.bastion_id == mode.bastion_id
+        assert resumed.workflow_id == workflow_id
+        assert set(resumed.resources) == set(mode.resources)
 
-                # Mock SSM parameter creation
-                with patch.object(mode, "_create_ssm_parameter"):
-                    # Submit some jobs
-                    job_ids = []
-                    resource_ids = []
-                    for i in range(3):
-                        job_id = f"test-job-{i}-{uuid.uuid4().hex[:8]}"
-                        resource_id = mode.submit_job(job_id, f"echo 'Job {i}'", 1)
-                        job_ids.append(job_id)
-                        resource_ids.append(resource_id)
+        resumed.cleanup_infrastructure()
 
-            # Verify resources were created
-            assert len(mode.resources) == 3
-            for resource_id in resource_ids:
-                assert resource_id in mode.resources
+        assert not resumed.initialized
+        assert resumed.bastion_id is None
+        assert resumed.resources == {}
+        # preserve_bastion=False, so the instance really goes.
+        described = substrate_session.client("ec2").describe_instances(
+            InstanceIds=[mode.bastion_id]
+        )
+        state = described["Reservations"][0]["Instances"][0]["State"]["Name"]
+        assert state in ("shutting-down", "terminated")
+        # And the caller's network is untouched, as in standard mode.
+        assert resumed.vpc_id == substrate_network["vpc_id"]
 
-            # Save state
-            mode.save_state()
 
-            # Verify state was saved to file
-            assert os.path.exists(file_state_store.file_path)
+class TestServerlessModeStatePersistence:
+    """ServerlessMode: the code bucket, and who is allowed to delete it."""
 
-            # Create a new mode instance
-            mode2 = DetachedMode(
-                provider_id=provider_id,
-                session=substrate_session,
-                state_store=file_state_store,
-                region="us-east-1",
-                instance_type="t2.micro",
-                image_id="ami-12345678",  # Dummy AMI
-                workflow_id=workflow_id,
-                bastion_instance_type="t2.micro",
-                bastion_host_type="direct",
-            )
+    def _build(self, session, state_store, provider_id, **overrides):
+        kwargs = dict(
+            provider_id=provider_id,
+            session=session,
+            state_store=state_store,
+            region=session.region_name,
+            # Lambda needs none of the three network IDs, so this is also the one
+            # mode that can be exercised without a VPC.
+            worker_type="lambda",
+            lambda_memory=128,
+            lambda_timeout=30,
+        )
+        kwargs.update(overrides)
+        return ServerlessMode(**kwargs)
 
-            # Load state
-            mode2.load_state()
-
-            # Verify state was loaded correctly
-            assert mode2.initialized
-            assert mode2.vpc_id == "vpc-12345"
-            assert mode2.subnet_id == "subnet-12345"
-            assert mode2.security_group_id == "sg-12345"
-            assert mode2.bastion_id is not None
-            assert len(mode2.resources) == 3
-
-            # Check that resources were loaded correctly
-            for resource_id in resource_ids:
-                assert resource_id in mode2.resources
-                assert mode2.resources[resource_id]["job_id"] in job_ids
-
-            # Clean up
-            with patch.object(mode2, "_delete_ec2_instance"):
-                with patch.object(mode2, "_delete_ssm_parameter"):
-                    with patch.object(mode2, "_delete_security_group"):
-                        with patch.object(mode2, "_delete_subnet"):
-                            with patch.object(mode2, "_delete_vpc"):
-                                mode2.preserve_bastion = (
-                                    False  # Ensure bastion is cleaned up
-                                )
-                                mode2.cleanup_infrastructure()
-
-            # Verify cleanup logic updated the state
-            assert not mode2.initialized
-            assert mode2.vpc_id is None
-            assert mode2.subnet_id is None
-            assert mode2.security_group_id is None
-            assert mode2.bastion_id is None
-
-    @pytest.mark.substrate
-    def test_serverless_mode_state_persistence(
-        self, substrate_session, file_state_store
+    def test_a_bucket_the_mode_created_is_deleted_after_a_restart(
+        self, substrate_session, state_store, provider_id
     ):
-        """Test state persistence with ServerlessMode."""
-        # Create a ServerlessMode instance
-        provider_id = f"test-provider-{uuid.uuid4().hex[:8]}"
+        """Ownership has to survive persistence or the bucket leaks.
 
-        # Set up mocks for AWS services using substrate
-        with patch("boto3.Session", return_value=substrate_session):
-            # Create a serverless mode
-            mode = ServerlessMode(
-                provider_id=provider_id,
-                session=substrate_session,
-                state_store=file_state_store,
-                region="us-east-1",
-                worker_type="lambda",  # Use Lambda for simplicity
-                lambda_memory=128,
-                lambda_timeout=30,
+        ``_owns_lambda_code_bucket`` is set at creation time, in memory. A driver
+        that restarted between the create and the shutdown would clean up with
+        the flag back at its ``False`` default and leave the bucket standing --
+        so the flag is persisted, and this asserts the resumed object acts on it.
+
+        ``_submit_lambda_job`` is patched out because dispatch goes through
+        CloudFormation, which substrate does not serve. The tracking record is
+        written by ``submit_job`` before dispatch (#115), which is the part under
+        test here.
+        """
+        mode = self._build(substrate_session, state_store, provider_id)
+        mode.initialize()
+
+        with patch.object(mode, "_submit_lambda_job"):
+            resource_ids = [
+                mode.submit_job(f"job-{i}", f"echo 'Job {i}'", 1) for i in range(3)
+            ]
+        bucket = mode._ensure_lambda_code_bucket()
+        assert mode._owns_lambda_code_bucket is True
+        mode.save_state()
+
+        resumed = self._build(substrate_session, state_store, provider_id)
+        assert resumed._lambda_code_bucket is None
+        assert resumed._owns_lambda_code_bucket is False
+
+        assert resumed.load_state() is True
+        assert resumed.initialized
+        assert set(resumed.resources) == set(resource_ids)
+        for index, resource_id in enumerate(resource_ids):
+            record = resumed.resources[resource_id]
+            assert record["job_id"] == f"job-{index}"
+            # The routing decision is in the document because it determines
+            # whether the network IDs were required at all (#118).
+            assert record["worker_type"] == "lambda"
+        assert resumed._lambda_code_bucket == bucket
+        assert resumed._owns_lambda_code_bucket is True
+
+        resumed.cleanup_infrastructure()
+
+        assert not resumed.initialized
+        assert resumed.resources == {}
+        buckets = [
+            b["Name"] for b in substrate_session.client("s3").list_buckets()["Buckets"]
+        ]
+        assert bucket not in buckets
+
+    def test_a_bucket_the_caller_supplied_survives_cleanup(
+        self, substrate_session, state_store, provider_id
+    ):
+        """The other side of the gate, and the reason it exists.
+
+        A caller-supplied bucket may hold more than this provider's code, and
+        deleting it would destroy data the provider never owned -- the same
+        hazard class as the shared security group deleted in #100. Checked
+        through a restart, because that is where ownership is easiest to lose.
+        """
+        s3 = substrate_session.client("s3")
+        bucket = f"caller-owned-{uuid.uuid4().hex[:8]}"
+        s3.create_bucket(
+            Bucket=bucket,
+            CreateBucketConfiguration={
+                "LocationConstraint": substrate_session.region_name
+            },
+        )
+        try:
+            mode = self._build(
+                substrate_session, state_store, provider_id, lambda_code_bucket=bucket
             )
-
-            # Initialize mode - Lambda-only mode won't create network resources
             mode.initialize()
-
-            # Verify mode is initialized
-            assert mode.initialized
-
-            # Lambda mode should not create VPC resources
-            assert mode.vpc_id is None
-            assert mode.subnet_id is None
-            assert mode.security_group_id is None
-
-            # Mock Lambda function creation and invocation
-            with patch.object(
-                mode.lambda_manager, "_create_lambda_function"
-            ) as mock_create_lambda:
-                mock_create_lambda.return_value = {
-                    "FunctionName": f"lambda-{uuid.uuid4().hex[:8]}",
-                    "FunctionArn": f"arn:aws:lambda:us-east-1:123456789012:function:lambda-{uuid.uuid4().hex[:8]}",
-                }
-
-                with patch.object(mode.lambda_manager, "_invoke_lambda") as mock_invoke:
-                    mock_invoke.return_value = {
-                        "StatusCode": 200,
-                        "Payload": json.dumps({"statusCode": 200, "body": "Success"}),
-                    }
-
-                    # Submit some jobs
-                    job_ids = []
-                    resource_ids = []
-                    for i in range(3):
-                        job_id = f"test-job-{i}-{uuid.uuid4().hex[:8]}"
-
-                        # Mock writing to temp file for Lambda code
-                        with patch("builtins.open", mock_open()):
-                            resource_id = mode.submit_job(job_id, f"echo 'Job {i}'", 1)
-                            job_ids.append(job_id)
-                            resource_ids.append(resource_id)
-
-            # Verify resources were created
-            assert len(mode.resources) == 3
-            for resource_id in resource_ids:
-                assert resource_id in mode.resources
-
-            # Save state
+            assert mode._ensure_lambda_code_bucket() == bucket
+            assert mode._owns_lambda_code_bucket is False
             mode.save_state()
 
-            # Verify state was saved to file
-            assert os.path.exists(file_state_store.file_path)
-
-            # Create a new mode instance
-            mode2 = ServerlessMode(
-                provider_id=provider_id,
-                session=substrate_session,
-                state_store=file_state_store,
-                region="us-east-1",
-                worker_type="lambda",
-                lambda_memory=128,
-                lambda_timeout=30,
+            resumed = self._build(
+                substrate_session, state_store, provider_id, lambda_code_bucket=bucket
             )
+            assert resumed.load_state() is True
+            assert resumed._owns_lambda_code_bucket is False
 
-            # Load state
-            mode2.load_state()
+            resumed.cleanup_infrastructure()
 
-            # Verify state was loaded correctly
-            assert mode2.initialized
-            assert len(mode2.resources) == 3
+            assert bucket in [b["Name"] for b in s3.list_buckets()["Buckets"]]
+        finally:
+            s3.delete_bucket(Bucket=bucket)
 
-            # Check that resources were loaded correctly
-            for resource_id in resource_ids:
-                assert resource_id in mode2.resources
-                assert mode2.resources[resource_id]["job_id"] in job_ids
-                assert mode2.resources[resource_id]["worker_type"] == "lambda"
 
-            # Clean up
-            with patch.object(mode2.lambda_manager, "_delete_lambda_function"):
-                mode2.cleanup_infrastructure()
+class TestInterruptionPersistence:
+    """A reclaim marker must outlive the driver that recorded it."""
 
-            # Verify cleanup logic updated the state
-            assert not mode2.initialized
-            assert len(mode2.resources) == 0
-
-    @pytest.mark.substrate
     def test_an_interruption_survives_a_restart(
-        self, substrate_session, file_state_store
+        self, substrate_session, substrate_network, state_store, provider_id
     ):
         """An interrupted block must still read as interrupted after a restart.
 
@@ -427,20 +448,19 @@ class TestWorkflowStatePersistence:
         re-run the tasks -- checked across the persistence boundary this file
         exists to cover.
         """
-        provider_id = f"test-provider-{uuid.uuid4().hex[:8]}"
         instance_id = f"i-spot-{uuid.uuid4().hex[:12]}"
 
         def build_mode():
             return StandardMode(
                 provider_id=provider_id,
                 session=substrate_session,
-                state_store=file_state_store,
-                region="us-east-1",
+                state_store=state_store,
+                region=substrate_session.region_name,
                 instance_type="t3.micro",
                 image_id="ami-12345678",
-                vpc_id="vpc-12345",
-                subnet_id="subnet-12345",
-                security_group_id="sg-12345",
+                vpc_id=substrate_network["vpc_id"],
+                subnet_id=substrate_network["subnet_id"],
+                security_group_id=substrate_network["security_group_id"],
                 use_spot=True,
                 spot_interruption_handling=True,
             )
@@ -493,3 +513,15 @@ class TestWorkflowStatePersistence:
         finally:
             if mode2.spot_interruption_monitor:
                 mode2.spot_interruption_monitor.stop_monitoring()
+
+
+def test_the_state_file_lives_where_the_caller_put_it(state_store, tmp_path):
+    """A sanity check on the fixture the whole file depends on.
+
+    If the store wrote somewhere else, every round-trip above would still pass by
+    reading back an object it never persisted.
+    """
+    state_store.save_state("mode", {"provider_id": state_store.provider_id})
+
+    assert os.path.dirname(state_store.file_path) == str(tmp_path)
+    assert os.path.exists(state_store.file_path)

--- a/tests/substrate_support.py
+++ b/tests/substrate_support.py
@@ -173,19 +173,25 @@ def get_substrate_resource(
     return session.resource(service_name, endpoint_url=endpoint)
 
 
-def setup_substrate_vpc() -> Dict[str, str]:
+def setup_substrate_vpc(session: Optional[boto3.Session] = None) -> Dict[str, str]:
     """Provision a VPC, subnet, gateway, route table and security group.
 
     Since #69 the provider creates no network resources, so every mode requires
     ``vpc_id``/``subnet_id``/``security_group_id`` to exist beforehand. This is
     what supplies them in the emulator.
 
+    Pass ``session`` when the caller has one, so the resources land in the region
+    that session uses. Substrate partitions by region, and the default here is
+    ``us-east-1`` while the suite's ``AWS_TEST_REGION`` defaults to ``us-west-2``
+    -- creating in one and describing from the other reports the resource as
+    missing immediately after it was created successfully.
+
     The subnet's availability zone is read from ``describe_availability_zones``
     rather than built as ``f"{region}a"``: that string is a guess about zone
     naming, and a wrong guess is how the real-AWS suite ended up pinned to a zone
     that does not offer ``t3.micro``.
     """
-    ec2 = get_substrate_client("ec2")
+    ec2 = get_substrate_client("ec2", session=session)
 
     def tag(resource_id: str, name: str) -> None:
         ec2.create_tags(
@@ -269,17 +275,20 @@ def setup_substrate_vpc() -> Dict[str, str]:
     }
 
 
-def cleanup_substrate_vpc(vpc_id: str) -> None:
+def cleanup_substrate_vpc(vpc_id: str, session: Optional[boto3.Session] = None) -> None:
     """Delete a VPC and everything attached to it, best-effort.
 
     Every step is individually guarded: this runs in teardown, where raising
     would mask the actual test result. Order matters — dependents before
     dependencies, or the VPC delete fails with ``DependencyViolation``.
 
+    Pass the same ``session`` used to create the VPC — see
+    :func:`setup_substrate_vpc` on why the region has to match.
+
     Prefer :func:`reset_substrate_state` where the whole emulator can be wiped;
     this exists for tests that share a server with others.
     """
-    ec2 = get_substrate_client("ec2")
+    ec2 = get_substrate_client("ec2", session=session)
 
     try:
         vpcs = ec2.describe_vpcs(VpcIds=[vpc_id]).get("Vpcs")


### PR DESCRIPTION
Baseline on `main` was **33 failed / 8 errors / 43 passed / 3 skipped**. This
branch takes `tests/integration` to **129 passed / 1 skipped / 1 xfailed**.

Reopens the work from #160, which GitHub auto-closed when its base branch
(`fix/phase-c-fleet-error-history`) was deleted on merge. Rebased onto `main`
with no conflicts; contents are unchanged apart from the rebase.

## Why the suite was red

Not one cause. Six families, and most of them were tests written against a
design the package never had:

1. **No injection seam (9 constructions).** Tests passed `_test_session=` and
   `_test_state_store=` — kwargs that **never existed**. `git log -S"_test_session"
   -- parsl_ephemeral_aws/` is empty. Since #105 rejects unknown kwargs they
   became hard errors. Fixed on the package side: `endpoint_url` is now a real
   provider option, threaded to `create_session()` (which already accepted it).
   That is useful public API — VPC endpoints, FIPS endpoints, emulators — not a
   test hook.
2. **MagicMock reaching real I/O (40).** `gzip.BadGzipFile` from the Lambda zip
   path and `fileno() returned a non-integer` from `fcntl.flock` on a mocked
   handle. Replaced with the real `substrate_session` fixture and a real
   `tmp_path` state file.
3. **Missing network IDs (14).** What #92 describes: `vpc_id, subnet_id, and
   security_group_id are required` since #69.
4. **#136-blocked options (9).** Fixed by Phase B, now on `main`. Two were
   test-side typos: `launcher` (not a provider option) and `state_store`.
5. **`FileStateStore(file_path=...)` (6).** Omitted the required `provider_id`.
6. **CloudFormation not emulated (4).** `DetachedMode`'s bastion is a CFN stack,
   so these now **skip** rather than fail — real-AWS coverage lives in `tests/aws/`.

## The package defect this found (#159)

`StandardMode.__init__` builds an inline `SimpleProvider` stand-in to hand to
`SpotFleetManager`, and it omitted `session`. `resolve_manager_session()` prefers
`provider.session` and otherwise **builds one from ambient environment
credentials** — so every Spot Fleet `StandardMode` created went to the account
the environment named (`https://ec2.us-west-2.amazonaws.com`) while the rest of
the mode used the caller's (`http://localhost:4566`). Measured, not inferred.

Same class as #117, which fixed this everywhere the provider passes `self`. This
stand-in is built inline, so it was missed. The only prior fleet integration test
constructed `SpotFleetManager` directly and rebound its clients by hand — which
masked exactly this.

`test_the_fleet_manager_inherits_the_modes_session` is the regression test.

## What the multi-node rewrite pins

`tests/integration/test_multinode_workflows.py` was 599 lines of dead mocks
asserting a launcher that does not exist. Before rewriting it I measured all four
`nodes_per_block` paths live against substrate:

| path | effect of `nodes_per_block=4` |
|---|---|
| StandardMode + `use_spot_fleet=True` | fleet `TotalTargetCapacity = 4` |
| StandardMode single-instance | **1** — `_create_instance` hardcodes `MinCount=1, MaxCount=1` |
| ServerlessMode ECS + fleet | 4, via its own `_create_job_fleet` |
| DetachedMode | written into the SSM work order; the *bastion* acts on it |

So `nodes_per_block` has exactly one effect in this package: an EC2 Fleet's
target capacity. There is **no launcher concept** (`grep -rn launcher
parsl_ephemeral_aws/` → zero hits), so MPI does not work, and
`test_a_launcher_is_not_a_provider_option` pins the `ProviderConfigurationError`
instead of pretending otherwise.

## Verification

```
tests/integration          129 passed, 1 skipped, 1 xfailed
tests/unit tests/security  1138 passed, 2 skipped
ruff check                 clean
mypy                       76 errors (baseline unchanged)
```

The one skip is CloudFormation-not-emulated. The one xfail is substrate#446
(`PUT ?publicAccessBlock` routed to `CreateBucket`), which leaves
`S3State(create_bucket_if_not_exists=True)` uncovered against real S3 — noted
rather than papered over.

Two substrate gaps surfaced along the way and are filed upstream: substrate#443,
substrate#444, substrate#446.