### PR TITLE
ci: use a commit prefix commitlint accepts for dependabot (closes #184)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,15 @@ updates:
     reviewers:
       - "scttfrdmn"
     commit-message:
-      prefix: "deps"
+      # "build", not "deps". `deps` is not in commitlint.config.js's type-enum,
+      # so every PR dependabot opened carried a subject the repo's own
+      # commit-msg hook rejects (#184). It went unnoticed because commitlint
+      # runs only via pre-commit and dependabot commits server-side, so the hook
+      # never fires on them -- the failure surfaces only when a human rebases or
+      # amends the branch. `build` is the conventional-commits type for
+      # dependency changes and is already allowed; `include: scope` appends
+      # `(deps)`, which scope-enum also allows, giving `build(deps): ...`.
+      prefix: "build"
       include: "scope"
     ignore:
       - dependency-name: "*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rather than installing something stale, so anyone following the guide could not
   get started at all. Now documents installing from the repository, and points at
   #180 for the publishing fix.
+- **Dependabot generated commit messages the repo's own hook rejects.**
+  `.github/dependabot.yml` set `commit-message.prefix: "deps"` for the `uv`
+  ecosystem, but `deps` is absent from `commitlint.config.js`'s `type-enum`, so
+  every dependabot subject failed the `commit-msg` hook. It stayed invisible
+  because commitlint runs only through pre-commit and dependabot commits
+  server-side — the failure surfaces only once a human rebases or amends the
+  branch. Prefix is now `build`, the conventional-commits type for dependency
+  changes, yielding `build(deps): …` (#184).
 
 ## [0.8.0] - 2026-08-01
 


### PR DESCRIPTION
Closes #184. Found while triaging the ten open dependabot PRs; filing and fixing rather than leaving a known-broken config in place.

## The defect

`.github/dependabot.yml` set `commit-message.prefix: "deps"` for the `uv` ecosystem. `commitlint.config.js` does not list `deps` in its `type-enum`, so every subject dependabot generated fails the repo's own `commit-msg` hook:

```
$ commitlint --config commitlint.config.js <<< 'deps(deps): bump requests from 2.32.5 to 2.34.2'
✖ type must be one of [build, ci, docs, feat, fix, perf, refactor, style, test, chore, revert] [type-enum]
✖ found 1 problems, 0 warnings

$ commitlint --config commitlint.config.js <<< 'build(deps): bump requests from 2.32.5 to 2.34.2'
(clean, exit 0)
```

## Why it went unnoticed for so long

commitlint runs **only** through the pre-commit `commit-msg` hook (`.pre-commit-config.yaml:70`) — `grep -rl commitlint .github/` is empty, so no workflow checks it. Dependabot commits server-side, where no local hook can fire. The breakage is latent until a human rebases, amends, or hand-writes an equivalent commit — which is exactly what happened during the #167–#177 triage, where a `deps:` subject was rejected and had to be rewritten as `fix:`.

## The change

One line plus its explanation: prefix `deps` → `build`. `build` is the conventional-commits type for dependency changes and is already in the enum; `scope-enum` already allows `deps`, so `include: scope` produces `build(deps): …`, clean on both rules. The `github-actions` ecosystem already used `prefix: ci`, which is valid — unchanged.

## Verified

- `commitlint` run directly against both forms, output above.
- `yaml.safe_load` on the edited file → `uv -> {'prefix': 'build', 'include': 'scope'}`, `github-actions -> {'prefix': 'ci', ...}`.
- `grep -rn 'deps(deps)'` across md/yml/js finds nothing else documenting the old prefix.
- The commit itself passed the commitlint hook (see the `commit-msg` output on `241ab85`).

## Context: the dependabot queue is now empty

Ten PRs, resolved as:

| PRs | Disposition |
|---|---|
| #175, #177 | superseded by #182 — same advisories, floor set to the *lowest* fixed release rather than the newest |
| #173 | superseded by #182 (pytest) |
| #167–#172, #176 | closed: OSV reports all seven clean at the locked versions, so each was a floor bump with no advisory behind it |

Two were more than routine and are recorded on their PRs: **#168** (`mypy>=0.812` → `>=2.3.0`) is a major-version adoption that would silently move the 76-error baseline, since `type-check` is `continue-on-error: true` — belongs with #81/#82 and a re-measured baseline. **#167** (`moto>=5.0.0` → `>=5.2.2`) would have encoded a requirement that does not exist: 5.0 is the real floor because moto 5 introduced `mock_aws`, which the tests use.

Policy applied throughout: `pyproject.toml` floors move only to clear an advisory, and then only to the lowest release that does; `uv.lock` carries currency, and CI installs from it via `uv sync --locked`.