### PR TITLE
docs: publish to GitHub Pages, fix the dead metadata URL (closes #191)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,3 +290,36 @@ jobs:
         with:
           name: documentation
           path: docs/_build/html/
+      - name: Package for Pages
+        # Only on main: a PR must not publish. Uploaded as a *Pages* artifact,
+        # which is a distinct format from the plain artifact above -- that one
+        # stays, because it is how a PR author inspects a docs change before it
+        # ships.
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: docs/_build/html/
+
+  deploy-docs:
+    # #191: the `Documentation` URL in pyproject.toml pointed at a Read the Docs
+    # site that was never set up -- 404 under both the old and new package names.
+    # That URL is baked into wheel and sdist metadata, so it becomes one of three
+    # links on the PyPI landing page; publishing (#180) with it dead ships a
+    # prominent 404.
+    #
+    # Pages rather than RTD because the HTML already exists: the `docs` job has
+    # built it on every PR all along and simply never published it. This is a
+    # deploy step, where RTD would have meant a new external account and a
+    # `.readthedocs.yaml` duplicating the build this repo already does under uv.
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    needs: docs
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write         # deploy to the Pages site
+      id-token: write      # OIDC, which deploy-pages requires
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   would strand already-created resources in live accounts.
 
 ### Added
+- **The documentation is actually published.** CI's `docs` job has built the
+  Sphinx HTML on every PR since #124 and uploaded it as an artifact — a form only
+  reachable by someone browsing a workflow run. It now deploys to GitHub Pages at
+  <https://scttfrdmn.github.io/parsl-aws-provider/> on pushes to `main`, and the
+  `Documentation` entry in `[project.urls]` points there instead of at a Read the
+  Docs site that never existed.
+
+  That URL returned **404**, and so did the old name's, so it was a pre-existing
+  dead link the rename carried forward rather than fallout from it. It mattered
+  because `[project.urls]` is baked into wheel and sdist metadata and becomes the
+  links on the PyPI landing page — publishing (#180) as-is would have shipped a
+  prominent 404. Pages rather than RTD because the HTML already existed; RTD would
+  have meant a new external account and a `.readthedocs.yaml` duplicating the
+  build this repo already does under `uv`.
+
+  Deployment is gated on `refs/heads/main` **and** a `push` event, so a pull
+  request cannot publish. The plain artifact upload stays, since that is how a PR
+  author reviews a documentation change before it ships. A `Changelog` URL was
+  added while there (closes #191).
 - **`S3State(create_bucket_if_not_exists=True)` is now covered.** #166 recorded it
   as verified nowhere, and it was: the integration test for it was `xfail`ed,
   because substrate left `?publicAccessBlock` unrouted, so the `PUT` that locks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,18 @@ docs = [
 [project.urls]
 "Homepage" = "https://github.com/scttfrdmn/parsl-aws-provider"
 "Bug Tracker" = "https://github.com/scttfrdmn/parsl-aws-provider/issues"
-"Documentation" = "https://parsl-aws-provider.readthedocs.io"
+# GitHub Pages, not Read the Docs. This read
+# `https://parsl-aws-provider.readthedocs.io` and 404'd -- as did the old name,
+# so it was a pre-existing dead link the #189 rename carried forward rather than
+# fallout from it. RTD was never configured: no `.readthedocs.yaml`, no project
+# under either name.
+#
+# These URLs are baked into wheel and sdist metadata and become the links on the
+# PyPI landing page, so this had to resolve before the first publish (#180) or be
+# dropped. CI's `docs` job had been building the HTML on every PR all along and
+# never publishing it; `deploy-docs` now ships it on pushes to main (#191).
+"Documentation" = "https://scttfrdmn.github.io/parsl-aws-provider/"
+"Changelog" = "https://github.com/scttfrdmn/parsl-aws-provider/blob/main/CHANGELOG.md"
 
 # [tool.uv] conflicts removed with the localstack dependency (#125). The pin
 # existed because globus-compute-sdk requires dill==0.3.9 while localstack<4.10


### PR DESCRIPTION
Clears the last non-account blocker on #180. No documentation **content** changes
here — two review agents are auditing that separately.

## The defect

`pyproject.toml`'s `Documentation` URL pointed at
`https://parsl-aws-provider.readthedocs.io`, which **404s**. So does the old
name's, so this was a pre-existing dead link that the #189 rename carried forward
under a new spelling, not fallout from it. Read the Docs was never configured:
no `.readthedocs.yaml`, no project under either name.

It matters *now* because `[project.urls]` is baked into wheel and sdist metadata
and becomes the links on the PyPI landing page. Publishing as-is ships a prominent
404 as one of three links a visitor sees.

Verified against the built artifact rather than the source, since metadata is what
PyPI actually renders:

```
$ uv build && unzip -p dist/*.whl '*/METADATA' | grep Project-URL
Project-URL: Homepage, https://github.com/scttfrdmn/parsl-aws-provider
Project-URL: Bug Tracker, https://github.com/scttfrdmn/parsl-aws-provider/issues
Project-URL: Documentation, https://scttfrdmn.github.io/parsl-aws-provider/
Project-URL: Changelog, https://github.com/scttfrdmn/parsl-aws-provider/blob/main/CHANGELOG.md
```

## Pages, not RTD

#191 offered both. Pages, because **the HTML already exists** — CI's `docs` job
has built it with `SPHINXOPTS="-W"` on every PR since #124 and uploaded it as a
plain artifact, a form reachable only by someone browsing a workflow run. So this
is a deploy step. RTD would have meant a new external account (the same class of
step that has #180 itself stalled) plus a `.readthedocs.yaml` duplicating a build
this repo already does under `uv`.

Pages is enabled with `build_type=workflow`, which `deploy-pages` requires.

## Safety of the deploy

`deploy-docs` is gated on `refs/heads/main` **and** `github.event_name == 'push'`,
so **a pull request cannot publish** — including this one. Permissions are scoped
to `pages: write` + `id-token: write` on that job only, not the workflow.

The existing plain-artifact upload **stays**. It is how a PR author inspects a
documentation change before it ships, which the Pages artifact cannot do.

Both Pages actions pinned at **v5**, their current major. v4 is a release behind
and dependabot would have opened a bump immediately.

## Verification

- `uv run make -C docs html SPHINXOPTS="-W"` — succeeds, **zero warnings**, 18
  pages
- `.nojekyll` is emitted. Load-bearing: without it Pages runs Jekyll, which
  strips underscore-prefixed directories, so Sphinx's `_static/` would vanish and
  the site would render unstyled
- Every `docs/*.md` and `docs/*.rst` builds except `docs/README.md`, which is
  deliberate — `conf.py` excludes it and the file says so in its own second line.
  It documents how to build the site rather than being part of it
- Workflow YAML parses; `deploy-docs` resolves `needs: docs`

The site only exists once this reaches `main`, since the deploy is push-gated.
I'll confirm the URL resolves after merge, before anything goes to PyPI.

closes #191, refs #180