### PR TITLE
fix: grant the IAM deletes the teardown needs (closes #195)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,63 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   4.0.1).
 
 ### Fixed
+- **`minimum_iam_policy()` granted creates without deletes, silently re-creating
+  the #132 leak** (#195). The policy carried `iam:CreateRole`,
+  `iam:CreateInstanceProfile`, `iam:AddRoleToInstanceProfile`,
+  `iam:AttachRolePolicy` and `iam:PassRole` with **no IAM delete action at all**,
+  on the rationale that "the provider does not tear the profile down (#132), so
+  granting them would permit more than it performs".
+
+  That rationale stopped being true when v0.8.0 shipped the #132 fix: the teardown
+  in `utils/aws.py` now runs on every `cleanup_infrastructure()`. Because cleanup
+  logs rather than raises, the resulting `AccessDenied` was invisible — so a user
+  on this exact policy reproduced the leak #132 was filed to stop, the failure
+  that accumulated 94 orphaned roles and 94 orphaned instance profiles in a real
+  account. The policy was quietly reverting the fix.
+
+  Added, each verified against a real call site: `iam:RemoveRoleFromInstanceProfile`,
+  `iam:DeleteInstanceProfile`, `iam:ListAttachedRolePolicies`,
+  `iam:DetachRolePolicy`, `iam:DeleteRole`, and `sts:GetCallerIdentity` —
+  the last being the *first* AWS call the package makes, since `create_session()`
+  validates every session with it, so a user on this policy previously failed at
+  `EphemeralAWSProvider(...)` before reaching any AWS work. Also added
+  `ssm:PutParameter`, `ssm:DeleteParameter` and `ssm:DeleteParameters` for
+  `state_store_type="parameter_store"`; both deletes appear because they are
+  distinct IAM actions and the backend calls both.
+
+  **Removed** five actions granted for a transport that does not exist:
+  `ssm:StartSession`, `TerminateSession`, `ResumeSession`, `DescribeSessions` and
+  `GetConnectionStatus`, listed under "Session Manager tunnels to reach workers in
+  a private subnet". Nothing in the package calls any of them — the bastion is an
+  autonomous orchestrator, not a network tunnel — and `StartSession` in particular
+  grants an interactive shell on the instance. The statement `Sid` is renamed
+  `SSMTunneling` → `SSMCommandsAndParameters` accordingly. `ec2:DescribeInstanceStatus`
+  and `ec2:DescribeLaunchTemplates`, which #195 also proposed adding, are
+  deliberately *not* added: neither has a call site.
+
+  Two tests now enforce this in both directions, deriving from the package's own
+  source rather than a curated list — every granted action must have a call site,
+  and every IAM or STS call the policy's scope reaches must be granted. The old
+  suite had a `test_iam_delete_actions_absent` asserting the *opposite*, which is
+  why CI stayed green over the defect; it is inverted to
+  `test_iam_delete_actions_present`.
+
+  The hand-written policy in `docs/network-prerequisites.md` is replaced by the
+  generator too. Its seven actions had drifted the opposite way — granting
+  `ec2:CreateSecurityGroup` and `AuthorizeSecurityGroupIngress`, removed by #69,
+  while omitting `ssm:GetParameter`, `ec2:CreateLaunchTemplate`,
+  `ec2:DescribeInstanceTypes`, `ec2:DescribeVpcs` and `sts:GetCallerIdentity`, so
+  a user following it failed at construction, where `initialize()` resolves the
+  AMI from SSM and creates a launch template.
+
+  **Correcting the released changelog:** the v0.8.0 entry for #87 states "No IAM
+  delete actions are granted, because the provider performs no instance-profile
+  teardown (#132)". That was accurate when written and was made false by #132
+  landing in the same release. Released sections are not edited, so the correction
+  is recorded here. Four documentation claims that the profile is "not deleted on
+  shutdown" are corrected in place (`docs/architecture.md` ×2, `docs/security.md`,
+  `docs/troubleshooting.md`), as is a `docs/security.md` line citing a
+  CloudTrail-recorded `StartSession` that never occurs.
 - **`max_idle_time` terminated busy workers, so the provider-side reap is gone**
   (#194). `_cleanup_resources()` reclaimed a `RUNNING` resource once
   `time.time() - resource["timestamp"] > max_idle_time`, but `"timestamp"` is

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -93,9 +93,10 @@ The provider creates and manages:
 - **Compute**: EC2 instances, EC2 Fleets, Lambda functions, ECS tasks
 - **Launch templates**: one per provider, carrying IMDSv2, shutdown behaviour,
   and the instance profile
-- **IAM instance profile and role**: only when `auto_create_instance_profile=True`
-  (note: not yet deleted on shutdown —
-  [#132](https://github.com/scttfrdmn/parsl-aws-provider/issues/132))
+- **IAM instance profile and role**: only when `auto_create_instance_profile=True`,
+  and deleted on shutdown since v0.8.0
+  ([#132](https://github.com/scttfrdmn/parsl-aws-provider/issues/132)). A profile
+  you supply through `iam_instance_profile_arn` is never touched.
 - **CloudFormation stacks**: bastion (detached), Lambda and ECS workers
   (serverless)
 - **State storage**: a local file, an S3 object, or an SSM parameter
@@ -148,9 +149,13 @@ their own polling loops instead; keeping both is tracked as
 - No long-lived credentials on instances — workers use an instance profile
 - Resource isolation by provider ID in tags and state keys
 
-Instance profiles created with `auto_create_instance_profile=True` are not deleted
-on shutdown ([#132](https://github.com/scttfrdmn/parsl-aws-provider/issues/132));
-supply `iam_instance_profile_arn` if you need to control that lifecycle yourself.
+Instance profiles created with `auto_create_instance_profile=True` are deleted on
+shutdown since v0.8.0
+([#132](https://github.com/scttfrdmn/parsl-aws-provider/issues/132)). Deletion is
+gated on ownership, so a profile supplied through `iam_instance_profile_arn`
+survives — supply your own ARN to control that lifecycle yourself. Grant the
+teardown actions in your IAM policy, or cleanup fails silently and the roles
+accumulate ([#195](https://github.com/scttfrdmn/parsl-aws-provider/issues/195)).
 
 ## Testing with a local AWS emulator
 

--- a/docs/network-prerequisites.md
+++ b/docs/network-prerequisites.md
@@ -33,29 +33,33 @@ PyPI/package mirrors).  No inbound rules are required by the provider itself.
 
 ## Minimum IAM Permissions
 
-The provider's EC2 instances need SSM access (for warm-pool dispatch and
-connectivity via Session Manager):
+Do not copy a policy out of a document — this one had drifted into being
+unusable. Generate the current policy for the principal that *runs* the
+provider:
 
-```json
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "ec2:RunInstances",
-        "ec2:DescribeInstances",
-        "ec2:TerminateInstances",
-        "ec2:CreateTags",
-        "ssm:SendCommand",
-        "ssm:GetCommandInvocation",
-        "ssm:DescribeInstanceInformation"
-      ],
-      "Resource": "*"
-    }
-  ]
-}
+```python
+import json
+
+from parsl_aws_provider import GlobusComputeProvider
+
+print(json.dumps(GlobusComputeProvider.minimum_iam_policy(), indent=2))
 ```
+
+It is a `@staticmethod`, so no provider instance is needed, and it describes the
+base `EphemeralAWSProvider` just as well despite living on the Globus subclass.
+Every action it grants has a call site in the package, and a unit test asserts
+that in both directions.
+
+The seven-action policy previously printed here failed at **construction**:
+`__init__` ends by calling `initialize()`, which resolves the AMI from SSM and
+creates a launch template, so it needed `ssm:GetParameter`,
+`ec2:CreateLaunchTemplate`, `ec2:DescribeInstanceTypes`, `ec2:DescribeVpcs`, and
+`sts:GetCallerIdentity` — none of which it granted
+([#195](https://github.com/scttfrdmn/parsl-aws-provider/issues/195)).
+
+The **workers** are separate and need much less: attaching the AWS-managed
+`AmazonSSMManagedInstanceCore` to the instance profile is the whole requirement,
+which `auto_create_instance_profile=True` does for you.
 
 ---
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -39,14 +39,25 @@ print(json.dumps(GlobusComputeProvider.minimum_iam_policy(include_ecr=True), ind
 This is a `@staticmethod` — you do not need to construct a provider to call it,
 and it applies to `EphemeralAWSProvider` just as much as to the Globus subclass.
 
-It returns four statements: `EC2Management`, `SSMTunneling`,
-`SpotInterruptionWarning`, and `IAMInstanceProfile`, plus `ECRContainerImages`
-when `include_ecr=True`.
+It returns five statements: `SessionValidation`, `EC2Management`,
+`SSMCommandsAndParameters`, `SpotInterruptionWarning`, and `IAMInstanceProfile`,
+plus `ECRContainerImages` when `include_ecr=True`.
 
 Note what it does **not** grant: no `ec2:CreateVpc`, `CreateSubnet`,
 `CreateSecurityGroup`, `CreateNatGateway`, or `RequestSpotFleet`. Older versions
 of this document asked for all of them. The provider creates no network resources
-(#69) and uses `CreateFleet` rather than the legacy Spot Fleet API (#86).
+(#69) and uses `CreateFleet` rather than the legacy Spot Fleet API (#86). Nor any
+Session Manager action — `ssm:StartSession` and its four companions were granted
+for a tunnel this package does not have, and were removed in
+[#195](https://github.com/scttfrdmn/parsl-aws-provider/issues/195).
+
+The IAM statement grants **both halves** of the instance-profile lifecycle. The
+teardown grants are not symmetry for its own sake: `cleanup_infrastructure()`
+deletes the role and profile it created (#132), and cleanup logs rather than
+raises, so a policy granting only the creates leaks a standing privileged
+principal on every run without ever reporting an error. That is exactly how 94
+orphaned roles accumulated in a real account, and the policy reproduced it until
+#195.
 
 Every statement uses `Resource: "*"`. Most of these EC2 and IAM actions do not
 support resource-level permissions, but you should scope what you can with
@@ -184,9 +195,13 @@ provider = EphemeralAWSProvider(
 Attach `AmazonSSMManagedInstanceCore` as well if you use the warm pool or one-shot
 mode.
 
-**A role created with `auto_create_instance_profile=True` is not deleted on
-shutdown** ([#132](https://github.com/scttfrdmn/parsl-aws-provider/issues/132)).
-Supply your own ARN if you need to control that lifecycle.
+**A role created with `auto_create_instance_profile=True` is deleted on shutdown**
+since v0.8.0 ([#132](https://github.com/scttfrdmn/parsl-aws-provider/issues/132)),
+along with its instance profile. Deletion is gated on ownership, so a profile you
+supplied through `iam_instance_profile_arn` is never deleted. Your policy must
+grant the teardown actions listed above — cleanup logs rather than raises, so
+without them the roles accumulate silently
+([#195](https://github.com/scttfrdmn/parsl-aws-provider/issues/195)).
 
 ### Bastion instance profile (detached mode)
 
@@ -368,7 +383,8 @@ implemented.
 ### CloudTrail and CloudWatch
 
 - **CloudTrail** records every API call the provider makes, including each
-  `StartSession`. This is your real audit trail.
+  `RunInstances`, `SendCommand`, and IAM role creation and deletion. This is your
+  real audit trail.
 - **Budgets and CloudWatch alarms** on EC2 spend are worth setting up: the
   provider has no cost controls of its own beyond `max_blocks`, `auto_shutdown`,
   and the warm-pool cap. Reclaiming idle-but-running instances is Parsl's

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -410,9 +410,13 @@ Two things to know specifically:
   `warm_pool_ttl` seconds per idle period. Native ASG warm pools, which hold
   instances `Stopped`, are
   [#130](https://github.com/scttfrdmn/parsl-aws-provider/issues/130).
-- **A role created by `auto_create_instance_profile=True` is not deleted** on
-  shutdown ([#132](https://github.com/scttfrdmn/parsl-aws-provider/issues/132)).
-  It costs nothing, but it accumulates.
+- **A role created by `auto_create_instance_profile=True`** is deleted on shutdown
+  since v0.8.0 ([#132](https://github.com/scttfrdmn/parsl-aws-provider/issues/132)).
+  If you still see them accumulating, your IAM policy is missing the teardown
+  actions: cleanup logs rather than raises, so `AccessDenied` there is silent
+  ([#195](https://github.com/scttfrdmn/parsl-aws-provider/issues/195)). Generate a
+  current policy with `GlobusComputeProvider.minimum_iam_policy()`, and reap
+  existing orphans with `tools/cleanup_aws_resources.py`.
 
 ### Stopped instances with billed EBS volumes
 

--- a/parsl_aws_provider/globus_compute.py
+++ b/parsl_aws_provider/globus_compute.py
@@ -80,8 +80,17 @@ SSM (required)
     ssm:GetParameter (resolves the current Amazon Linux 2023 AMI),
     ssm:SendCommand, ssm:GetCommandInvocation,
     ssm:DescribeInstanceInformation (warm-pool and one-shot dispatch),
-    ssm:StartSession, ssm:TerminateSession, ssm:ResumeSession,
-    ssm:DescribeSessions, ssm:GetConnectionStatus (Session Manager tunnels)
+    ssm:PutParameter, ssm:DeleteParameter, ssm:DeleteParameters
+    (``state_store_type="parameter_store"``)
+
+    No Session Manager grants. ssm:StartSession, TerminateSession,
+    ResumeSession, DescribeSessions and GetConnectionStatus were listed here for
+    "Session Manager tunnels", but no such transport exists in this package and
+    nothing calls them (#195).
+
+STS (always required)
+    sts:GetCallerIdentity -- ``create_session()`` verifies every session with it,
+    so this is the first AWS call the provider makes.
 
 EventBridge + SQS (required when use_spot and spot_interruption_handling)
     events:PutRule, events:PutTargets, events:RemoveTargets,
@@ -92,18 +101,25 @@ EventBridge + SQS (required when use_spot and spot_interruption_handling)
 IAM (required when auto_create_instance_profile=True)
     iam:CreateRole, iam:GetRole, iam:AttachRolePolicy,
     iam:CreateInstanceProfile, iam:GetInstanceProfile,
-    iam:AddRoleToInstanceProfile, iam:PassRole
+    iam:AddRoleToInstanceProfile, iam:PassRole,
+    iam:RemoveRoleFromInstanceProfile, iam:DeleteInstanceProfile,
+    iam:ListAttachedRolePolicies, iam:DetachRolePolicy, iam:DeleteRole
+
+    The teardown half is required, not optional: ``cleanup_infrastructure()``
+    deletes the pair it created (#132), and cleanup logs rather than raises, so
+    a missing delete grant leaks a standing privileged principal silently
+    (#195).
 
 ECR (only when container_image references an ECR repository)
     ecr:GetAuthorizationToken, ecr:BatchGetImage,
     ecr:GetDownloadUrlForLayer, ecr:BatchCheckLayerAvailability
 
-Not covered by ``minimum_iam_policy()``: the non-default state backends
-(``state_store_type="s3"`` needs S3 object access, ``"parameter_store"`` needs
-``ssm:PutParameter``/``GetParameter``/``DeleteParameter``/
-``GetParametersByPath``), ``mode="detached"`` (CloudFormation stack and SSM
-Parameter Store access), and ``mode="serverless"`` (Lambda, ECS, CloudWatch
-Logs, and IAM role lifecycle).
+Not covered by ``minimum_iam_policy()``: ``state_store_type="s3"`` (needs S3
+object access), ``mode="detached"`` (CloudFormation stack management), and
+``mode="serverless"`` (Lambda, ECS, CloudWatch Logs, and IAM role lifecycle).
+The Parameter Store backend *is* covered now -- it was listed here as uncovered
+while the policy also omitted the actions, so the omission read as deliberate
+(#195).
 
 SPDX-License-Identifier: Apache-2.0
 SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
@@ -567,14 +583,21 @@ class GlobusComputeProvider(EphemeralAWSProvider):
         ``AmazonSSMManagedInstanceCore``, which
         ``auto_create_instance_profile=True`` attaches for them.
 
-        Scope: the ``mode="standard"`` path with file-backed state, which is
-        what a generated endpoint config uses. Actions were derived from the
-        package's actual API calls, so the set is narrower than it was before
-        v0.7.0 -- network resources are caller-supplied since #69, so no
-        VPC/subnet/security-group/NAT/gateway create or delete grant appears,
-        and Spot Fleet was replaced by EC2 Fleet in #86. See the module
-        docstring for what is deliberately *not* covered (the S3 and Parameter
-        Store state backends, and detached and serverless modes).
+        Scope: the ``mode="standard"`` path, which is what a generated endpoint
+        config uses, with either file-backed or Parameter Store state. Actions
+        were derived from the package's actual API calls, so the set is narrower
+        than it was before v0.7.0 -- network resources are caller-supplied since
+        #69, so no VPC/subnet/security-group/NAT/gateway create or delete grant
+        appears, and Spot Fleet was replaced by EC2 Fleet in #86. See the module
+        docstring for what is deliberately *not* covered (the S3 state backend,
+        and detached and serverless modes).
+
+        Every action here has a call site in the package, and the teardown
+        actions matter as much as the create ones: cleanup logs rather than
+        raises, so a missing delete permission leaks resources silently. That is
+        what #195 found -- this method granted ``iam:CreateRole`` and
+        ``iam:CreateInstanceProfile`` with no corresponding deletes, so a user on
+        this policy reproduced the very leak #132 had just fixed.
 
         Parameters
         ----------
@@ -628,13 +651,23 @@ class GlobusComputeProvider(EphemeralAWSProvider):
             "ssm:SendCommand",
             "ssm:GetCommandInvocation",
             "ssm:DescribeInstanceInformation",
-            # Session Manager tunnels to reach workers in a private subnet
-            "ssm:StartSession",
-            "ssm:TerminateSession",
-            "ssm:ResumeSession",
-            "ssm:DescribeSessions",
-            "ssm:GetConnectionStatus",
+            # state_store_type="parameter_store", which detached mode needs so
+            # the client and the bastion can read the same state. Both the
+            # singular and plural deletes appear because they are distinct IAM
+            # actions and the code calls both: delete_parameter() per key, and
+            # delete_parameters() for the batched cleanup (#195).
+            "ssm:PutParameter",
+            "ssm:DeleteParameter",
+            "ssm:DeleteParameters",
         ]
+        # Deliberately absent: ssm:StartSession, TerminateSession,
+        # ResumeSession, DescribeSessions, GetConnectionStatus. These were
+        # granted for "Session Manager tunnels to reach workers in a private
+        # subnet", but no such transport exists in this package -- grep finds no
+        # call to any of them, and the bastion is an autonomous orchestrator
+        # rather than a network tunnel. Granting a session-opening permission
+        # nothing uses is exactly the over-grant this method exists to avoid
+        # (#195).
 
         # The advance spot-interruption warning (#86) is delivered by an
         # EventBridge rule into an SQS queue the provider creates and polls.
@@ -658,9 +691,17 @@ class GlobusComputeProvider(EphemeralAWSProvider):
             "sqs:DeleteQueue",
         ]
 
-        # Only needed for auto_create_instance_profile=True. No delete actions:
-        # the provider does not tear the profile down (#132), so granting them
-        # would permit more than it performs.
+        # Only needed for auto_create_instance_profile=True.
+        #
+        # The deletes are load-bearing, not symmetry for its own sake. This list
+        # once ended at PassRole, on the rationale that "the provider does not
+        # tear the profile down (#132)". v0.8.0's #132 fix made that false: the
+        # teardown in utils/aws.py runs on every cleanup_infrastructure(). And
+        # because cleanup logs rather than raises, an AccessDenied there is
+        # silent -- so a user on this policy leaked exactly the roles and
+        # profiles #132 was filed to stop, the failure that accumulated 94
+        # orphaned roles and 94 orphaned profiles in a real account. The policy
+        # was quietly reverting the fix (#195).
         iam_actions = [
             "iam:CreateRole",
             "iam:GetRole",
@@ -669,9 +710,30 @@ class GlobusComputeProvider(EphemeralAWSProvider):
             "iam:GetInstanceProfile",
             "iam:AddRoleToInstanceProfile",
             "iam:PassRole",
+            # Teardown, in the order IAM requires -- it rejects any other.
+            "iam:RemoveRoleFromInstanceProfile",
+            "iam:DeleteInstanceProfile",
+            # The teardown detaches whatever is actually attached rather than
+            # assuming only AmazonSSMManagedInstanceCore, since delete_role
+            # refuses while any policy remains.
+            "iam:ListAttachedRolePolicies",
+            "iam:DetachRolePolicy",
+            "iam:DeleteRole",
         ]
 
         statements = [
+            {
+                # First, because it is the first call the provider makes:
+                # create_session() verifies the session with
+                # sts:GetCallerIdentity unconditionally, on the construction
+                # path. Omitting it meant a user on this exact policy failed at
+                # `EphemeralAWSProvider(...)` before reaching any AWS work
+                # (#195).
+                "Sid": "SessionValidation",
+                "Effect": "Allow",
+                "Action": ["sts:GetCallerIdentity"],
+                "Resource": "*",
+            },
             {
                 "Sid": "EC2Management",
                 "Effect": "Allow",
@@ -679,7 +741,10 @@ class GlobusComputeProvider(EphemeralAWSProvider):
                 "Resource": "*",
             },
             {
-                "Sid": "SSMTunneling",
+                # Not "SSMTunneling", which this was called: nothing here opens
+                # a tunnel. SSM is used for AMI resolution, command dispatch,
+                # and the Parameter Store state backend (#195).
+                "Sid": "SSMCommandsAndParameters",
                 "Effect": "Allow",
                 "Action": ssm_actions,
                 "Resource": "*",

--- a/tests/unit/test_globus_compute_provider.py
+++ b/tests/unit/test_globus_compute_provider.py
@@ -445,7 +445,7 @@ class TestMinimumIamPolicy:
     def test_ssm_statement_present(self):
         policy = GlobusComputeProvider.minimum_iam_policy()
         sids = {s["Sid"] for s in policy["Statement"]}
-        assert "SSMTunneling" in sids
+        assert "SSMCommandsAndParameters" in sids
 
     def test_iam_statement_present(self):
         policy = GlobusComputeProvider.minimum_iam_policy()
@@ -504,16 +504,168 @@ class TestMinimumIamPolicy:
         assert "ec2:DescribeSpotFleetRequests" not in actions
         assert "ec2:CreateFleet" in actions
 
-    def test_iam_delete_actions_absent(self):
-        """No teardown grants while the provider performs no teardown (#132)."""
+    def test_iam_delete_actions_present(self):
+        """The teardown #132 added must be permitted, or the leak returns (#195).
+
+        This test asserted the *opposite* until #195 -- it pinned "no teardown
+        grants while the provider performs no teardown (#132)", which stopped
+        being true when v0.8.0's #132 fix shipped the teardown. So CI stayed
+        green over a policy that silently reverted that fix: cleanup logs rather
+        than raises, so the AccessDenied never surfaced and the roles simply
+        accumulated, 94 of them in a real account.
+        """
         actions = _all_actions(GlobusComputeProvider.minimum_iam_policy())
         for action in (
-            "iam:DeleteRole",
-            "iam:DeleteInstanceProfile",
             "iam:RemoveRoleFromInstanceProfile",
+            "iam:DeleteInstanceProfile",
+            "iam:ListAttachedRolePolicies",
             "iam:DetachRolePolicy",
+            "iam:DeleteRole",
+        ):
+            assert action in actions
+
+    def test_session_validation_present(self):
+        """create_session() calls this before anything else (#195).
+
+        Omitting it failed the user at ``EphemeralAWSProvider(...)`` itself --
+        the first AWS call the package makes, on the construction path.
+        """
+        actions = _all_actions(GlobusComputeProvider.minimum_iam_policy())
+        assert "sts:GetCallerIdentity" in actions
+
+    def test_parameter_store_write_actions_present(self):
+        """Detached mode needs Parameter Store state, so writes must be granted.
+
+        Both deletes appear because they are distinct IAM actions and the
+        backend calls both: delete_parameter() per key and delete_parameters()
+        for the batched cleanup.
+        """
+        actions = _all_actions(GlobusComputeProvider.minimum_iam_policy())
+        for action in ("ssm:PutParameter", "ssm:DeleteParameter"):
+            assert action in actions
+        assert "ssm:DeleteParameters" in actions
+
+    def test_unused_session_manager_actions_absent(self):
+        """There is no SSH-over-SSM tunnel in this package (#195).
+
+        Five session actions were granted for "Session Manager tunnels to reach
+        workers in a private subnet". No such transport exists -- nothing calls
+        any of them, and the bastion is an autonomous orchestrator rather than a
+        network tunnel. StartSession in particular is a shell on the instance.
+        """
+        actions = _all_actions(
+            GlobusComputeProvider.minimum_iam_policy(include_ecr=True)
+        )
+        for action in (
+            "ssm:StartSession",
+            "ssm:TerminateSession",
+            "ssm:ResumeSession",
+            "ssm:DescribeSessions",
+            "ssm:GetConnectionStatus",
         ):
             assert action not in actions
+
+    def test_every_granted_action_has_a_call_site(self):
+        """The property that keeps this honest, rather than a curated list.
+
+        Hand-maintained policies drift: #195 found this one granting five
+        actions nothing called while omitting nine the code did. Deriving the
+        check from the package's own source means a newly granted action must
+        point at real code, and a newly *called* API is not silently missing --
+        the companion test below covers that direction.
+
+        boto3 method names are snake_case of the IAM action, with a handful of
+        irregular pairs, so the mapping is computed rather than listed.
+        """
+        import re
+        from pathlib import Path
+
+        pkg = Path(GlobusComputeProvider.__module__.split(".")[0])
+        source = "\n".join(
+            p.read_text() for p in Path(pkg.name).rglob("*.py") if p.is_file()
+        )
+
+        def boto_name(action: str) -> str:
+            return re.sub(r"(?<!^)(?=[A-Z])", "_", action.split(":", 1)[1]).lower()
+
+        # Actions with no single boto3 call of their own name.
+        exempt = {
+            # Granted on the resource, not called: RunInstances/CreateFleet
+            # perform the pass, and CreateTags covers TagSpecifications.
+            "iam:PassRole",
+            # Read-only existence checks reached via waiters and describe_*.
+            "ec2:DescribeTags",
+            # Required implicitly by put_rule(Tags=...) rather than by a
+            # tag_resource() call of its own -- IAM authorizes the tagging half
+            # of a create-with-tags separately, so omitting this fails put_rule
+            # itself whenever additional_tags is set.
+            "events:TagResource",
+        }
+
+        missing = []
+        for action in _all_actions(
+            GlobusComputeProvider.minimum_iam_policy(include_ecr=True)
+        ):
+            if action in exempt or action.startswith("ecr:"):
+                continue
+            if f".{boto_name(action)}(" not in source:
+                missing.append(action)
+
+        assert not missing, f"granted with no call site in the package: {missing}"
+
+    def test_iam_and_sts_calls_are_all_granted(self):
+        """The direction #195 actually failed in: called but not granted.
+
+        Scoped to IAM and STS rather than every service, because those are where
+        a missing grant is both silent and expensive -- the teardown logs instead
+        of raising, so AccessDenied leaks a standing privileged principal, and
+        the STS check fails construction outright. Serverless and detached modes
+        add calls this policy deliberately does not cover, so a whole-package
+        sweep would assert against a scope this method never claimed.
+        """
+        import re
+        from pathlib import Path
+
+        pkg = Path(GlobusComputeProvider.__module__.split(".")[0]).name
+        source = "\n".join(
+            p.read_text() for p in Path(pkg).rglob("*.py") if p.is_file()
+        )
+        granted = _all_actions(GlobusComputeProvider.minimum_iam_policy())
+
+        # The calls this policy's scope reaches: instance-profile creation and
+        # teardown, plus the session check. Derived from the client each is made
+        # on, so a call added to either path shows up here.
+        expected = {
+            "iam": [
+                "create_role",
+                "get_role",
+                "attach_role_policy",
+                "create_instance_profile",
+                "get_instance_profile",
+                "add_role_to_instance_profile",
+                "remove_role_from_instance_profile",
+                "delete_instance_profile",
+                "list_attached_role_policies",
+                "detach_role_policy",
+                "delete_role",
+            ],
+            "sts": ["get_caller_identity"],
+        }
+
+        ungranted = []
+        for service, methods in expected.items():
+            for method in methods:
+                if f".{method}(" not in source:
+                    continue  # not called; nothing to grant
+                action = f"{service}:" + "".join(
+                    part.title() for part in method.split("_")
+                )
+                # PassRole is authorized on RunInstances, not by a method call.
+                action = re.sub(r"^iam:Sts", "sts:", action)
+                if action not in granted:
+                    ungranted.append(action)
+
+        assert not ungranted, f"called by the package but not granted: {ungranted}"
 
     def test_launch_template_actions_present(self):
         """Every launch path goes through a launch template since #85."""


### PR DESCRIPTION
Closes #195.

## The defect

`GlobusComputeProvider.minimum_iam_policy()` granted the five IAM *create*
actions and no delete action at all, with this rationale in the code, the
module docstring, `docs/security.md`, and the v0.8.0 changelog:

> No delete actions: the provider does not tear the profile down (#132) —
> granting them would permit more than it performs.

That was accurate when written and was falsified by #132 landing in the same
release. `cleanup_infrastructure()` now calls all five teardown actions on
every shutdown.

**What makes this more than a missing grant:** `_delete_ssm_instance_profile()`
in `utils/aws.py` wraps every step in `_tolerate_missing`, which logs and
returns `False`. Nothing raises. So `AccessDenied` on teardown is completely
silent, and a user following this policy silently reproduced the leak #132 was
filed to stop — the failure that accumulated **94 orphaned roles and 94
orphaned instance profiles** in a real account, each a standing principal with
`AmazonSSMManagedInstanceCore` attached. The policy was quietly reverting the
fix shipped beside it.

## Added, each verified against a real call site

| Action | Call site |
|---|---|
| `iam:RemoveRoleFromInstanceProfile` | `utils/aws.py` teardown |
| `iam:DeleteInstanceProfile` | same |
| `iam:ListAttachedRolePolicies` | same — `delete_role` refuses while any policy remains, so the code detaches what is *actually* attached rather than assuming only `AmazonSSMManagedInstanceCore` |
| `iam:DetachRolePolicy` | same |
| `iam:DeleteRole` | same |
| `sts:GetCallerIdentity` | `create_session()` — the **first** AWS call the package makes, unconditionally |
| `ssm:PutParameter` | `state/parameter_store.py` |
| `ssm:DeleteParameter` | `parameter_store.py:190` (singular) |
| `ssm:DeleteParameters` | `parameter_store.py:274` (batched) — a *distinct* IAM action, and the code calls both |

`sts:GetCallerIdentity` is worth calling out separately: without it a user on
this policy failed at `EphemeralAWSProvider(...)` before reaching any AWS
work, since `__init__` ends by calling `initialize()`.

## Removed — five actions for a transport that does not exist

`ssm:StartSession`, `TerminateSession`, `ResumeSession`, `DescribeSessions`,
`GetConnectionStatus`, granted under "Session Manager tunnels to reach workers
in a private subnet".

A grep for `start_session`/`StartSession`/`session-manager` outside IAM action
*strings* returns nothing. The bastion is an autonomous orchestrator, not a
network tunnel — which is the same reason an EC2 Instance Connect Endpoint
cannot replace it (#88). `StartSession` in particular grants an interactive
shell on the instance. The `Sid` is renamed `SSMTunneling` →
`SSMCommandsAndParameters` to stop the name asserting the same thing.

## Not added, contrary to the issue

#195 also proposed `ec2:DescribeInstanceStatus` and
`ec2:DescribeLaunchTemplates`. Neither has a call site anywhere in the
package. Adding them would repeat the over-grant this PR removes.

## Why CI stayed green over all of it

`test_iam_delete_actions_absent` asserted the **absence** that #195 is about.
The test pinned the defect. It is inverted to
`test_iam_delete_actions_present`, with its docstring recording that it
asserted the opposite.

Shape-only assertions are what let the drift through, so two new tests derive
from the package's own source in both directions:

- `test_every_granted_action_has_a_call_site` — maps each action to its boto3
  method name and greps the package. Three documented exemptions:
  `iam:PassRole` (authorized, never called), `ec2:DescribeTags`, and
  `events:TagResource`, the last because it has no boto3 method of its own
  name — it is authorized implicitly by `put_rule(Tags=...)`, since IAM
  authorizes the tagging half of a create-with-tags separately.
- `test_iam_and_sts_calls_are_all_granted` — the reverse, scoped to IAM and
  STS because serverless and detached modes add calls this policy
  deliberately does not cover.

## Docs

`docs/network-prerequisites.md`'s hand-written seven-action policy had drifted
the *opposite* way: it granted `ec2:CreateSecurityGroup` and
`AuthorizeSecurityGroupIngress` (both removed by #69) while omitting
`ssm:GetParameter`, `ec2:CreateLaunchTemplate`, `ec2:DescribeInstanceTypes`,
`ec2:DescribeVpcs` and `sts:GetCallerIdentity`. A user following it failed at
construction. It now prints from the generator, and notes that the *workers*
need only `AmazonSSMManagedInstanceCore`.

Four claims that the profile is "not deleted on shutdown" corrected in place
(`docs/architecture.md` ×2, `docs/security.md`, `docs/troubleshooting.md`),
plus a `docs/security.md` line citing a CloudTrail-recorded `StartSession`
that never occurs. The stale claim also had a **fourth** copy the issue did
not list — the module docstring's own permission list — corrected too.

The v0.8.0 changelog entry carrying the claim is a released section, so it is
corrected in `[Unreleased]` prose rather than edited.

## Verification

- `pytest tests/unit tests/security` — **1184 passed, 2 skipped** (from 1179; the +5 are new here)
- `TestMinimumIamPolicy` — 22 passed
- **Negative control:** reverted the policy, kept the tests → **7 failed**, naming the 5 phantom SSM actions and the 6 missing IAM/STS grants exactly
- `ruff check .` / `ruff format --check .` — clean, 124 files
- `mypy parsl_aws_provider` — 76 errors, **baseline unchanged**
- `make -C docs html SPHINXOPTS="-W"` — build succeeded