### PR TITLE
fix: stop max_idle_time terminating busy workers (closes #194)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   4.0.1).
 
 ### Fixed
+- **`max_idle_time` terminated busy workers, so the provider-side reap is gone**
+  (#194). `_cleanup_resources()` reclaimed a `RUNNING` resource once
+  `time.time() - resource["timestamp"] > max_idle_time`, but `"timestamp"` is
+  stamped once at submit and never refreshed. The expression was therefore
+  wall-clock age since submission with no idleness component at all, despite a log
+  line reading "has been idle for N seconds" — so **any task running longer than
+  the limit was killed mid-flight**, at the 300-second default. Not a corner:
+  `_cleanup_resources()` is called unconditionally from `cancel()`, which Parsl
+  invokes on every scale-in.
+
+  It cannot be repaired at this layer. Idleness means "holding no tasks", and a
+  provider never sees task state; Parsl's interchange does, and
+  `HighThroughputExecutor.scale_in` already reaps on it, selecting blocks where
+  `idle > max_idletime and tasks == 0` from per-manager counts. So the branch is
+  removed rather than rewritten, and callers wanting idle reclamation set
+  `max_idletime` on their Parsl `Config`.
+
+  Nothing leaks as a result. The branch only ever fired when `auto_shutdown` was
+  set, and that same flag already appends `shutdown -h now` to the worker's
+  UserData with `InstanceInitiatedShutdownBehavior=terminate` — a worker that
+  finishes its command terminates itself, and the existing `COMPLETED` branch
+  collects the record.
+
+  `max_idle_time` is still accepted, still persisted, and still forwarded to the
+  modes, so state files and generated Globus endpoint configs from earlier
+  versions keep loading; it is simply read by nothing. Passing a non-default value
+  now raises a `DeprecationWarning`, because silently ignoring a tuned value is
+  the worse failure here — the option used to terminate running work, so somebody
+  may have raised it as a workaround and would otherwise never learn it no longer
+  applies.
+
+  Six regression tests were added, each verified to fail against the previous
+  code, and eleven documentation and example references were corrected. Three of
+  those had documented the defect as though it were the intent
+  (`docs/getting_started.md`, `docs/operating_modes.md`, `docs/troubleshooting.md`
+  all described reclaiming a "long-`RUNNING`" resource), and
+  `docs/architecture.md` separately attributed the bastion's own shutdown to
+  `max_idle_time` when it uses `idle_timeout`.
 - **The README was fiction, and it is the PyPI landing page.** Both quick starts
   opened on modules that have never existed in this repository or on PyPI —
   `from phase15_enhanced import AWSProvider` and

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,7 +74,7 @@ behind NAT.
 2. The bastion polls for pending jobs, launches workers, tracks status, and
    handles cancellations.
 3. The client may disconnect; the workflow continues.
-4. The bastion shuts down after `max_idle_time` with no work.
+4. The bastion shuts down after `idle_timeout` minutes with no work.
 
 The bastion is an autonomous orchestrator, not a network tunnel — which is why an
 EC2 Instance Connect Endpoint cannot replace it

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -488,7 +488,6 @@ provider = EphemeralAWSProvider(
     min_blocks=0,
     max_blocks=5,
     auto_shutdown=True,
-    max_idle_time=300,
     additional_tags={"Project": "parsl-demo", "CostCenter": "research"},
 )
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -161,13 +161,27 @@ provider = EphemeralAWSProvider(
     # ... network and compute options ...
     min_blocks=0,     # no floor; nothing runs when nothing is queued
     max_blocks=10,
-    auto_shutdown=True,
-    max_idle_time=300,  # seconds a RUNNING resource may sit before reclaim
+    auto_shutdown=True,  # a worker terminates itself when its command finishes
 )
 ```
 
 `max_blocks` also caps concurrent submissions — a job past the limit raises
 rather than queueing.
+
+To reclaim instances that are up but *idle*, use Parsl's `max_idletime`, not a
+provider option — only Parsl's interchange knows how many tasks a worker holds:
+
+```python
+from parsl.config import Config
+
+config = Config(executors=[...], max_idletime=300.0)
+```
+
+`HighThroughputExecutor.scale_in` applies it to blocks that are both idle past
+the limit and holding zero tasks. The provider's own `max_idle_time` is
+deprecated and ignored: it compared against a timestamp taken at submission, so
+it terminated any task that simply ran longer than the limit
+([#194](https://github.com/scttfrdmn/parsl-aws-provider/issues/194)).
 
 ### Multiple instance types
 

--- a/docs/globus_compute.md
+++ b/docs/globus_compute.md
@@ -264,7 +264,7 @@ Recommended values for a Globus Compute deployment:
 | `max_blocks` | `4`–`20` | Hard ceiling on concurrent instances |
 | `use_spot` | `True` | Large saving for fault-tolerant functions; set `max_retries_on_system_failure` on the engine |
 | `auto_create_instance_profile` | `True` | Creates a role with `AmazonSSMManagedInstanceCore` |
-| `auto_shutdown` + `max_idle_time` | `True`, `300` | Reclaim idle instances |
+| `auto_shutdown` | `True` | A worker terminates itself when its command finishes |
 | `bake_ami` | `True` | Runs `worker_init` once into an AMI instead of on every launch |
 
 `mode="serverless"` is not useful here — Lambda and Fargate cannot run the

--- a/docs/operating_modes.md
+++ b/docs/operating_modes.md
@@ -54,7 +54,6 @@ provider = EphemeralAWSProvider(
     use_public_ips=True,     # False if reaching the subnet over VPN/Direct Connect
     key_name="your-key-pair",  # optional; SSM Session Manager needs no key
     use_spot=True,
-    max_idle_time=600,       # seconds a RUNNING resource may sit before reclaim
 )
 ```
 
@@ -172,9 +171,10 @@ These are accepted only on `mode="detached"`; setting one on another mode raises
 detached branch only and they would otherwise appear configured while having no
 effect.
 
-Note `max_idle_time` is a *provider*-level setting and is unrelated: it governs
-when the provider reclaims a resource that has been `RUNNING` longer than the
-limit, not when the bastion shuts down.
+Note `idle_timeout` governs only the bastion. It is unrelated to the provider's
+`max_idle_time`, which is deprecated and ignored
+([#194](https://github.com/scttfrdmn/parsl-aws-provider/issues/194)) — to reclaim
+idle workers, set `max_idletime` on your Parsl `Config`.
 
 ### When to use
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -370,8 +370,9 @@ implemented.
 - **CloudTrail** records every API call the provider makes, including each
   `StartSession`. This is your real audit trail.
 - **Budgets and CloudWatch alarms** on EC2 spend are worth setting up: the
-  provider has no cost controls of its own beyond `max_blocks`,
-  `max_idle_time`, and the warm-pool cap.
+  provider has no cost controls of its own beyond `max_blocks`, `auto_shutdown`,
+  and the warm-pool cap. Reclaiming idle-but-running instances is Parsl's
+  `max_idletime`, not a provider setting.
 - **CloudWatch Logs** hold cloud-init output only if you configure the agent in
   `worker_init`; the provider does not install it.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -54,7 +54,7 @@ The option does not exist. Common renames:
 | `state_bucket` | `s3_bucket` |
 | `state_file` / `state_directory` | `state_file_path` |
 | `worker_type` | `compute_type` |
-| `idle_timeout_minutes` | `max_idle_time` (**seconds**) |
+| `idle_timeout_minutes` | `idle_timeout` (minutes, detached mode's bastion) |
 | `create_vpc` / `use_existing_vpc` | removed — the network is always yours (#69) |
 
 Eight options that were unreachable before v0.8.0 are now accepted:
@@ -369,8 +369,9 @@ for the SSM agent to register — a private subnet requires a NAT gateway or the
 That is deliberate: the bastion is preserved so you can reconnect. Call
 `provider.shutdown()` when the workflow is genuinely over, or pass
 `preserve_bastion=False` so shutdown terminates it. Its own idle-shutdown timer
-is `idle_timeout` (minutes, default 30); `max_idle_time` is unrelated — that
-governs when the *provider* reclaims a long-`RUNNING` resource.
+is `idle_timeout` (minutes, default 30). The provider's `max_idle_time` is
+unrelated, and is deprecated and ignored
+([#194](https://github.com/scttfrdmn/parsl-aws-provider/issues/194)).
 
 ## Cost
 
@@ -396,7 +397,8 @@ The provider has no cost monitoring — `max_cost_per_hour` and
 
 - `min_blocks=0` so nothing runs when nothing is queued
 - `max_blocks` as a hard ceiling
-- `auto_shutdown=True` with `max_idle_time` (seconds) to reclaim idle resources
+- `auto_shutdown=True` so a worker terminates itself once its command finishes
+- `max_idletime` on your Parsl `Config` to reclaim workers that are idle but up
 - `use_spot=True`, optionally with `spot_max_price_percentage`
 
 Set AWS Budgets and a CloudWatch billing alarm; tag with `additional_tags` for

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -57,8 +57,10 @@ def standard_mode_provider() -> EphemeralAWSProvider:
         state_store_type="file",
         state_file_path="basic_usage_standard.json",
         auto_create_instance_profile=True,
+        # A worker terminates itself when its command finishes. To reclaim
+        # workers that are idle but still up, set max_idletime on the Parsl
+        # Config -- the provider cannot see task occupancy (#194).
         auto_shutdown=True,
-        max_idle_time=300,
         additional_tags={"Project": "ParslExample", "Mode": "standard"},
         **_network(),
     )

--- a/examples/standard_mode.py
+++ b/examples/standard_mode.py
@@ -76,8 +76,10 @@ def main() -> int:
         init_blocks=1,
         # image_id is omitted, so an Amazon Linux 2023 AMI matching the
         # instance type's architecture is resolved from SSM.
+        # A worker terminates itself when its command finishes. Reclaiming
+        # idle-but-running workers is Parsl's max_idletime, not a provider
+        # option -- only the interchange knows a worker's task count (#194).
         auto_shutdown=True,
-        max_idle_time=300,
         auto_create_instance_profile=True,
         state_store_type="file",
         state_file_path="standard_mode_state.json",

--- a/parsl_aws_provider/modes/base.py
+++ b/parsl_aws_provider/modes/base.py
@@ -64,9 +64,9 @@ class OperatingMode(abc.ABC):
     additional_tags : Dict[str, str]
         Tags to apply to created resources
     auto_shutdown : bool
-        Whether to automatically shut down idle resources
+        Whether a worker terminates itself once its command finishes
     max_idle_time : int
-        Maximum idle time in seconds before shutdown
+        Deprecated and ignored; retained so older state files still load (#194)
     use_public_ips : bool
         Whether to assign public IPs to instances
     custom_ami : bool
@@ -139,9 +139,12 @@ class OperatingMode(abc.ABC):
         additional_tags : Optional[Dict[str, str]], optional
             Tags to apply to created resources, by default None
         auto_shutdown : bool, optional
-            Whether to automatically shut down idle resources, by default True
+            Whether a worker terminates itself once its command finishes, by
+            default True
         max_idle_time : int, optional
-            Maximum idle time in seconds before shutdown, by default 300
+            Deprecated and ignored, by default 300. Nothing reads it; it is kept
+            so state files written by earlier versions still load. Use Parsl's
+            own ``max_idletime`` to reclaim idle blocks (#194).
         use_public_ips : bool, optional
             Whether to assign public IPs to instances, by default True
         custom_ami : bool, optional

--- a/parsl_aws_provider/modes/standard.py
+++ b/parsl_aws_provider/modes/standard.py
@@ -135,9 +135,11 @@ class StandardMode(OperatingMode):
         additional_tags : Optional[Dict[str, str]], optional
             Tags to apply to created resources, by default None
         auto_shutdown : bool, optional
-            Whether to automatically shut down idle resources, by default True
+            Whether a worker terminates itself once its command finishes, by
+            default True. Appends ``shutdown -h now`` to the worker's UserData.
         max_idle_time : int, optional
-            Maximum idle time in seconds before shutdown, by default 300
+            Deprecated and ignored, by default 300. Use Parsl's own
+            ``max_idletime`` to reclaim idle blocks (#194).
         use_public_ips : bool, optional
             Whether to assign public IPs to instances, by default True
         custom_ami : bool, optional

--- a/parsl_aws_provider/provider.py
+++ b/parsl_aws_provider/provider.py
@@ -12,6 +12,7 @@ import logging
 import threading
 import time
 import uuid
+import warnings
 from enum import Enum
 from typing import Any, Dict, List, Optional, Sequence
 
@@ -197,9 +198,27 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
     additional_tags : Dict[str, str], optional
         Additional tags to apply to AWS resources.
     auto_shutdown : bool, optional
-        Whether to automatically shut down idle resources. Default is True.
+        Whether a worker terminates itself once its command finishes. Default is
+        True, which appends ``shutdown -h now`` to the worker's UserData; the
+        instance launches with ``InstanceInitiatedShutdownBehavior=terminate``,
+        so it is terminated rather than stopped with a billed EBS volume. Set
+        False only if you intend to keep instances after their work completes.
     max_idle_time : int, optional
-        Maximum idle time in seconds before shutdown. Default is 300 (5 minutes).
+        Deprecated and ignored; accepted only so existing configurations keep
+        loading. Default is 300.
+
+        This never measured idleness. It was compared against a timestamp
+        stamped once at submit, making it wall-clock age since submission, so it
+        terminated any task that ran longer than the limit (#194). A provider
+        cannot compute idleness -- that needs per-manager task counts only
+        Parsl's interchange has. Use Parsl's own ``max_idletime``, which
+        ``HighThroughputExecutor.scale_in`` applies to genuinely idle blocks:
+
+        .. code-block:: python
+
+            from parsl.config import Config
+
+            config = Config(executors=[...], max_idletime=300.0)
     compute_type : str, optional
         Type of compute resource when using serverless mode ('ec2', 'lambda', or 'ecs').
         Default is 'ec2'.
@@ -451,7 +470,25 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
         self.spot_max_price_percentage = spot_max_price_percentage
         self.additional_tags = additional_tags or {}
         self.auto_shutdown = auto_shutdown
+        # Retained as an attribute because it is persisted in the state document
+        # and forwarded to every mode, so dropping it would break state files
+        # written by earlier versions. Nothing reads it (#194).
         self.max_idle_time = max_idle_time
+        if max_idle_time != DEFAULT_MAX_IDLE_TIME:
+            # Warn only when it was set deliberately. Silently ignoring a
+            # tuned value is the worse failure here: the option used to
+            # terminate running work, so somebody may have raised it as a
+            # workaround and would otherwise never learn it no longer applies.
+            warnings.warn(
+                "max_idle_time is deprecated and ignored: it measured age since "
+                "submission rather than idleness, and terminated tasks that ran "
+                "longer than it (#194). A provider cannot see task occupancy. "
+                "Set max_idletime on your Parsl Config instead, which "
+                "HighThroughputExecutor.scale_in applies to genuinely idle "
+                "blocks.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self.compute_type = ComputeType(compute_type.lower())
         self.bastion_instance_type = bastion_instance_type
         self.idle_timeout = idle_timeout
@@ -1425,17 +1462,30 @@ class EphemeralAWSProvider(ExecutionProvider, RepresentationMixin):
                 # cost leak (#137).
                 if status in ["COMPLETED", "FAILED", "CANCELED", STATUS_INTERRUPTED]:
                     resources_to_cleanup.append(resource_id)
-                elif (
-                    self.auto_shutdown
-                    and status == "RUNNING"
-                    and time.time() - resource.get("timestamp", 0) > self.max_idle_time
-                ):
-                    logger.info(
-                        f"Resource {resource_id} has been idle for "
-                        f"{time.time() - resource.get('timestamp', 0):.0f} seconds, "
-                        f"exceeding max_idle_time {self.max_idle_time}"
-                    )
-                    resources_to_cleanup.append(resource_id)
+
+                # A RUNNING resource is never reaped here. There used to be a
+                # branch that terminated one once
+                # `time.time() - resource["timestamp"] > max_idle_time`, but
+                # "timestamp" is stamped once at submit and never refreshed, so
+                # that expression measured wall-clock age since submission and
+                # had no idleness component at all -- it killed any task that
+                # simply ran longer than the limit, mid-flight (#194).
+                #
+                # It cannot be repaired at this layer: idleness means "no tasks
+                # assigned", and a provider never sees task state. Parsl does,
+                # and already reaps on it -- HighThroughputExecutor.scale_in
+                # selects blocks with `idle > max_idletime and tasks == 0` from
+                # per-manager `idle_duration` and `tasks` counts that only the
+                # interchange has. Set `max_idletime` on the Parsl config to
+                # tune it.
+                #
+                # Nothing is leaked by dropping this. Whenever auto_shutdown is
+                # set -- the only case the old branch fired in -- the worker's
+                # UserData ends in `shutdown -h now`
+                # (modes/standard.py:_generate_init_script) with
+                # InstanceInitiatedShutdownBehavior=terminate, so a worker that
+                # finishes its command terminates itself, and the COMPLETED
+                # branch above collects the record.
 
         # Process COMPLETED → WARM transitions
         state_dirty = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -566,5 +566,8 @@ def ephemeral_provider_config():
         "max_blocks": 2,
         "debug": True,
         "auto_shutdown": True,
-        "max_idle_time": 60,  # 1 minute for faster tests
+        # max_idle_time deliberately omitted: it is deprecated and ignored, and
+        # setting it to anything but the default now raises a
+        # DeprecationWarning (#194). It shortened nothing here anyway -- nothing
+        # ever read it.
     }

--- a/tests/unit/test_globus_config_loading.py
+++ b/tests/unit/test_globus_config_loading.py
@@ -299,7 +299,16 @@ class TestEveryParameterSurvivesTheRoundTrip:
             ),
             pytest.param({"baked_ami_id": "ami-0bakedbakedbaked0"}, id="baked-ami"),
             pytest.param({"key_name": "mykey", "use_public_ips": False}, id="access"),
-            pytest.param({"auto_shutdown": False, "max_idle_time": 900}, id="idle"),
+            # max_idle_time is deprecated and ignored (#194), but it is still
+            # persisted and forwarded, so it must still survive the round trip --
+            # that is exactly what this class asserts. The warning is expected.
+            pytest.param(
+                {"auto_shutdown": False, "max_idle_time": 900},
+                id="idle",
+                marks=pytest.mark.filterwarnings(
+                    "ignore:max_idle_time is deprecated:DeprecationWarning"
+                ),
+            ),
             pytest.param({"profile_name": "aws"}, id="profile"),
         ],
     )
@@ -399,6 +408,12 @@ class TestEveryParameterSurvivesTheRoundTrip:
 
         assert loaded.image_id == "ami-0123456789abcdef0"
 
+    @pytest.mark.filterwarnings(
+        # The sample below sets every accepted parameter, including the
+        # deprecated max_idle_time (#194), which is the point: a deprecated
+        # option must still be emitted or a loaded config would silently differ.
+        "ignore:max_idle_time is deprecated:DeprecationWarning"
+    )
     def test_emitted_set_is_derived_from_the_signature(self, tmp_path):
         """The property that keeps this fixed: no hand-maintained list.
 

--- a/tests/unit/test_provider_edge_cases.py
+++ b/tests/unit/test_provider_edge_cases.py
@@ -10,6 +10,7 @@ import os
 import tempfile
 import time
 import uuid
+import warnings
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -23,6 +24,7 @@ from parsl_aws_provider.constants import (
     DEFAULT_ECS_CPU,
     DEFAULT_ECS_MEMORY,
     DEFAULT_LAMBDA_RUNTIME,
+    DEFAULT_MAX_IDLE_TIME,
     DEFAULT_PRESERVE_BASTION,
     DEFAULT_WARM_POOL_SIZE,
     DEFAULT_WARM_POOL_TTL,
@@ -1573,3 +1575,135 @@ class TestSpotInterruptionStatus:
         mode.cleanup_resources.assert_called_once_with(["i-001"])
         assert "i-001" not in mode._warm_instances
         assert "i-001" not in provider.resources
+
+
+@pytest.mark.unit
+class TestRunningResourcesSurviveCleanup:
+    """A RUNNING resource is never reaped by age (#194).
+
+    The removed branch compared ``time.time() - resource["timestamp"]`` against
+    ``max_idle_time``, but "timestamp" is stamped once at submit and never
+    refreshed. That made it age-since-submission, so any task running longer
+    than the limit was terminated mid-flight. These cases pin the absence of
+    that branch; each one fails against the old code.
+    """
+
+    @pytest.fixture
+    def tmp_dir(self):
+        with tempfile.TemporaryDirectory() as d:
+            yield d
+
+    def test_a_long_running_job_is_not_terminated(self, tmp_dir):
+        """The regression itself: busy work, far past the limit, left alone."""
+        provider, mode = _make_provider(tmp_dir, auto_shutdown=True)
+        # Submitted an hour ago and still running -- a perfectly healthy job
+        # for any real workload, and 12x the old 300s default.
+        provider.resources["i-busy"] = {
+            "job_id": "j-busy",
+            "status": "RUNNING",
+            "timestamp": time.time() - 3600,
+        }
+        provider.job_map["j-busy"] = {"resource_id": "i-busy", "status": "RUNNING"}
+
+        provider._cleanup_resources()
+
+        mode.cleanup_resources.assert_not_called()
+        assert "i-busy" in provider.resources
+        assert provider.resources["i-busy"]["status"] == "RUNNING"
+
+    def test_age_does_not_reap_even_at_the_extreme(self, tmp_dir):
+        """No threshold survives: a timestamp of 0 is maximally "old"."""
+        provider, mode = _make_provider(tmp_dir, auto_shutdown=True)
+        provider.resources["i-ancient"] = {
+            "job_id": "j-ancient",
+            "status": "RUNNING",
+            "timestamp": 0,
+        }
+        provider.job_map["j-ancient"] = {
+            "resource_id": "i-ancient",
+            "status": "RUNNING",
+        }
+
+        provider._cleanup_resources()
+
+        mode.cleanup_resources.assert_not_called()
+        assert "i-ancient" in provider.resources
+
+    def test_a_pending_resource_is_also_left_alone(self, tmp_dir):
+        """A slow-booting instance must not be reclaimed before it registers."""
+        provider, mode = _make_provider(tmp_dir, auto_shutdown=True)
+        provider.resources["i-booting"] = {
+            "job_id": "j-booting",
+            "status": "PENDING",
+            "timestamp": time.time() - 3600,
+        }
+        provider.job_map["j-booting"] = {
+            "resource_id": "i-booting",
+            "status": "PENDING",
+        }
+
+        provider._cleanup_resources()
+
+        mode.cleanup_resources.assert_not_called()
+        assert "i-booting" in provider.resources
+
+    def test_terminal_resources_are_still_collected(self, tmp_dir):
+        """Removing the age branch must not stop real cleanup.
+
+        Guards against "fixing" the reap by disabling ``_cleanup_resources``
+        altogether, which would leak every finished instance's record.
+        """
+        provider, mode = _make_provider(tmp_dir, auto_shutdown=True)
+        for idx, status in enumerate(
+            ["COMPLETED", "FAILED", "CANCELED", STATUS_INTERRUPTED]
+        ):
+            rid = f"i-{idx}"
+            provider.resources[rid] = {
+                "job_id": f"j-{idx}",
+                "status": status,
+                "timestamp": time.time(),
+            }
+            provider.job_map[f"j-{idx}"] = {"resource_id": rid, "status": status}
+
+        provider._cleanup_resources()
+
+        mode.cleanup_resources.assert_called_once()
+        assert sorted(mode.cleanup_resources.call_args[0][0]) == [
+            "i-0",
+            "i-1",
+            "i-2",
+            "i-3",
+        ]
+        assert provider.resources == {}
+
+    def test_setting_max_idle_time_warns_that_it_is_ignored(self, tmp_dir):
+        """Silently ignoring a tuned value would be the worse failure.
+
+        The option used to terminate running work, so somebody may have raised
+        it as a workaround; they need to learn it no longer applies.
+        """
+        with pytest.warns(DeprecationWarning, match="max_idle_time is deprecated"):
+            provider, mode = _make_provider(tmp_dir, max_idle_time=900)
+
+        # Still recorded: it is persisted in the state document and forwarded to
+        # every mode, so dropping the attribute would break older state files.
+        assert provider.max_idle_time == 900
+
+        provider.resources["i-busy"] = {
+            "job_id": "j-busy",
+            "status": "RUNNING",
+            "timestamp": time.time() - 9000,  # 10x the value that was set
+        }
+        provider.job_map["j-busy"] = {"resource_id": "i-busy", "status": "RUNNING"}
+
+        provider._cleanup_resources()
+
+        mode.cleanup_resources.assert_not_called()
+
+    def test_leaving_max_idle_time_at_its_default_is_silent(self, tmp_dir):
+        """Warning on a value nobody set would be noise on every construction."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            provider, _ = _make_provider(tmp_dir)
+
+        assert provider.max_idle_time == DEFAULT_MAX_IDLE_TIME


### PR DESCRIPTION
Closes #194.

## The defect

`_cleanup_resources()` reclaimed a `RUNNING` resource once
`time.time() - resource["timestamp"] > self.max_idle_time`. But `"timestamp"` is
written exactly once — at `provider.py:1099`, inside `submit()` — and never
refreshed. The only other `"timestamp"` in the file is the state document's own.

So the expression was **wall-clock age since submission**, with no idleness
component at all, while the log line read `has been idle for N seconds`. Any task
running longer than the limit was terminated mid-flight, at the 300-second
default.

Not a corner case: `_cleanup_resources()` is called unconditionally from
`cancel()`, and `cancel()` is what Parsl invokes on every scale-in.

## Why the reap is removed rather than repaired

Idleness means "holding no tasks", and a provider never sees task state. Parsl's
interchange does, and already reaps on it — `HighThroughputExecutor.scale_in`
selects blocks where `idle > max_idletime and tasks == 0`, from per-manager
`idle_duration` and `tasks` counts that no provider can reach. Parsl got this
right and the provider was overriding it with a wrong metric.

**Nothing leaks by dropping it.** The branch only ever fired when
`auto_shutdown` was set — and that same flag already appends `shutdown -h now`
to the worker's UserData (`modes/standard.py:_generate_init_script`) with
`InstanceInitiatedShutdownBehavior=terminate`. A worker that finishes its command
terminates itself, and the existing `COMPLETED` branch collects the record. The
removed branch could therefore *only* ever have fired on work still in flight.

## Compatibility

`max_idle_time` remains accepted, persisted in the state document, and forwarded
to every mode, so state files and generated Globus endpoint configs written by
earlier versions keep loading. It is simply read by nothing.

Passing a **non-default** value now raises `DeprecationWarning`. Silently
ignoring a tuned value is the worse failure here: the option used to terminate
running work, so somebody may have raised it as a workaround and would otherwise
never learn it no longer applies. Leaving it at the default stays silent, so no
existing config gains noise.

## Verification

**Negative control first.** Stashed the fix, restored the old `provider.py`, ran
the new tests — exactly the right three failed, for the right reasons, including:

```
INFO Resource i-ancient has been idle for 1785639774 seconds, exceeding max_idle_time 300
FAILED ...::test_a_long_running_job_is_not_terminated
FAILED ...::test_age_does_not_reap_even_at_the_extreme
FAILED ...::test_setting_max_idle_time_warns_that_it_is_ignored
```

on a job that was never idle. The other three pass either way by design — one
pins that terminal resources are *still* collected, guarding against "fixing"
this by disabling `_cleanup_resources()` altogether.

| Check | Result |
|---|---|
| `pytest tests/unit tests/security` | **1179 passed, 2 skipped** (was 1173; +6) |
| `ruff check .` / `ruff format --check .` | clean, 124 files formatted |
| `mypy parsl_aws_provider` | 76 errors — baseline, no new |
| `make -C docs html SPHINXOPTS="-W"` | build succeeded |
| Suite `DeprecationWarning` count | 23 → 20 (none from this change) |

## Documentation

Eleven references corrected across seven files. Three had documented the defect
as though it were the intent — `getting_started.md`, `operating_modes.md`, and
`troubleshooting.md` all described reclaiming a "long-`RUNNING`" resource, which
invited users to tune exactly the thing that would kill their work. Separately,
`architecture.md:77` attributed the *bastion's* shutdown to `max_idle_time` when
the bastion uses `idle_timeout`, and `troubleshooting.md:57` mapped a migrating
user's `idle_timeout_minutes` onto `max_idle_time` rather than `idle_timeout`.

`getting_started.md` now shows the replacement, since a reader hitting this needs
somewhere to go:

```python
config = Config(executors=[...], max_idletime=300.0)
```

Two tests in `test_globus_config_loading.py` deliberately pass a non-default
`max_idle_time` to prove it survives the config round trip; both carry a scoped
`filterwarnings` marker explaining why, rather than the warning being silenced
globally. `tests/conftest.py` drops `max_idle_time: 60`, which had claimed to
make tests faster while being read by nothing.