### PR TITLE
chore: release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   these as literals; the new detached-only guard has to compare against the real
   defaults, and a guard repeating the numbers would stop firing the moment one
   changed (refs #136).
+- `ServerlessMode` accepts `lambda_code_bucket`, an existing S3 bucket to stage
+  Lambda deployment packages in. This is the surviving half of `checkpoint_bucket`
+  removed above: alongside gating the interruption monitor, it also overrode the
+  code-staging bucket, and that half was real. A caller-supplied bucket is reused
+  as-is and never deleted (`_owns_lambda_code_bucket` stays `False`, which is what
+  protects it); omit it and a provider-scoped bucket is created on first use and
+  removed by `cleanup_infrastructure()` (refs #137).
+- `GlobusComputeProvider` accepts `encrypted` (default `False`), and defaults
+  `worker_init` to a script that installs `globus-compute-endpoint` rather than
+  inheriting the `parsl`-only default. Both are part of #138 above.
+- An autouse `tests/conftest.py` guard fails any test that leaves a
+  default-named state file in the working directory or the repository root,
+  naming the test and the fix. Gitignoring the path was the alternative and was
+  rejected: it would have silenced the symptom while tests kept writing outside
+  their sandbox. The watched filename is read from the `state_file_path` signature
+  default rather than hardcoded, so renaming the default cannot quietly disable
+  the check (refs #93).
+- **Real-AWS E2E coverage for the warm pool**, `tests/aws/test_warm_pool_e2e.py`,
+  which had none. Every property the pool is sold on is a live-AWS property that
+  a mock asserts by construction: that SSM `SendCommand` actually reached the
+  instance, that no *second* `RunInstances` was issued, that `worker_init` did not
+  run again, and that a WARM instance — a **billed**, running instance — is
+  terminated by TTL expiry, by pool-full eviction, and by `shutdown()`.
+
+  The reuse and eviction tests count instances by the `E2ETestRunId` tag applied
+  in the launch's own `TagSpecifications`, so an instance cannot exist for the run
+  without being counted. `worker_init` is a file append rather than the
+  Parsl-installing default, both to keep the suite's runtime workable and to make
+  "ran once, job ran twice" readable off the instance over SSM.
+  `test_status_follows_the_ssm_command_not_the_instance_state` is the one that
+  cannot be faked another way: on the warm path the instance stays `running`
+  whether the command succeeded or failed, so a FAILED verdict can only have come
+  from the invocation's response code (closes #65).
 
 ### Changed
 - **`DEFAULT_LAMBDA_RUNTIME` is `python3.12`, was `python3.9`** — past end of
@@ -49,6 +82,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   it waits for an invocation event instead of running the task's `Command`, and
   Fargate tasks exited immediately. The CloudFormation template already defaulted
   to a plain Python image; the Python constant overrode it (refs #136).
+- CI actions updated: `actions/checkout` and `actions/upload-artifact` to v7,
+  `astral-sh/setup-uv` to v7, `codecov/codecov-action` to v7, and
+  `aws-actions/configure-aws-credentials` to v6. Swept in one commit rather than
+  merged individually so a dependency bump cannot be mistaken for a functional
+  regression. `configure-aws-credentials` v6 is safe here because the
+  `aws-e2e-tests` job already declares `id-token: write` and assumes a role via
+  OIDC instead of using long-lived keys.
+- **Lint and format now cover the whole repository** rather than
+  `parsl_ephemeral_aws tests`. The 107 pre-existing ruff errors that forced the
+  narrower scope lived entirely in the `tools/` scripts removed above, so
+  `ruff check .` and `ruff format --check .` both pass and nothing outside the
+  package can drift unchecked. Applied in CI, the Makefile, and `make format`
+  (refs #93).
+- Six README links pointed into deleted `tools/` files — the examples table, the
+  documentation list, the quickstart, and the status badge. They now point at
+  `examples/` and `docs/`, which are maintained. While there, the Development
+  Setup block was using `pyenv`, `python -m venv`, and `pip install`, all three
+  forbidden by the project's uv-only rule, and told the reader to clone
+  `your-org/parsl-aws-provider` (refs #93).
+- `scripts/setup_environment.sh` checked for Python 3.9, two releases below the
+  `requires-python = ">=3.10"` that Parsl 2026.x forces. Its bats mock reported
+  3.9 to match, so the pair agreed with each other and with nothing else
+  (refs #93).
+- **Dependabot tracks the `uv` ecosystem instead of `pip`.** Its pip updates read
+  the `requirements.txt` removed above, and that file pinned `black`,
+  `aws-cdk-lib`, `pydantic`, `typeguard`, `types-boto3`, and `tf-ecosystem` —
+  none of which the project depends on or imports. All six open pip pull requests
+  were bumping a dependency set that does not exist. The `uv` ecosystem reads
+  `pyproject.toml` and updates the committed `uv.lock`, which is what every CI
+  job installs from via `uv sync --locked` (refs #93).
+- `examples/serverless_mode.py` told readers the Fargate image was fixed at
+  `public.ecr.aws/lambda/python:3.9` and that Lambda was therefore the better
+  choice — both halves now wrong, since `ecs_container_image` is reachable and
+  the default is `python:3.12-slim`. Its ECS branch passes
+  `ecs_container_image`, `ecs_task_cpu`, and `ecs_task_memory` so the example
+  demonstrates them rather than only naming them (refs #136).
 
 ### Removed
 - **The spot task-recovery API, which could not work at this layer and never
@@ -97,44 +166,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (refs #93).
 - `PHASE1_SUCCESS_PROOF.md` and `README_PHASE1.md` — standalone status documents,
   unreferenced by anything (refs #93).
-
-### Changed
-- CI actions updated: `actions/checkout` and `actions/upload-artifact` to v7,
-  `astral-sh/setup-uv` to v7, `codecov/codecov-action` to v7, and
-  `aws-actions/configure-aws-credentials` to v6. Swept in one commit rather than
-  merged individually so a dependency bump cannot be mistaken for a functional
-  regression. `configure-aws-credentials` v6 is safe here because the
-  `aws-e2e-tests` job already declares `id-token: write` and assumes a role via
-  OIDC instead of using long-lived keys.
-- **Lint and format now cover the whole repository** rather than
-  `parsl_ephemeral_aws tests`. The 107 pre-existing ruff errors that forced the
-  narrower scope lived entirely in the `tools/` scripts removed above, so
-  `ruff check .` and `ruff format --check .` both pass and nothing outside the
-  package can drift unchecked. Applied in CI, the Makefile, and `make format`
-  (refs #93).
-- Six README links pointed into deleted `tools/` files — the examples table, the
-  documentation list, the quickstart, and the status badge. They now point at
-  `examples/` and `docs/`, which are maintained. While there, the Development
-  Setup block was using `pyenv`, `python -m venv`, and `pip install`, all three
-  forbidden by the project's uv-only rule, and told the reader to clone
-  `your-org/parsl-aws-provider` (refs #93).
-- `scripts/setup_environment.sh` checked for Python 3.9, two releases below the
-  `requires-python = ">=3.10"` that Parsl 2026.x forces. Its bats mock reported
-  3.9 to match, so the pair agreed with each other and with nothing else
-  (refs #93).
-- **Dependabot tracks the `uv` ecosystem instead of `pip`.** Its pip updates read
-  the `requirements.txt` removed above, and that file pinned `black`,
-  `aws-cdk-lib`, `pydantic`, `typeguard`, `types-boto3`, and `tf-ecosystem` —
-  none of which the project depends on or imports. All six open pip pull requests
-  were bumping a dependency set that does not exist. The `uv` ecosystem reads
-  `pyproject.toml` and updates the committed `uv.lock`, which is what every CI
-  job installs from via `uv sync --locked` (refs #93).
-- `examples/serverless_mode.py` told readers the Fargate image was fixed at
-  `public.ecr.aws/lambda/python:3.9` and that Lambda was therefore the better
-  choice — both halves now wrong, since `ecs_container_image` is reachable and
-  the default is `python:3.12-slim`. Its ECS branch passes
-  `ecs_container_image`, `ecs_task_cpu`, and `ecs_task_memory` so the example
-  demonstrates them rather than only naming them (refs #136).
 
 ### Fixed
 - **`aws-e2e-tests` went red on every manual dispatch, and its orphan sweep never
@@ -317,41 +348,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   which is what identified a test rather than a real session as the writer. A
   stale state document in the root is also what makes the `load_state()`
   null-restore hazard reachable, so this was not merely untidy (refs #93).
-
-### Added
-- `ServerlessMode` accepts `lambda_code_bucket`, an existing S3 bucket to stage
-  Lambda deployment packages in. This is the surviving half of `checkpoint_bucket`
-  removed above: alongside gating the interruption monitor, it also overrode the
-  code-staging bucket, and that half was real. A caller-supplied bucket is reused
-  as-is and never deleted (`_owns_lambda_code_bucket` stays `False`, which is what
-  protects it); omit it and a provider-scoped bucket is created on first use and
-  removed by `cleanup_infrastructure()` (refs #137).
-- `GlobusComputeProvider` accepts `encrypted` (default `False`), and defaults
-  `worker_init` to a script that installs `globus-compute-endpoint` rather than
-  inheriting the `parsl`-only default. Both are part of #138 above.
-- An autouse `tests/conftest.py` guard fails any test that leaves a
-  default-named state file in the working directory or the repository root,
-  naming the test and the fix. Gitignoring the path was the alternative and was
-  rejected: it would have silenced the symptom while tests kept writing outside
-  their sandbox. The watched filename is read from the `state_file_path` signature
-  default rather than hardcoded, so renaming the default cannot quietly disable
-  the check (refs #93).
-- **Real-AWS E2E coverage for the warm pool**, `tests/aws/test_warm_pool_e2e.py`,
-  which had none. Every property the pool is sold on is a live-AWS property that
-  a mock asserts by construction: that SSM `SendCommand` actually reached the
-  instance, that no *second* `RunInstances` was issued, that `worker_init` did not
-  run again, and that a WARM instance — a **billed**, running instance — is
-  terminated by TTL expiry, by pool-full eviction, and by `shutdown()`.
-
-  The reuse and eviction tests count instances by the `E2ETestRunId` tag applied
-  in the launch's own `TagSpecifications`, so an instance cannot exist for the run
-  without being counted. `worker_init` is a file append rather than the
-  Parsl-installing default, both to keep the suite's runtime workable and to make
-  "ran once, job ran twice" readable off the instance over SSM.
-  `test_status_follows_the_ssm_command_not_the_instance_state` is the one that
-  cannot be faked another way: on the warm path the instance stays `running`
-  whether the command succeeded or failed, so a FAILED verdict can only have come
-  from the invocation's response code (closes #65).
 
 ### Security
 - **The IAM leak fixed above was accumulating standing privileged principals.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-08-01
+
 ### Added
 - **Eight mode options that the provider documented but could not accept.**
   `idle_timeout`, `preserve_bastion`, `bastion_host_type`, and `workflow_id` on
@@ -1818,7 +1820,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ECS task definitions now create their CloudWatch log group before registration;
   log groups are tracked and deleted on cleanup (closes #22)
 
-[Unreleased]: https://github.com/scttfrdmn/parsl-aws-provider/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/scttfrdmn/parsl-aws-provider/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/scttfrdmn/parsl-aws-provider/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/scttfrdmn/parsl-aws-provider/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/scttfrdmn/parsl-aws-provider/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/scttfrdmn/parsl-aws-provider/compare/v0.4.0...v0.5.0

--- a/parsl_ephemeral_aws/__init__.py
+++ b/parsl_ephemeral_aws/__init__.py
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
 """
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"
 
 from .globus_compute import GlobusComputeProvider
 from .provider import EphemeralAWSProvider

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ parsl_ephemeral_aws = [
 
 [project]
 name = "parsl-ephemeral-aws"
-version = "0.7.0"
+version = "0.8.0"
 description = "A modern, flexible AWS provider for the Parsl parallel scripting library"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -194,7 +194,7 @@ skip_covered = false
 directory = "htmlcov"
 
 [tool.bumpversion]
-current_version = "0.7.0"
+current_version = "0.8.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 search = "{current_version}"

--- a/uv.lock
+++ b/uv.lock
@@ -1476,7 +1476,7 @@ wheels = [
 
 [[package]]
 name = "parsl-ephemeral-aws"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Release commit for **v0.8.0 — Stabilization**. No functional changes: this PR
folds the changelog and bumps the version strings. Everything it describes has
already merged to `main` under its own PR, and the milestone is **0 open / 12
closed**.

## What changed

| File | Change |
|---|---|
| `CHANGELOG.md` | duplicate category blocks consolidated; `[Unreleased]` → `[0.8.0] - 2026-08-01`; footer comparison link added |
| `pyproject.toml` | `version` and `[tool.bumpversion] current_version` → `0.8.0` |
| `parsl_ephemeral_aws/__init__.py` | `__version__` → `0.8.0` |
| `uv.lock` | own record of the package version |

## How it was done

`bump-my-version bump minor --no-commit --no-tag`, verified against a
`--dry-run` first. Both flags are deliberate:

- `--no-commit` — the configured message (`Bump version: 0.7.0 → 0.8.0`) is not
  a commitlint-valid subject, so the commit is made by hand.
- `--no-tag` — tagging and publishing wait for review. `git tag --list 'v0.8*'`
  is empty on this branch.

`bump-my-version` does not template the footer comparison link, so
`[0.8.0]: .../compare/v0.7.0...v0.8.0` was added manually and `[Unreleased]`
repointed to `v0.8.0...HEAD`.

The changelog consolidation is reordering only — `[Unreleased]` had accumulated
two `### Added` and two `### Changed` blocks as phases appended independently.
Merged into Keep-a-Changelog order by a script that asserts both the bullet count
and that no non-standard category name appears: **33 top-level bullets before, 33
after** (Added 6, Changed 8, Removed 5, Fixed 13, Security 1). Released sections
are untouched — the rewrite is scoped to the `[Unreleased]` span.

## Verification

- `make version-verify` → `Versions agree: 0.8.0`. This is the check that
  matters: `__init__.py` sat at `0.1.0` through six releases because the
  bumpversion search string had drifted.
- unit + security **1139 passed / 2 skipped**; `ruff check .` clean; `ruff format
  --check .` 124 files; `mypy` **76 errors** — all at baseline
- `git tag --list 'v0.8*'` → empty

## What v0.8.0 contains

- **#132** — the IAM leak. `StandardMode` created an SSM role and instance
  profile per run and deleted neither; 94 orphaned privileged principals had
  accumulated against IAM's 1,000-role quota. Cleanup is ownership-gated, so a
  caller-supplied `iam_instance_profile_arn` is never deleted.
- **#136** — eight mode options the provider documented but rejected. Most
  consequential is `ecs_container_image`: Fargate previously always ran a Lambda
  base image, so serverless mode could not run a workload with its own
  dependencies.
- **#92** — integration suite green (129 passed / 1 skipped / 1 xfailed, from
  33 failed / 8 errors).
- **#163** — a warm instance was dropped from the state file the moment it went
  warm, so a reconstructed provider neither reused it nor applied its TTL while
  AWS billed it.
- **#161** — `aws-e2e-tests` was red on every manual dispatch, and its orphan
  sweep died on a developer's profile name.
- **#120** — recognized fleet errors now recorded in `error_history`.
- **#65** — first real-AWS warm-pool coverage.
- **#93** — repository hygiene. Removing `tools/` cleared all 107 pre-existing
  ruff errors, so lint and format now run repo-wide in CI, the Makefile, and
  `make format`.

Two `Fixed` entries are for defects that shipped inside #92's PR without
changelog entries and are recorded here: the bastion `KeyName=None` failure
(#158) and the ECS `response["clusters"]` KeyError that misreported itself as a
cluster-creation failure.

## Not in this PR

Tagging, `git push --tags`, and the PyPI publish that `release.yml` triggers.
Awaiting approval.