### PR TITLE
ci: sweep the five genuine dependabot action bumps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
       - name: Sync environment
@@ -52,8 +52,8 @@ jobs:
   type-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
       - name: Sync environment
@@ -74,8 +74,8 @@ jobs:
         # matrix entries could not have installed the package at all.
         python-version: ["3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
@@ -100,7 +100,7 @@ jobs:
         # letting coverage silently rot.
         run: uv run pytest tests/unit tests/security -v --cov-fail-under=65
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           files: ./coverage.xml
           flags: unittests
@@ -131,8 +131,8 @@ jobs:
         # see into the container's PATH assumptions reliably. The wait step below
         # polls from the runner instead, where curl is guaranteed.
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
       - name: Sync environment
@@ -163,7 +163,7 @@ jobs:
           SUBSTRATE_ENDPOINT: http://localhost:4566
         run: uv run pytest tests/test_substrate_emulation.py -v --no-cov
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           files: ./coverage.xml
           flags: integration
@@ -183,14 +183,14 @@ jobs:
       id-token: write      # OIDC, so no long-lived keys live in secrets
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
       - name: Sync environment
         run: uv sync --locked --extra dev --extra test
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_E2E_ROLE_ARN }}
           aws-region: ${{ vars.AWS_TEST_REGION }}
@@ -213,7 +213,7 @@ jobs:
   test-bats:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up bats
         # `sudo` applied to the npm line only, so `mkdir -p /usr/local/lib/bats`
         # ran unprivileged and the step died on "Permission denied" once the
@@ -236,8 +236,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint, unit-tests]
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
       - name: Build package
@@ -250,7 +250,7 @@ jobs:
         run: |
           python -m zipfile -l dist/*.whl | grep -q 'templates/cloudformation/' \
             || { echo "::error::CloudFormation templates missing from wheel"; exit 1; }
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
@@ -259,8 +259,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint, unit-tests]
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
       - name: Sync environment
@@ -270,7 +270,7 @@ jobs:
         # #124, which hid ~65 toctree entries pointing at pages nobody had
         # written. Zero now, so keep it that way.
         run: uv run make -C docs html SPHINXOPTS="-W"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: documentation
           path: docs/_build/html/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,11 +18,11 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unreferenced by anything (refs #93).
 
 ### Changed
+- CI actions updated: `actions/checkout` and `actions/upload-artifact` to v7,
+  `astral-sh/setup-uv` to v7, `codecov/codecov-action` to v7, and
+  `aws-actions/configure-aws-credentials` to v6. Swept in one commit rather than
+  merged individually so a dependency bump cannot be mistaken for a functional
+  regression. `configure-aws-credentials` v6 is safe here because the
+  `aws-e2e-tests` job already declares `id-token: write` and assumes a role via
+  OIDC instead of using long-lived keys.
 - **Lint and format now cover the whole repository** rather than
   `parsl_ephemeral_aws tests`. The 107 pre-existing ruff errors that forced the
   narrower scope lived entirely in the `tools/` scripts removed above, so


### PR DESCRIPTION
Sweeps the five genuine dependabot action bumps into one PR, per the v0.8.0 plan — so a
dependency bump cannot be confused with a functional regression. Supersedes #140, #141,
#142, #143, #145.

| Action | From | To | PR |
|---|---|---|---|
| `actions/checkout` | v4 | **v7** | #141 |
| `actions/upload-artifact` | v4 | **v7** | #140 |
| `astral-sh/setup-uv` | v5 | **v7** | #142 |
| `codecov/codecov-action` | v5 | **v7** | #143 |
| `aws-actions/configure-aws-credentials` | v4 | **v6** | #145 |

## Checked, not assumed

These are major-version jumps, so each was verified against how this repo actually uses it:

- **Every target tag resolves** (`gh api repos/<action>/git/ref/tags/<tag>`).
- **`upload-artifact` v7** — only `name` and `path` are passed, both stable across v4→v7.
- **`codecov-action` v7** — only `files`, `flags`, and `name` are passed; both call sites
  are `continue-on-error: true`, so a codecov change cannot fail the build regardless.
- **`setup-uv` v7** — still accepts `enable-cache` (all seven call sites) and
  `python-version` (the unit-test matrix); confirmed against the action's own `action.yml`.
- **`configure-aws-credentials` v6** — safe because the `aws-e2e-tests` job already declares
  `id-token: write` and assumes `secrets.AWS_E2E_ROLE_ARN` via OIDC rather than using
  long-lived access keys, which is what v5+ requires by default.

## The other eight dependabot PRs were closed, not merged

Working #93 turned up why the queue was so long: **dependabot was maintaining a dependency
set that does not exist.**

- **#144, #146, #147, #148, #149, #150** each edited only `requirements.txt`, deleted in #93
  (`5b8a8df`). That file pinned `black`, `aws-cdk-lib`, `pydantic`, `typeguard`,
  `types-boto3`, and `tf-ecosystem` — none of which this project depends on or imports.
  `.github/dependabot.yml` now tracks the **`uv`** ecosystem, which reads `pyproject.toml`
  and updates the committed `uv.lock` (what every job installs from via `uv sync --locked`).
- **#3** targeted `.github/workflows/ci-cd.yml`, which no longer exists, and an action
  (`peaceiris/actions-gh-pages`) referenced nowhere.
- **#7** bumped `actions/setup-python`, which appears nowhere in `.github/` — this project
  uses `astral-sh/setup-uv` per the uv-only rule.

## Verification

CI is the verification for this one: the change *is* the CI configuration, so a green run
across all jobs — including the `build` and `docs` jobs that use `upload-artifact`, and the
codecov uploads — is the evidence. `aws-e2e-tests` remains `workflow_dispatch`-only, so the
`configure-aws-credentials` v6 bump is **not** exercised by this run; that is called out
rather than glossed, and #161 covers that job's separate no-op problem.
