### PR TITLE
docs: install from source, since the package is not on PyPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **The documented install command could not work.** `docs/getting_started.md`
+  opened with `uv add parsl-ephemeral-aws`, but the package has never been
+  published — `pypi.org/pypi/parsl-ephemeral-aws/json` returns 404, because
+  `release.yml`'s PyPI trusted publisher was never registered and every release
+  run since v0.1.0 has failed at or before that step. The command fails outright
+  rather than installing something stale, so anyone following the guide could not
+  get started at all. Now documents installing from the repository, and points at
+  #180 for the publishing fix.
+
 ## [0.8.0] - 2026-08-01
 
 ### Added

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -2,8 +2,10 @@
 
 ## Installation
 
+**Not yet on PyPI**, so install from the repository:
+
 ```bash
-uv add parsl-ephemeral-aws
+uv add git+https://github.com/scttfrdmn/parsl-aws-provider
 ```
 
 Or, working from a clone:
@@ -11,6 +13,11 @@ Or, working from a clone:
 ```bash
 uv sync --extra dev --extra test
 ```
+
+`uv add parsl-ephemeral-aws` will start working once
+[#180](https://github.com/scttfrdmn/parsl-aws-provider/issues/180) is resolved —
+the package name is unregistered, so that command currently fails with "no
+matching distribution found" rather than installing an older version.
 
 Python 3.10 or newer is required (Parsl 2026.x dropped 3.9).
 


### PR DESCRIPTION
`docs/getting_started.md` opened with:

```bash
uv add parsl-ephemeral-aws
```

That cannot work. `https://pypi.org/pypi/parsl-ephemeral-aws/json` returns
**404** — the name has never been published, so the command fails with "no
matching distribution found" rather than installing something stale. It was the
**first instruction in the getting-started guide**, so a reader following the docs
could not get started at all.

Found while tagging v0.8.0: the release ran further than any before it — tag
verified against `__version__`, suites green, build clean, `twine check` passed,
GitHub release created with both artifacts — and then failed on the last step
with `invalid-publisher`. PyPI has no trusted publisher registered for this repo.
All eight release runs since v0.1.0 have failed at or before that step.

Fixing the publishing side needs PyPI account access, so it is filed separately
as **#180** (v0.9.0, `severity: high`). This PR only stops the docs from
promising something that cannot happen:

- install from the repository via `uv add git+https://...`
- note that `uv add parsl-ephemeral-aws` starts working once #180 is resolved,
  and say explicitly that it currently fails rather than silently installing an
  older version
- the clone-based `uv sync --extra dev --extra test` path was already correct and
  is unchanged

## Verification

- `sphinx-build` — clean, exit 0
- `tests/unit/test_docs_examples.py` — 88 passed, 1 skipped (that suite parses the
  docs, and `getting_started.md` is one of the files it reads)