### PR TITLE
ci: skip aws-e2e-tests when unconfigured, not fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,9 +173,17 @@ jobs:
   aws-e2e-tests:
     # Real AWS: bills money and needs a pre-provisioned VPC/subnet/SG, so it is
     # manual-only. #60 closed with 51 tests under tests/aws that no workflow ever
-    # referenced. tests/aws/conftest.py skips when the three IDs are unset, so a
-    # run without the repository variables configured is a no-op, not a failure.
-    if: github.event_name == 'workflow_dispatch'
+    # referenced.
+    #
+    # The `vars.AWS_TEST_REGION != ''` half of the gate is what makes an
+    # unconfigured run a no-op (#161). Relying on conftest.py's skip was not
+    # enough: pytest is never reached, because configure-aws-credentials fails
+    # first on the empty region with "Input required and not supplied:
+    # aws-region". So the job went red on every dispatch, which made manual
+    # dispatch useless as a green signal -- and dispatch is the only way to get
+    # CI evidence for a stacked PR, since the workflow triggers on pull_request
+    # into main and a PR based on a feature branch reports no checks at all.
+    if: github.event_name == 'workflow_dispatch' && vars.AWS_TEST_REGION != ''
     runs-on: ubuntu-latest
     needs: unit-tests
     environment: aws-e2e
@@ -205,6 +213,10 @@ jobs:
         # always(): a failed test is exactly when instances are most likely to be
         # left running. --dry-run reports without deleting, so a shared account is
         # never touched by CI.
+        #
+        # No --profile: the script now defaults to the boto3 credential chain,
+        # which picks up the OIDC credentials configure-aws-credentials exported
+        # (#161). It used to default to the local "aws" profile and die here.
         if: always()
         env:
           AWS_TEST_REGION: ${{ vars.AWS_TEST_REGION }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   demonstrates them rather than only naming them (refs #136).
 
 ### Fixed
+- **`aws-e2e-tests` went red on every manual dispatch, and its orphan sweep never
+  ran.** The job's comment claimed a dispatch without the repository variables
+  configured was "a no-op, not a failure" on the strength of
+  `tests/aws/conftest.py`'s skip — but pytest was never reached:
+  `configure-aws-credentials` fails first on the empty region with `Input
+  required and not supplied: aws-region`. The job is now gated on
+  `vars.AWS_TEST_REGION != ''`, so it skips as documented. That mattered beyond
+  tidiness: `ci.yml` triggers on `pull_request` into `main`, so a stacked PR based
+  on another feature branch reports no checks at all, and manual dispatch is the
+  only way to get evidence before the parent merges.
+
+  The `always()` orphan sweep then died on `The config profile (aws) could not be
+  found` — `tools/cleanup_aws_resources.py` defaulted `--profile` to `aws`, the
+  name this project's developers use locally but one no runner has. It now
+  defaults to the boto3 credential chain, which honours `AWS_PROFILE` locally and
+  picks up the OIDC credentials in CI. The step that reports leaked instances was
+  failing at exactly the moment instances are most likely to be leaked
+  (closes #161).
 - **A warm instance was forgotten the moment it went warm, and then billed for
   indefinitely.** `_cleanup_resources()` moved a finished warm-pool instance to
   `STATUS_WARM` in memory, but reached `_save_state()` only inside its

--- a/docs/ci_cd.md
+++ b/docs/ci_cd.md
@@ -105,16 +105,25 @@ long-lived access keys live in secrets. Configure:
 * **Variables** `AWS_TEST_REGION`, `AWS_TEST_VPC_ID`, `AWS_TEST_SUBNET_ID`,
   `AWS_TEST_SG_ID`.
 
-`tests/aws/conftest.py` skips when the three IDs are unset, so a dispatch without
-them configured is a no-op rather than a failure. It also validates the IDs
-against `AWS_TEST_REGION` up front — IDs from another region otherwise surface
-minutes in, from deep inside `RunInstances`, after instances have been billed.
-Pick a subnet in an AZ that offers your instance type (`us-east-1e` does not offer
-`t3.micro`).
+The job is gated on `vars.AWS_TEST_REGION != ''`, so a dispatch on a repository
+without these configured skips rather than failing. The gate is what makes that
+true, not `tests/aws/conftest.py`: conftest does skip when the three IDs are
+unset, but pytest is never reached — `configure-aws-credentials` fails first on
+the empty region, so before
+[#161](https://github.com/scttfrdmn/parsl-aws-provider/issues/161) every dispatch
+was red.
+
+Once it does run, conftest validates the IDs against `AWS_TEST_REGION` up front —
+IDs from another region otherwise surface minutes in, from deep inside
+`RunInstances`, after instances have been billed. Pick a subnet in an AZ that
+offers your instance type (`us-east-1e` does not offer `t3.micro`).
 
 A final `always()` step runs `tools/cleanup_aws_resources.py --dry-run` to report
 orphans, since a failed test is exactly when instances are most likely to be left
-running. It reports without deleting, so CI never mutates a shared account.
+running. It reports without deleting, so CI never mutates a shared account. The
+script takes credentials from the boto3 chain — the OIDC credentials the earlier
+step exported — rather than a named profile; it previously defaulted to the local
+`aws` profile and died here on "The config profile (aws) could not be found".
 
 ### `test-bats`
 

--- a/tools/cleanup_aws_resources.py
+++ b/tools/cleanup_aws_resources.py
@@ -7,7 +7,7 @@ Safely removes all test instances, security groups, and other resources.
 import boto3
 import time
 import sys
-from typing import List, Dict
+from typing import List, Dict, Optional
 import logging
 
 from parsl_ephemeral_aws.utils.aws import (
@@ -29,15 +29,30 @@ _ROLE_PREFIX, _PROFILE_PREFIX = (
 class AWSResourceCleaner:
     """Cleans up AWS resources created during testing."""
 
-    def __init__(self, profile_name: str = "aws", region: str = "us-east-1"):
-        """Initialize the cleaner with AWS session."""
+    def __init__(self, profile_name: Optional[str] = None, region: str = "us-east-1"):
+        """Initialize the cleaner with AWS session.
+
+        A None profile_name means the standard boto3 credential chain, which
+        honours AWS_PROFILE. The default used to be the literal "aws" -- the
+        profile name this project's developers use locally, per CLAUDE.md, but
+        one that exists on no CI runner. CI's post-E2E sweep therefore died on
+        "The config profile (aws) could not be found" instead of reporting
+        orphans, which is the one moment orphans are most likely (#161). The
+        runner authenticates via OIDC, so it has credentials but no profile.
+        """
         try:
-            self.session = boto3.Session(profile_name=profile_name, region_name=region)
+            if profile_name:
+                self.session = boto3.Session(
+                    profile_name=profile_name, region_name=region
+                )
+            else:
+                self.session = boto3.Session(region_name=region)
             self.ec2_client = self.session.client("ec2")
             self.iam_client = self.session.client("iam")
             self.region = region
             logger.info(
-                f"Initialized AWS session for region {region} with profile {profile_name}"
+                f"Initialized AWS session for region {region} with profile "
+                f"{profile_name or 'default credential chain'}"
             )
         except Exception as e:
             logger.error(f"Failed to initialize AWS session: {e}")
@@ -368,7 +383,10 @@ def main():
         description="Clean up AWS resources created by Parsl testing"
     )
     parser.add_argument(
-        "--profile", default="aws", help="AWS profile to use (default: aws)"
+        "--profile",
+        default=None,
+        help="AWS profile to use (default: the standard credential chain, "
+        "which honours AWS_PROFILE)",
     )
     parser.add_argument(
         "--region", default="us-east-1", help="AWS region (default: us-east-1)"


### PR DESCRIPTION
Closes #161 — the last open v0.8.0 issue. Two defects, both in the path that is
supposed to report leaked AWS resources.

## 1. The job could not skip

`ci.yml` claimed a dispatch without the repository variables configured was
"a no-op, not a failure", crediting `tests/aws/conftest.py`'s skip. **pytest is
never reached.** `configure-aws-credentials` runs first and fails on the empty
region:

```
##[error]Input required and not supplied: aws-region
```

So the job was red on every `workflow_dispatch` (observed on run 30710200397).
Now gated:

```yaml
if: github.event_name == 'workflow_dispatch' && vars.AWS_TEST_REGION != ''
```

This matters beyond tidiness. `ci.yml` triggers on `pull_request` into `main`, so
a stacked PR based on another feature branch reports **no checks at all** —
manual dispatch is the only way to get CI evidence before the parent merges, and
a permanently red job cannot provide it. That cost real time during this
release's phases.

## 2. The orphan sweep died on a developer's profile name

The `always()` step then failed:

```
ERROR: Failed to initialize AWS session: The config profile (aws) could not be found
```

`tools/cleanup_aws_resources.py` defaulted `--profile` to `"aws"` — the profile
CLAUDE.md standardises on locally, but one no runner has. The runner
authenticates via OIDC, so it *has* credentials, just no profile.

`--profile` now defaults to `None`, i.e. the standard boto3 credential chain,
which honours `AWS_PROFILE` locally and picks up the OIDC credentials in CI.
**No call site regresses**: all 13 invocations across `docs/` and `ci.yml` pass
only `--dry-run` and `--region`, and the local documented workflow exports
`AWS_PROFILE=aws`, which the chain reads.

The step reporting leaked instances was failing at exactly the moment instances
are most likely to be leaked — a failed E2E run.

## Also

`docs/ci_cd.md:108` repeated the same wrong claim, attributing the no-op to
conftest. Corrected to credit the gate and to state why conftest's skip cannot
be what saves you.

## Verification

- `.github/workflows/ci.yml` parses; gate reads
  `github.event_name == 'workflow_dispatch' && vars.AWS_TEST_REGION != ''`
- `python tools/cleanup_aws_resources.py --help` shows the new default; module
  parses
- no doc or workflow call site passes `--profile` (checked all 13)
- `ruff check`, `ruff format --check`, `sphinx-build` — clean
- CI on this PR exercises the fix's own skip path: `aws-e2e-tests` should report
  **skipping**, as it does on `pull_request` regardless

The `pypa/gh-action-pypi-publish@release/v1` pin and the region defaults are
untouched.