### PR TITLE
test: pin substrate 0.85.0, gate integration in CI (refs #183)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,8 +122,11 @@ jobs:
       substrate:
         # Pinned rather than `latest`, matching docker-compose.substrate.yml: an
         # emulator that changes underneath CI turns an unrelated PR red. Bump the
-        # two together, deliberately.
-        image: ghcr.io/scttfrdmn/substrate:0.76.0
+        # two together, deliberately -- they had drifted, this pin sitting on
+        # 0.76.0 while compose moved to 0.82.0, so CI was validating against an
+        # emulator six releases older than the one developers ran. See that file
+        # for what 0.85.0 fixes.
+        image: ghcr.io/scttfrdmn/substrate:0.85.0
         ports:
           - 4566:4566
         # No `--health-cmd`. The image is Alpine and ships no curl, and GitHub
@@ -140,11 +143,12 @@ jobs:
       - name: Wait for substrate
         run: ./scripts/substrate-wait.sh
       - name: Run integration tests
-        # Not gating yet: 46 mode constructions across 9 files still omit the
-        # network IDs #69 made required, so the emulator-backed tests cannot pass
-        # until they are repaired (#92, v0.8.0). Gating here would make every PR
-        # red on known debt.
-        continue-on-error: true
+        # Now gating. This carried `continue-on-error: true` while #92's debt was
+        # outstanding -- 46 mode constructions omitted the network IDs #69 made
+        # required, so the suite could not pass and gating would have made every
+        # PR red. #92 closed in v0.8.0 and the suite is green (130 passed, 1
+        # skipped against substrate 0.85.0), so the exemption now only hides
+        # regressions.
         env:
           # Structural, not secret: substrate authenticates against nothing, but
           # botocore refuses to sign a request without credentials present.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **substrate pinned to `0.85.0`, and CI's pin realigned with compose's.** The two
+  pins had drifted: `.github/workflows/ci.yml` sat on `0.76.0` while
+  `docker-compose.substrate.yml` had moved to `0.82.0`, so CI validated against an
+  emulator six releases older than the one developers ran locally. Both now read
+  `0.85.0`, which is the first release carrying all four emulator fixes this suite
+  was waiting on — three land in `0.84.0` and one only in `0.85.0`, so `0.84.0`
+  would not have been enough (refs #183):
+
+  - substrate#392 — symbolic error codes, so `Error.Code` is `ParameterNotFound`
+    rather than `"404"`. That is the exact string
+    `ParameterStoreState.save_state()` branches on to choose put-with-`Overwrite`
+    against create-with-`Tags`, so its create path was uncoverable here before.
+  - substrate#443 — `aws:ec2:fleet-id` is stamped on fleet-launched instances.
+  - substrate#391 — an unknown instance ID raises `InvalidInstanceID.NotFound`
+    instead of answering 200 with an empty list. That had silently defeated the #69
+    network guard: `_verify_resources` never raised, so the guard was asserted
+    against nothing.
+  - substrate#446 (`0.85.0` only) — `?publicAccessBlock` is routed, so `PUT` no
+    longer falls through to `CreateBucket` and `DELETE` no longer deletes the
+    bucket.
+
+  A merged substrate fix is not a released one — substrate cuts release commits, so
+  a fix merged to `main` lands *after* the newest tag and is invisible to an image
+  pin. `git tag --contains <sha>` is the check, and it is now written down in
+  `docs/substrate_testing.md` alongside the reminder that the pin lives in two
+  places.
+- **CI's integration-tests step now gates.** It carried `continue-on-error: true`
+  while #92's debt was outstanding — 46 mode constructions omitted the network IDs
+  #69 made required, so the suite could not pass and gating would have turned every
+  PR red. #92 closed in v0.8.0 and the suite is green, so the exemption had stopped
+  protecting anything and could only hide a regression.
 - **Renamed to `parsl-aws-provider`.** The distribution, the import package, and
   the repository now agree: `parsl-ephemeral-aws` → `parsl-aws-provider`, and
   `import parsl_ephemeral_aws` → `import parsl_aws_provider`. **Breaking for
@@ -26,6 +57,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   would strand already-created resources in live accounts.
 
 ### Added
+- **`S3State(create_bucket_if_not_exists=True)` is now covered.** #166 recorded it
+  as verified nowhere, and it was: the integration test for it was `xfail`ed,
+  because substrate left `?publicAccessBlock` unrouted, so the `PUT` that locks
+  down a freshly-created bucket fell through to `CreateBucket` and answered
+  `BucketAlreadyExists`. Fixed upstream in substrate 0.85.0, so the test asserts
+  outright — an `xfail` kept past its cause reads as coverage while producing an
+  `XPASS` on every run. The escape hatch became a regression guard that names the
+  upstream issue and the pin to check.
+
+  Still unverified against **real** S3; the gap #166 tracks narrows rather than
+  closes (refs #166).
 - **Independent-project disclaimer and a `NOTICE` file.** The README badges AWS,
   Parsl, and Globus Compute, and the repository carried no non-endorsement text
   at all. `NOTICE` now records that this is unaffiliated community work and

--- a/docker-compose.substrate.yml
+++ b/docker-compose.substrate.yml
@@ -19,12 +19,33 @@ services:
     # Pinned, not `latest`: an emulator that silently changes under CI turns an
     # unrelated PR red. Bump deliberately.
     #
-    # 0.82.0 is the first release with an EC2 `CreateFleet` handler (substrate
-    # #387), which is what lets the spot-fleet suite run against an endpoint
+    # 0.82.0 was the first release with an EC2 `CreateFleet` handler (substrate
+    # #387), which is what let the spot-fleet suite run against an endpoint
     # instead of moto. `RequestSpotFleet`/`RequestSpotInstances` are still
     # unimplemented and are not coming back here -- #86 moved this provider onto
     # CreateFleet, so nothing calls them.
-    image: ghcr.io/scttfrdmn/substrate:0.82.0
+    #
+    # 0.85.0 is the first release carrying four fixes this suite waited on
+    # (#183). Three land in 0.84.0 and one only in 0.85.0, so 0.84.0 is not
+    # enough:
+    #
+    #   substrate#392 symbolic error codes -- `ParameterNotFound` instead of
+    #     "404", which is the code ParameterStoreState.save_state() branches on
+    #     to choose put-with-Overwrite vs create-with-Tags.
+    #   substrate#443 `tag:aws:ec2:fleet-id` is set on fleet instances, so the
+    #     hand-applied tag workaround in the spot-fleet integration test is gone.
+    #   substrate#391 an unknown instance ID raises InvalidInstanceID.NotFound
+    #     instead of returning 200 + an empty list -- it had silently defeated
+    #     the #69 network guard, so _verify_resources never raised.
+    #   substrate#446 (0.85.0 only) `?publicAccessBlock` is routed, so PUT no
+    #     longer reaches CreateBucket and DELETE no longer deletes the bucket.
+    #     That unblocks S3State(create_bucket_if_not_exists=True), which was
+    #     xfailed and verified nowhere (#166).
+    #
+    # Verify a bump reaches the image, not just the git tag: substrate cuts
+    # release commits, so a merged fix sits on `main` after the newest tag and is
+    # invisible to this pin. `git tag --contains <sha>` is the check.
+    image: ghcr.io/scttfrdmn/substrate:0.85.0
     container_name: parsl-substrate
     ports:
       - "4566:4566"

--- a/docs/substrate_testing.md
+++ b/docs/substrate_testing.md
@@ -37,10 +37,22 @@ any step ran.
 The compose file is pinned to a specific image tag, deliberately — an emulator that
 silently changes under CI turns an unrelated PR red.
 
-Do not try to confirm the pin from `/health`: released images report
-`"version":"dev"` whatever their tag ([substrate#402](https://github.com/scttfrdmn/substrate/issues/402)).
-Use `podman image inspect ghcr.io/scttfrdmn/substrate:0.76.0 --format '{{.Digest}}'`
+`/health` reports the real version as of 0.85.0 — `{"status":"ok","version":"v0.85.0"}` —
+so `make substrate-status` is enough to confirm the pin. Released images used to
+report `"version":"dev"` whatever their tag
+([substrate#402](https://github.com/scttfrdmn/substrate/issues/402)); against an
+older image, use
+`podman image inspect ghcr.io/scttfrdmn/substrate:0.85.0 --format '{{.Digest}}'`
 instead.
+
+When bumping the pin, change it in **two** places — `docker-compose.substrate.yml`
+and the `services.substrate.image` in `.github/workflows/ci.yml`. They drifted
+once (CI on 0.76.0, compose on 0.82.0), which meant CI validated against an
+emulator six releases behind the one developers ran locally.
+
+Note also that a merged substrate fix is not a released one: substrate cuts
+release commits, so a fix merged to `main` lands *after* the newest tag and is
+invisible to an image pin. `git tag --contains <sha>` is the check.
 
 ```bash
 make substrate-up      # start and wait for /health
@@ -170,17 +182,30 @@ provider.
 
 ## Known gaps
 
-Verified against substrate `0.76.0`. None of these block the current suite, but
-they shape what can be tested where:
+Verified by probing substrate `0.85.0` directly, not read off the milestones.
+Only two gaps remain, and both are why part of the suite still uses moto:
 
 | Gap | Effect | Upstream |
 |---|---|---|
-| `describe_instances`/`describe_vpcs` with an unknown ID return HTTP 200 and an empty list instead of `Invalid*ID.NotFound` | `modes/base.py::_verify_resources` never raises, so the whole #69 network-validation guard is silently skipped and the test still reports green | [substrate#391](https://github.com/scttfrdmn/substrate/issues/391) |
-| `Error.Code` carries the HTTP status (`"404"`) rather than the symbolic code for SSM/Lambda not-found; IAM returns `NoSuchEntityException` where the wire code is `NoSuchEntity`; `s3.get_object` reports `NoSuchKey` for a missing *bucket* | `ParameterStoreState.save_state()` branches on `Code == "ParameterNotFound"` to choose between put-with-Overwrite and create-with-Tags, so its create path cannot be covered here | [substrate#392](https://github.com/scttfrdmn/substrate/issues/392) |
-| `lambda.invoke` sets `FunctionError` to `""` on success, where AWS omits the key | Cosmetic. `compute/lambda_func.py` reads it with `.get()`, so a falsy value behaves correctly | [substrate#393](https://github.com/scttfrdmn/substrate/issues/393) |
-| CloudFormation is not exposed over HTTP; `create_stack` returns `ServiceNotAvailable` | `DetachedMode`'s bastion stack cannot be exercised here. The one test that touches it patches `_create_cloudformation_stack` out; real coverage is in `tests/aws/` | — |
-| `RequestSpotFleet`, `RequestSpotInstances`, and `CreateFleet` are unimplemented | No impact: every spot-fleet test uses moto rather than an endpoint | — |
-| Released images report `"version":"dev"` from `/health` regardless of tag | The image pin cannot be confirmed from the running emulator; verify with `podman image inspect` instead | [substrate#402](https://github.com/scttfrdmn/substrate/issues/402) |
+| CloudFormation is not exposed over HTTP; `create_stack` returns `ServiceNotAvailable` | `DetachedMode`'s bastion stack and six `ServerlessMode` tests that drive `cf_client` cannot run here. `tests/integration/test_serverless_mode_spot_fleet_integration.py` stays on moto for exactly this reason; real coverage is in `tests/aws/` | — |
+| EventBridge is not emulated; `PutRule` returns `501 service not emulated: awsevents` | The spot-warning notifier's degradation path is testable *because* of this. The warning path itself is covered end to end by wiring an SQS queue directly, since the monitor only ever reads warnings through SQS | — |
+| IAM does not serve AWS-managed policies — `get_policy` on `arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore` returns `NoSuchEntity` (though `attach_role_policy` accepts it) | The unit suite keeps moto with `MOTO_IAM_LOAD_MANAGED_POLICIES=true`, which serves the real policy documents | — |
+| The instance-type catalog is partial — `t3.micro` resolves, `m5.xlarge` does not | `describe_instance_capacity` tests stay on moto, which knows the full catalog | — |
+
+Fixed since, and no longer worked around anywhere:
+
+| Was | Now | Upstream |
+|---|---|---|
+| Unknown instance/VPC IDs returned HTTP 200 + empty list, silently skipping the whole #69 network-validation guard | Raises `InvalidInstanceID.NotFound`, so `_verify_resources` is genuinely exercised | [substrate#391](https://github.com/scttfrdmn/substrate/issues/391) |
+| `Error.Code` carried the HTTP status (`"404"`) rather than the symbolic code | `ParameterNotFound`, `NoSuchEntity`, `NoSuchBucket` all correct, so `ParameterStoreState.save_state()`'s create-path branch is coverable | [substrate#392](https://github.com/scttfrdmn/substrate/issues/392) |
+| `lambda.invoke` set `FunctionError` to `""` on success where AWS omits it | Key omitted, matching AWS | [substrate#393](https://github.com/scttfrdmn/substrate/issues/393) |
+| `CreateFleet` unimplemented | Implemented; an instant fleet launches its full `TotalTargetCapacity` | [substrate#387](https://github.com/scttfrdmn/substrate/issues/387) |
+| Fleet instances carried no `aws:ec2:fleet-id` tag, so tests hand-applied it | Substrate stamps it, and now *rejects* manual `aws:`-prefixed keys as reserved — so the old workaround is an error, not merely redundant | [substrate#443](https://github.com/scttfrdmn/substrate/issues/443) |
+| `?publicAccessBlock` was unrouted: `PUT` hit `CreateBucket`, `DELETE` **deleted the bucket** | Routed, so `S3State(create_bucket_if_not_exists=True)` is covered instead of xfailed | [substrate#446](https://github.com/scttfrdmn/substrate/issues/446) |
+| `/health` reported `"version":"dev"` regardless of tag | Reports the real version | [substrate#402](https://github.com/scttfrdmn/substrate/issues/402) |
+
+`RequestSpotFleet` and `RequestSpotInstances` are still unimplemented and are not
+coming back here: #86 moved this provider onto `CreateFleet`, so nothing calls them.
 
 Substrate does emulate two things LocalStack did not, and both are load-bearing
 here: EC2 instance state actually transitions to `terminated` (which

--- a/tests/integration/test_serverless_mode_spot_fleet_integration.py
+++ b/tests/integration/test_serverless_mode_spot_fleet_integration.py
@@ -332,10 +332,18 @@ class TestServerlessModeSpotFleetIntegration:
         # and that tag is the only supported way to enumerate an instant fleet's
         # instances: DescribeFleetInstances rejects this fleet type outright, and
         # DescribeFleets reports the original launch without dropping instances
-        # that have since terminated. Neither moto nor substrate applies it
-        # (substrate#443), so it is set here -- otherwise the lookup comes back
-        # empty and a running fleet reports COMPLETED for want of a tag rather
-        # than for any behaviour of the code under test.
+        # that have since terminated. **moto** does not apply it, so it is set
+        # here -- otherwise the lookup comes back empty and a running fleet
+        # reports COMPLETED for want of a tag rather than for any behaviour of
+        # the code under test.
+        #
+        # This file stays on moto even though substrate now applies the tag
+        # itself (substrate#443, 0.85.0): six tests here drive `cf_client`, and
+        # substrate does not emulate CloudFormation. Note the workaround is only
+        # viable *because* it is moto -- substrate now enforces the real rule
+        # that `aws:` keys are reserved and rejects create_tags outright, which
+        # is why the substrate-backed copy of this pattern in
+        # test_spot_interruption_substrate.py had to drop it.
         instance_ids = [i for g in fleet["Instances"] for i in g["InstanceIds"]]
         assert instance_ids, "fleet launched nothing; nothing to assert about"
         ec2.create_tags(
@@ -386,7 +394,7 @@ class TestServerlessModeSpotFleetIntegration:
         )
         fleet_id = fleet["FleetId"]
         instance_ids = [i for g in fleet["Instances"] for i in g["InstanceIds"]]
-        ec2.create_tags(  # see substrate#443, above
+        ec2.create_tags(  # moto does not apply it; see above
             Resources=instance_ids,
             Tags=[{"Key": "aws:ec2:fleet-id", "Value": fleet_id}],
         )

--- a/tests/integration/test_spot_interruption_substrate.py
+++ b/tests/integration/test_spot_interruption_substrate.py
@@ -177,25 +177,55 @@ class TestSpotInterruptionSubstrate:
         assert remaining.get("Messages", []) == []
 
     def test_a_fleet_instance_warning_reaches_the_fleet_handler(
-        self, substrate_session, warning_queue
+        self, substrate_session, substrate_network, warning_queue
     ):
         """A warning names an instance; the handler owed it may own the fleet.
 
         The link is the reserved ``aws:ec2:fleet-id`` tag EC2 stamps on every
         fleet-launched instance -- the only workable route, since
         ``describe_fleet_instances`` rejects an instant fleet outright (#86).
-        Substrate serves both ``create_tags`` and the tag filter, so the lookup
-        is exercised for real here rather than mocked.
+
+        The fleet is created for real and the tag is *not* applied here.
+        Substrate stamps it itself as of 0.85.0 (substrate#443), so this now
+        covers the whole chain the provider depends on -- fleet launch, EC2
+        applying the reserved tag, and the tag-filtered lookup -- where the
+        earlier version asserted only the last link against a synthetic fleet ID
+        and a tag the test had written itself.
+
+        Hand-applying it is no longer merely redundant, it fails: substrate now
+        enforces the real rule that ``aws:``-prefixed keys are reserved, and
+        ``create_tags`` answers ``InvalidParameterValue``.
         """
         ec2 = substrate_session.client("ec2")
-        fleet_id = f"fleet-{uuid.uuid4().hex[:12]}"
-        instance_id = ec2.run_instances(
-            ImageId="ami-12345678", MinCount=1, MaxCount=1, InstanceType="t3.micro"
-        )["Instances"][0]["InstanceId"]
-        ec2.create_tags(
-            Resources=[instance_id],
-            Tags=[{"Key": "aws:ec2:fleet-id", "Value": fleet_id}],
+        template = ec2.create_launch_template(
+            LaunchTemplateName=f"parsl-warning-template-{uuid.uuid4().hex[:8]}",
+            LaunchTemplateData={"ImageId": "ami-12345678", "InstanceType": "t3.micro"},
+        )["LaunchTemplate"]
+        fleet = ec2.create_fleet(
+            Type="instant",
+            LaunchTemplateConfigs=[
+                {
+                    "LaunchTemplateSpecification": {
+                        "LaunchTemplateId": template["LaunchTemplateId"],
+                        "Version": str(template["LatestVersionNumber"]),
+                    },
+                    "Overrides": [
+                        {
+                            "InstanceType": "t3.micro",
+                            "SubnetId": substrate_network["subnet_id"],
+                        }
+                    ],
+                }
+            ],
+            TargetCapacitySpecification={
+                "TotalTargetCapacity": 1,
+                "DefaultTargetCapacityType": "spot",
+            },
         )
+        fleet_id = fleet["FleetId"]
+        instance_ids = [i for g in fleet["Instances"] for i in g["InstanceIds"]]
+        assert instance_ids, "fleet launched nothing; nothing to assert about"
+        instance_id = instance_ids[0]
 
         monitor = SpotInterruptionMonitor(session=substrate_session, check_interval=1)
         monitor.warning_queue_url = warning_queue
@@ -220,4 +250,7 @@ class TestSpotInterruptionSubstrate:
             assert instance_ids == [instance_id]
             assert event["FleetRequestId"] == fleet_id
         finally:
-            ec2.terminate_instances(InstanceIds=[instance_id])
+            ec2.terminate_instances(InstanceIds=instance_ids)
+            ec2.delete_launch_template(
+                LaunchTemplateId=template["LaunchTemplateId"],
+            )

--- a/tests/integration/test_state_persistence_integration.py
+++ b/tests/integration/test_state_persistence_integration.py
@@ -528,21 +528,26 @@ class TestS3StateIntegration:
         bucket created without it would be world-readable if any later policy
         allowed it.
 
-        ``xfail`` on substrate#446 rather than skip: ``?publicAccessBlock`` is
-        unrouted there, so ``PUT`` falls through to the ``CreateBucket`` handler
-        and answers ``BucketAlreadyExists`` for the bucket that was just made.
-        The provider wraps that as ``StateError: Failed to create S3 bucket``, so
-        the whole constructor fails. xfail keeps the test running -- it will
-        report ``XPASS`` the moment substrate routes the subresource, where a skip
-        would sit silently forever.
+        This passes as of substrate 0.85.0, which routes ``?publicAccessBlock``
+        (substrate#443's sibling, substrate#446). Before that the subresource was
+        unrouted, so ``PUT`` fell through to the ``CreateBucket`` handler and
+        answered ``BucketAlreadyExists`` for the bucket just made; the provider
+        wrapped that as ``StateError: Failed to create S3 bucket`` and the whole
+        constructor failed. The ``xfail`` that carried the test through that
+        period is gone -- keeping it would mean an ``XPASS`` on every run, which
+        reads as noise rather than as coverage.
 
-        Creation itself is covered under moto in
+        The ``except StateError`` branch below is kept deliberately: it names the
+        emulator gap that used to break this, so a regression in substrate's
+        routing fails here with that explanation rather than as a bare
+        constructor error.
+
+        Creation is also covered under moto in
         ``tests/unit/test_aws_mocking.py::test_bucket_is_created_when_requested``.
-        Nothing covers it against real S3: ``tests/aws`` pre-creates the bucket in
-        its ``s3_state_bucket`` fixture, so the provider takes the
+        It remains uncovered against *real* S3 -- ``tests/aws`` pre-creates the
+        bucket in its ``s3_state_bucket`` fixture, so the provider takes the
         already-exists branch there, and no E2E test passes
-        ``create_bucket_if_not_exists``. The public-access assertions below are
-        therefore unverified against AWS until substrate#446 lands.
+        ``create_bucket_if_not_exists`` (#166).
         """
         bucket_name = f"auto-create-bucket-{uuid.uuid4().hex[:16]}"
         s3_client = substrate_session.client("s3")
@@ -559,10 +564,11 @@ class TestS3StateIntegration:
             )
         except StateError as exc:
             if "BucketAlreadyExists" in str(exc):
-                pytest.xfail(
-                    "substrate#446: PUT ?publicAccessBlock is routed to "
-                    "CreateBucket, so the provider cannot lock down a bucket it "
-                    "just created."
+                pytest.fail(
+                    "substrate regressed on #446: PUT ?publicAccessBlock fell "
+                    "through to CreateBucket, so the provider could not lock "
+                    "down a bucket it had just made. Fixed in 0.85.0; check the "
+                    "pin in docker-compose.substrate.yml."
                 )
             raise
 

--- a/tests/test_substrate_emulation.py
+++ b/tests/test_substrate_emulation.py
@@ -199,15 +199,19 @@ def test_ssm_parameter_store(ssm_client):
     # Delete parameter
     ssm_client.delete_parameter(Name=parameter_name)
 
-    # Verify deletion. The assertion is on *what raised*, not on the error code:
-    # substrate returns Error.Code == "404" where AWS returns "ParameterNotFound"
-    # (substrate#392). That gap is not cosmetic here --
-    # ParameterStoreState.save_state() branches on exactly that code to decide
-    # between put-with-Overwrite and create-with-Tags, so its create path cannot be
-    # covered against this emulator. tests/aws/test_state_backends_e2e.py covers it
-    # against real AWS. Tighten this to the symbolic code once substrate#392 lands.
+    # Verify deletion. Asserted on the symbolic code now that substrate#392 has
+    # landed -- it used to return Error.Code == "404" where AWS returns
+    # "ParameterNotFound", and this assertion could only check the HTTP status.
+    #
+    # The code is what matters, not just the failure:
+    # ParameterStoreState.save_state() branches on exactly "ParameterNotFound" to
+    # choose between put-with-Overwrite and create-with-Tags, so under the old
+    # behaviour its create path could not be covered against this emulator at
+    # all. The HTTP status is still asserted alongside, since that is what the
+    # 0.84.0-and-earlier gap showed up as.
     with pytest.raises(ClientError) as excinfo:
         ssm_client.get_parameter(Name=parameter_name)
+    assert excinfo.value.response["Error"]["Code"] == "ParameterNotFound"
     assert excinfo.value.response["ResponseMetadata"]["HTTPStatusCode"] == 404
 
 
@@ -324,9 +328,12 @@ def handler(event, context):
     # rather than on 'Hello from Lambda!'. LambdaManager reads StatusCode and
     # FunctionError to decide job state, and those are what this covers.
     #
-    # Truthiness, not `"FunctionError" not in response`: substrate sets the key to
-    # "" on success where AWS omits it (substrate#393). Both spellings agree that
-    # the invocation did not error, and `.get()` is what lambda_func.py:458 uses.
+    # Truthiness via `.get()`, which is also what lambda_func.py:458 does, so
+    # this covers the provider's own spelling. Substrate omits the key entirely
+    # on success now, matching AWS -- it used to set it to "" (substrate#393),
+    # which is why the assertion was written to accept either. Both spellings
+    # agree that the invocation did not error, so the looser form is kept
+    # deliberately rather than tightened to `not in response`.
     assert not response.get("FunctionError")
 
     lambda_client.delete_function(FunctionName=function_name)


### PR DESCRIPTION
Bumps the emulator to the first release that carries everything this suite was
waiting on, and turns the CI step that runs against it back into a gate.

Answers the question #183 asks — **can moto be retired?** — with **no**, and
corrects the issue's premise. See the last section.

## substrate 0.82.0 → 0.85.0 (and CI 0.76.0 → 0.85.0)

Three of the four fixes land in `0.84.0` and one only in `0.85.0`, so `0.84.0`
would not have been enough:

| Upstream | Was | Now |
|---|---|---|
| [substrate#392](https://github.com/scttfrdmn/substrate/issues/392) | `Error.Code` carried the HTTP status (`"404"`) | `ParameterNotFound` — the exact string `ParameterStoreState.save_state()` branches on to pick put-with-`Overwrite` vs create-with-`Tags`, so its create path was uncoverable here |
| [substrate#443](https://github.com/scttfrdmn/substrate/issues/443) | fleet instances carried no `aws:ec2:fleet-id` tag | substrate stamps it, and *rejects* manual `aws:` keys as reserved |
| [substrate#391](https://github.com/scttfrdmn/substrate/issues/391) | unknown instance ID → 200 + empty list | `InvalidInstanceID.NotFound`. The old behaviour silently defeated the #69 network guard: `_verify_resources` never raised, so the guard was asserted against nothing |
| [substrate#446](https://github.com/scttfrdmn/substrate/issues/446) | `?publicAccessBlock` unrouted: `PUT` hit `CreateBucket`, `DELETE` **deleted the bucket** | routed |

Every one of those verified by probing `0.85.0` directly rather than read off the
milestones.

**The two pins had drifted.** CI sat on `0.76.0` while compose had moved to
`0.82.0`, so CI validated against an emulator six releases older than the one
developers ran locally. Both now read `0.85.0`, and `docs/substrate_testing.md`
records that the pin lives in two places — plus that a *merged* substrate fix is
not a *released* one, since substrate cuts release commits and a fix merged to
`main` lands after the newest tag, invisible to an image pin. `git tag --contains
<sha>` is the check. (That is how #446 first looked satisfied when it was not.)

## Test consequences

- **The #443 workaround had to go** from `test_spot_interruption_substrate.py` —
  not merely redundant now but an outright failure, since substrate enforces the
  real reserved-prefix rule and `create_tags` answers `InvalidParameterValue`.
  Replaced with a real `CreateFleet`, which covers strictly more: fleet launch,
  EC2 applying the tag, and the tag-filtered lookup in
  `get_ec2_fleet_instance_ids()`. The old version asserted only the last link,
  against a synthetic fleet ID and a tag the test had written itself.
- **The same workaround stays** in
  `test_serverless_mode_spot_fleet_integration.py`, with the comment rewritten to
  say why. That file is **moto**-backed via an autouse `mock_aws` fixture; moto
  applies no fleet-id tag and *does* permit manual `aws:` keys, so the workaround
  is both still needed and still viable there. Removing it makes a running fleet
  report `COMPLETED` for want of a tag.
- **`test_create_bucket_if_not_exists` is de-xfailed** (refs #166). Its
  `except` branch became a regression guard naming #446 and the pin to check. An
  `xfail` kept past its cause reads as coverage while producing an `XPASS` every
  run.
- **Two stale assertions tightened**: the SSM one now asserts the symbolic code
  (#392), and the Lambda `FunctionError` comment matches substrate omitting the
  key as AWS does (#393). The `.get()` truthiness is kept deliberately — it is
  what `lambda_func.py:458` itself does.

## CI's integration step now gates

`continue-on-error: true` existed because #92's 46 network-ID-less mode
constructions meant the suite could not pass, and gating would have made every PR
red. #92 closed in v0.8.0 and the suite is green, so the exemption had stopped
protecting anything and could only hide a regression.

## docs/substrate_testing.md

The "Known gaps" table was 5-of-6 rows stale — it still listed `CreateFleet` as
unimplemented and the fleet tag as missing. Rewritten as *remaining* gaps
(CloudFormation, EventBridge, IAM not serving AWS-managed policies, partial
instance-type catalog) plus a "fixed since, no longer worked around anywhere"
table.

## Can moto be retired? No — and #183's premise is wrong

49 grep hits reduce to **33 real `mock_aws` activations**: 31 in `tests/unit/`, 2
in `tests/integration/`. (`tests/bats/` hits are a same-named shell function; the
`tests/conftest.py` hit is a docstring.)

#183 calls the two integration files "the tractable half." They are not — **both
drive `cf_client`**, and substrate does not emulate CloudFormation
(`create_stack` → `ServiceNotAvailable`): 6 references in
`test_serverless_mode_spot_fleet_integration.py`, 2 in
`test_detached_mode_spot_fleet_integration.py`. Three further blockers:

- substrate's IAM does not serve AWS-managed policies — `get_policy` on
  `arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore` → `NoSuchEntity`, though
  `attach_role_policy` accepts it. The unit suite needs
  `MOTO_IAM_LOAD_MANAGED_POLICIES=true` for the real documents.
- substrate's instance-type catalog is partial: `t3.micro` resolves, `m5.xlarge`
  does not, so the `describe_instance_capacity` tests stay on moto.
- Moving the 31 unit activations at all would make the **unit** suite require a
  running container, which is a worse trade than keeping the dependency.

So `moto[cloudformation]>=5.0.0` stays. What actually retired under #183 is the
#443 workaround in the one genuinely substrate-backed file. I will correct the
issue body to match.

## Verification

| | Before | After |
|---|---|---|
| `tests/integration` | 129 passed / 1 failed / 1 skipped | **130 passed / 1 skipped** |
| `tests/unit tests/security` | 1119 passed / 3 skipped | unchanged |
| `ruff check .` / `ruff format --check .` | clean | clean (124 files) |
| `mypy parsl_aws_provider` | 76 errors / 19 files | unchanged |

The one gained test is the #446 `xfail` now passing outright.

Note when reading the integration run locally: use `SUBSTRATE_ENDPOINT`, not
`AWS_ENDPOINT_URL`. The latter is global and routes moto-mocked clients at
substrate too, which loses per-test isolation and produces spurious mass
failures.

refs #183, refs #166