### PR TITLE
fix: ship the orphan sweep and repair its filters (closes #198)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,7 @@ jobs:
         if: always()
         env:
           AWS_TEST_REGION: ${{ vars.AWS_TEST_REGION }}
-        run: uv run python tools/cleanup_aws_resources.py --dry-run --region "${AWS_TEST_REGION}"
+        run: uv run parsl-aws-cleanup --dry-run --region "${AWS_TEST_REGION}"
 
   test-bats:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,8 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   prefix — `parsl-ephemeral-ssm-role-`, `parsl-ephemeral-ssm-profile-`,
   `parsl-ephemeral-spot-fleet-role-`, `parsl-ephemeral-sg`,
   `parsl-ephemeral-cluster` — keeps its existing spelling, because
-  `tools/cleanup_aws_resources.py` reaps orphans by prefix and renaming them
-  would strand already-created resources in live accounts.
+  `parsl-aws-cleanup` reaps orphans by prefix and renaming them would strand
+  already-created resources in live accounts.
 
 ### Added
 - **The documentation is actually published.** CI's `docs` job has built the
@@ -118,6 +118,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   4.0.1).
 
 ### Fixed
+- **The orphan sweep shipped in no artifact, and found nothing when it was
+  reachable** (#198). Two independent defects in the one tool that bounds the bill
+  after a crash. Nothing terminates instances automatically — Parsl never calls
+  `provider.shutdown()`, `HighThroughputExecutor.shutdown()` documents that it does
+  not terminate workers, and `parsl/dataflow/dflow.py`'s `atexit_cleanup` only logs
+  — so after a `KeyboardInterrupt` or an uncaught exception this sweep is the whole
+  recovery path.
+
+  - **Not distributed.** It lived at `tools/cleanup_aws_resources.py`, and `tools/`
+    is in neither the wheel nor the sdist, so every documented
+    `python tools/cleanup_aws_resources.py` invocation worked only inside a git
+    clone. Moved to `parsl_aws_provider/cleanup.py` and exposed as the
+    `parsl-aws-cleanup` console script via `[project.scripts]`; verified from a
+    fresh venv installed from the built wheel alone. `main()` returns an exit
+    status rather than calling `sys.exit()` — `console_scripts` uses the return
+    value — which also makes it testable. `logging.basicConfig` moved out of module
+    scope into `main()`, since configuring the root logger at import would hijack
+    logging for anyone merely importing `parsl_aws_provider`.
+  - **Its filters matched nothing the package writes.** It queried EC2 for
+    `tag:parsl_provider` matching `*aws-enhanced*` and for security groups named
+    `aws-enhanced-*`. Neither string appears anywhere in this package — not as a
+    tag key, not as a value, not as a group name — so the tool documented as the
+    way to find orphaned billable resources reported "No resources to clean up!"
+    against an account full of them. It now queries both conventions the package
+    actually writes: `CreatedBy=ParslEphemeralAWSProvider` (standard mode) and the
+    `ParslResource` tag key (detached mode and the serverless fleet), and matches
+    security groups against `DEFAULT_SECURITY_GROUP_NAME`. The two tag conventions
+    need two `describe_instances` calls unioned by instance ID, because EC2 ANDs
+    its `Filters` — a single call passing both returns only instances carrying
+    *both*, which no mode writes. Proved against real AWS in us-west-2: five live
+    orphaned security groups the old filter reported as zero, and 0-vs-2 on live
+    instances tagged one per convention.
+- **Serverless mode discarded `worker_init` on the fleet path** (#198). Found while
+  fixing the above. `ServerlessMode._build_fleet_user_data` never referenced
+  `self.worker_init`, so a fleet instance booted a bare Amazon Linux image — no
+  Parsl, none of the workload's dependencies — and ran the job command against it.
+  UserData is the only opportunity to install anything on that instance, and it was
+  spent. `StandardMode._build_user_data` and
+  `SpotFleetManager._generate_user_data` both include it, so this was the single
+  EC2 path that did not. `examples/serverless_spot_fleet_example.py` now passes a
+  `worker_init` that installs its own imports, which it could not do before.
+- **Four examples raised `ImportError` on the first line a user would run** (#198).
+  `from parsl.app.python import python_app` names nothing — the decorator is
+  `parsl.python_app`, defined in `parsl/app/app.py`. `standard_mode.py`,
+  `detached_mode.py`, `serverless_mode.py` and `spot_interruption_example.py` were
+  all unrunnable for a full release, and `spot_fleet_example.py` used a third
+  spelling; all five now import from `parsl` directly. The existing docs test only
+  AST-parsed each example, which cannot see a name that does not exist at the other
+  end of an import, so it stayed green over all four. `test_example_imports` now
+  executes each module — safe because every example guards its entry point with
+  `if __name__ == "__main__"`.
 - **`minimum_iam_policy()` granted creates without deletes, silently re-creating
   the #132 leak** (#195). The policy carried `iam:CreateRole`,
   `iam:CreateInstanceProfile`, `iam:AddRoleToInstanceProfile`,

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ the provider believes it owns.
 To find what a crash left behind:
 
 ```bash
-uv run python tools/cleanup_aws_resources.py --dry-run --region us-east-1
+parsl-aws-cleanup --dry-run --region us-east-1
 ```
 
 ## Examples

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -103,9 +103,12 @@ The provider creates and manages:
 
 It does **not** create or delete VPCs, subnets, or security groups.
 
-EC2 resources are tagged `ParslResource=true` and `ParslWorkflowId=<provider_id>`
-so anything left behind is findable. `tools/cleanup_aws_resources.py --dry-run`
-reports orphans.
+EC2 resources are tagged so anything left behind is findable, in one of two
+conventions depending on the mode: standard mode writes
+`CreatedBy=ParslEphemeralAWSProvider` and `ProviderId=<provider_id>`, while
+detached mode and the serverless fleet write `ParslResource=true` and
+`ParslWorkflowId=<provider_id>`. `parsl-aws-cleanup --dry-run` queries both and
+reports the union.
 
 ## State management
 

--- a/docs/ci_cd.md
+++ b/docs/ci_cd.md
@@ -118,7 +118,7 @@ IDs from another region otherwise surface minutes in, from deep inside
 `RunInstances`, after instances have been billed. Pick a subnet in an AZ that
 offers your instance type (`us-east-1e` does not offer `t3.micro`).
 
-A final `always()` step runs `tools/cleanup_aws_resources.py --dry-run` to report
+A final `always()` step runs `parsl-aws-cleanup --dry-run` to report
 orphans, since a failed test is exactly when instances are most likely to be left
 running. It reports without deleting, so CI never mutates a shared account. The
 script takes credentials from the boto3 chain — the OIDC credentials the earlier

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -505,7 +505,7 @@ Every resource is tagged `ParslResource=true` and
 anything a crash left behind:
 
 ```bash
-python tools/cleanup_aws_resources.py --dry-run --region us-east-1
+parsl-aws-cleanup --dry-run --region us-east-1
 ```
 
 ## Migrating from Parsl's `AWSProvider`

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -280,7 +280,7 @@ pattern in `examples/parsl_aws_integration.py` handles that.
 To find anything a crash left behind:
 
 ```bash
-python tools/cleanup_aws_resources.py --dry-run --region us-east-1
+parsl-aws-cleanup --dry-run --region us-east-1
 ```
 
 ## Troubleshooting

--- a/docs/globus_compute.md
+++ b/docs/globus_compute.md
@@ -217,7 +217,7 @@ This drains pending functions and scales the provider's blocks in. It does not
 call `provider.shutdown()`, so sweep for leftovers if the daemon died uncleanly:
 
 ```bash
-uv run python tools/cleanup_aws_resources.py --dry-run --region us-east-1
+parsl-aws-cleanup --dry-run --region us-east-1
 ```
 
 ## Configuration reference
@@ -475,7 +475,7 @@ The worker ran your function and it raised. Read
 `provider.shutdown()`, and there is no `atexit` hook. Sweep by tag:
 
 ```bash
-uv run python tools/cleanup_aws_resources.py --region us-east-1   # --dry-run first
+parsl-aws-cleanup --region us-east-1   # --dry-run first
 ```
 
 ### SSM reports the instance as unreachable

--- a/docs/operating_modes.md
+++ b/docs/operating_modes.md
@@ -410,7 +410,7 @@ configuration carries over.
 
 ### Any mode
 - `provider.list_resources()` reports what the provider believes it owns
-- `python tools/cleanup_aws_resources.py --dry-run --region <region>` finds
+- `parsl-aws-cleanup --dry-run --region <region>` finds
   resources tagged `ParslResource=true` that the state no longer names
 
 SPDX-License-Identifier: Apache-2.0

--- a/docs/security.md
+++ b/docs/security.md
@@ -434,7 +434,7 @@ provider.shutdown()
 If the state is gone, sweep by tag instead:
 
 ```bash
-python tools/cleanup_aws_resources.py --region us-east-1            # --dry-run first
+parsl-aws-cleanup --region us-east-1            # --dry-run first
 ```
 
 ## Reporting a vulnerability

--- a/docs/state_persistence.md
+++ b/docs/state_persistence.md
@@ -226,7 +226,7 @@ construction (`provider.state_store = MyCustomStateStore(...)`) before the first
   resources.
 - Parameter Store operations emit `STATE_ACCESS` audit events when the provider
   has an `audit_logger`.
-- After any crash, run `tools/cleanup_aws_resources.py --dry-run --region <region>`
+- After any crash, run `parsl-aws-cleanup --dry-run --region <region>`
   to check for resources the state no longer names.
 
 SPDX-License-Identifier: Apache-2.0

--- a/docs/substrate_testing.md
+++ b/docs/substrate_testing.md
@@ -224,7 +224,7 @@ export AWS_TEST_VPC_ID=vpc-… AWS_TEST_SUBNET_ID=subnet-… AWS_TEST_SG_ID=sg-�
 uv run pytest tests/aws -m aws -v --no-cov
 ```
 
-These create billable resources. `tools/cleanup_aws_resources.py --dry-run`
+These create billable resources. `parsl-aws-cleanup --dry-run`
 reports anything left behind.
 
 ## Troubleshooting

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -304,7 +304,7 @@ If you have a stale `ephemeral_aws_state.json` from an older version, deleting i
 is safe once you have confirmed the resources it names are gone:
 
 ```bash
-python tools/cleanup_aws_resources.py --dry-run --region us-east-1
+parsl-aws-cleanup --dry-run --region us-east-1
 ```
 
 ### `StateStoreError` on the file backend
@@ -384,11 +384,13 @@ unrelated, and is deprecated and ignored
 To find orphans from a crash:
 
 ```bash
-python tools/cleanup_aws_resources.py --dry-run --region us-east-1   # then without --dry-run
+parsl-aws-cleanup --dry-run --region us-east-1   # then without --dry-run
 ```
 
-It sweeps by the `ParslResource=true` tag, so it finds resources the state file no
-longer names.
+It sweeps by tag — both `CreatedBy=ParslEphemeralAWSProvider` (standard mode) and
+`ParslResource=true` (detached and serverless) — so it finds resources the state
+file no longer names. It ships with the package, so it is on `PATH` after any
+install, not only in a git clone.
 
 ### The bill is higher than expected
 
@@ -416,7 +418,7 @@ Two things to know specifically:
   actions: cleanup logs rather than raises, so `AccessDenied` there is silent
   ([#195](https://github.com/scttfrdmn/parsl-aws-provider/issues/195)). Generate a
   current policy with `GlobusComputeProvider.minimum_iam_policy()`, and reap
-  existing orphans with `tools/cleanup_aws_resources.py`.
+  existing orphans with `parsl-aws-cleanup`.
 
 ### Stopped instances with billed EBS volumes
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -50,7 +50,7 @@ fail to register with no useful error. Certificate distribution is
 hard, sweep for orphans:
 
 ```bash
-uv run python tools/cleanup_aws_resources.py --dry-run --region us-east-1
+parsl-aws-cleanup --dry-run --region us-east-1
 ```
 
 It matches the `ParslResource=true` tag, so it finds resources no state file names.

--- a/examples/detached_mode.py
+++ b/examples/detached_mode.py
@@ -32,7 +32,7 @@ import sys
 import time
 
 import parsl
-from parsl.app.python import python_app
+from parsl import python_app
 from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
 

--- a/examples/serverless_mode.py
+++ b/examples/serverless_mode.py
@@ -38,7 +38,7 @@ import os
 import sys
 
 import parsl
-from parsl.app.python import python_app
+from parsl import python_app
 from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
 

--- a/examples/serverless_spot_fleet_example.py
+++ b/examples/serverless_spot_fleet_example.py
@@ -100,6 +100,16 @@ def main() -> int:
         min_blocks=0,
         max_blocks=4,
         use_public_ips=True,
+        # numpy is imported inside compute_intensive, which runs on the fleet
+        # instance rather than here, so this is where it has to be installed --
+        # the default worker_init installs Parsl alone. Serverless mode dropped
+        # worker_init on the fleet path until #198, which is why this example
+        # previously had nowhere to declare it.
+        worker_init=(
+            "dnf install -y python3.11 python3.11-pip\n"
+            "ln -sf /usr/bin/python3.11 /usr/bin/python3\n"
+            "pip3.11 install --quiet --upgrade parsl numpy\n"
+        ),
         state_store_type="parameter_store",
         parameter_store_path="/parsl/serverless-spot-fleet",
         additional_tags={

--- a/examples/spot_fleet_example.py
+++ b/examples/spot_fleet_example.py
@@ -29,8 +29,8 @@ import os
 import sys
 
 import parsl
+from parsl import python_app
 from parsl.addresses import address_by_route
-from parsl.app.app import python_app
 from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
 

--- a/examples/spot_interruption_example.py
+++ b/examples/spot_interruption_example.py
@@ -47,8 +47,8 @@ import os
 import sys
 
 import parsl
+from parsl import python_app
 from parsl.addresses import address_by_route
-from parsl.app.python import python_app
 from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
 

--- a/examples/standard_mode.py
+++ b/examples/standard_mode.py
@@ -26,8 +26,8 @@ import os
 import sys
 
 import parsl
+from parsl import python_app
 from parsl.addresses import address_by_route
-from parsl.app.python import python_app
 from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
 

--- a/parsl_aws_provider/cleanup.py
+++ b/parsl_aws_provider/cleanup.py
@@ -1,22 +1,40 @@
-#!/usr/bin/env python3
-"""
-AWS Resource Cleanup Script for Parsl AWS Provider Testing
-Safely removes all test instances, security groups, and other resources.
+"""Sweep for AWS resources this provider left behind, and delete them.
+
+Installed as the ``parsl-aws-cleanup`` console script. It lives in the package
+rather than under ``tools/`` because that is the only way it reaches a user who
+installed from a wheel: ``tools/`` ships in neither the wheel nor the sdist, so
+every documented ``python tools/cleanup_aws_resources.py`` invocation worked
+only inside a git clone (#198).
+
+That mattered more than a normal missing-file bug, because nothing stops the
+billing automatically. Parsl never calls ``provider.shutdown()``;
+``HighThroughputExecutor.shutdown()`` says outright that it does not terminate
+workers; and ``parsl/dataflow/dflow.py``'s ``atexit_cleanup`` only logs. So a
+``KeyboardInterrupt``, an uncaught exception, or a driver crash leaves EC2
+instances running until someone notices, and this is the tool that bounds the
+damage.
+
+Usage
+-----
+    parsl-aws-cleanup --dry-run --region us-east-1    # report only
+    parsl-aws-cleanup --region us-east-1              # delete, after confirming
+
+SPDX-License-Identifier: Apache-2.0
+SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
 """
 
-import boto3
-import time
-import sys
-from typing import List, Dict, Optional
 import logging
+import sys
+import time
+from typing import Dict, List, Optional
+
+import boto3
 
 from parsl_aws_provider.utils.aws import (
     delete_ssm_instance_profile,
     ssm_instance_profile_names,
 )
 
-# Configure logging
-logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
 
 # Both halves of the pair are named for the provider_id, so the suffix is what
@@ -24,6 +42,32 @@ logger = logging.getLogger(__name__)
 _ROLE_PREFIX, _PROFILE_PREFIX = (
     prefix[: -len("suffix")] for prefix in ssm_instance_profile_names("suffix")
 )
+
+# The package tags EC2 resources two different ways, and a sweep that knows only
+# one of them misses whole modes:
+#
+#   StandardMode          CreatedBy=ParslEphemeralAWSProvider, ProviderId=...
+#   DetachedMode          ParslResource=true, ParslWorkflowId=...
+#   ServerlessMode fleet  ParslResource=true, ParslWorkflowId=...
+#
+# This tool previously filtered on `tag:parsl_provider` matching `*aws-enhanced*`
+# and on security groups named `aws-enhanced-*`. Neither string appears anywhere
+# in the package -- not as a tag key, not as a value, not as a group name -- so
+# the sweep documented as the way to find orphaned billable resources reported
+# "No resources to clean up!" against an account full of them (#198).
+#
+# Tag *keys* rather than values are matched where possible, so a renamed value
+# cannot silently narrow the sweep again.
+_INSTANCE_TAG_FILTERS = (
+    {"Name": "tag:CreatedBy", "Values": ["ParslEphemeralAWSProvider"]},
+    {"Name": "tag-key", "Values": ["ParslResource"]},
+)
+
+# Security groups are no longer created by the provider (#69), so any match is a
+# pre-v0.7.0 leftover. `parsl-ephemeral-sg` is DEFAULT_SECURITY_GROUP_NAME, which
+# is the name the removed creation path used; the wildcard also catches the
+# suffixed variants.
+_SECURITY_GROUP_NAME_PATTERNS = ["parsl-ephemeral-sg", "parsl-ephemeral-sg-*"]
 
 
 class AWSResourceCleaner:
@@ -59,48 +103,59 @@ class AWSResourceCleaner:
             sys.exit(1)
 
     def get_parsl_instances(self) -> List[Dict]:
-        """Get all instances created by Parsl AWS provider."""
-        try:
-            response = self.ec2_client.describe_instances(
-                Filters=[
-                    {"Name": "tag:parsl_provider", "Values": ["*aws-enhanced*"]},
-                    {
-                        "Name": "instance-state-name",
-                        "Values": ["running", "pending", "stopping", "stopped"],
-                    },
-                ]
-            )
+        """Get all live instances created by this provider, across all modes.
 
-            instances = []
-            for reservation in response["Reservations"]:
-                for instance in reservation["Instances"]:
-                    instances.append(
+        One ``describe_instances`` call per tag convention, unioned by instance
+        ID. They cannot be combined into a single call: EC2 ``Filters`` are
+        ANDed, so passing both would return only instances carrying *both*
+        conventions -- which no mode writes.
+        """
+        instances: Dict[str, Dict] = {}
+
+        for tag_filter in _INSTANCE_TAG_FILTERS:
+            try:
+                paginator = self.ec2_client.get_paginator("describe_instances")
+                pages = paginator.paginate(
+                    Filters=[
+                        dict(tag_filter),
                         {
-                            "id": instance["InstanceId"],
-                            "state": instance["State"]["Name"],
-                            "launch_time": instance["LaunchTime"],
-                            "name": next(
-                                (
-                                    tag["Value"]
-                                    for tag in instance.get("Tags", [])
-                                    if tag["Key"] == "Name"
+                            "Name": "instance-state-name",
+                            "Values": ["running", "pending", "stopping", "stopped"],
+                        },
+                    ]
+                )
+                for page in pages:
+                    for reservation in page["Reservations"]:
+                        for instance in reservation["Instances"]:
+                            instances[instance["InstanceId"]] = {
+                                "id": instance["InstanceId"],
+                                "state": instance["State"]["Name"],
+                                "launch_time": instance["LaunchTime"],
+                                "name": next(
+                                    (
+                                        tag["Value"]
+                                        for tag in instance.get("Tags", [])
+                                        if tag["Key"] == "Name"
+                                    ),
+                                    "No Name",
                                 ),
-                                "No Name",
-                            ),
-                        }
-                    )
+                            }
+            except Exception as e:
+                logger.error(f"Error getting instances for {tag_filter['Name']}: {e}")
 
-            return sorted(instances, key=lambda x: x["launch_time"], reverse=True)
-
-        except Exception as e:
-            logger.error(f"Error getting instances: {e}")
-            return []
+        return sorted(instances.values(), key=lambda x: x["launch_time"], reverse=True)
 
     def get_parsl_security_groups(self) -> List[Dict]:
-        """Get all security groups created by Parsl AWS provider."""
+        """Get security groups left over from before #69 removed SG creation.
+
+        The provider has created no security group since v0.7.0, so a match here
+        is a pre-v0.7.0 orphan rather than something a current run left behind.
+        """
         try:
             response = self.ec2_client.describe_security_groups(
-                Filters=[{"Name": "group-name", "Values": ["aws-enhanced-*"]}]
+                Filters=[
+                    {"Name": "group-name", "Values": _SECURITY_GROUP_NAME_PATTERNS}
+                ]
             )
 
             return [
@@ -375,12 +430,26 @@ class AWSResourceCleaner:
         return success
 
 
-def main():
-    """Main cleanup function."""
+def main(argv: Optional[List[str]] = None) -> int:
+    """Entry point for the ``parsl-aws-cleanup`` console script.
+
+    Returns an exit status rather than calling ``sys.exit()`` so the function is
+    testable; ``console_scripts`` uses the return value as the process status.
+
+    ``basicConfig`` is called here rather than at import, because this module is
+    now part of the installed package: configuring the root logger on import
+    would hijack logging for anyone who merely imports ``parsl_aws_provider``.
+    """
     import argparse
 
     parser = argparse.ArgumentParser(
-        description="Clean up AWS resources created by Parsl testing"
+        prog="parsl-aws-cleanup",
+        description=(
+            "Find and delete AWS resources left behind by this provider. "
+            "Sweeps by tag, so it finds resources no state file names -- the "
+            "case after a crash or KeyboardInterrupt, which Parsl does not "
+            "clean up."
+        ),
     )
     parser.add_argument(
         "--profile",
@@ -397,13 +466,15 @@ def main():
         help="Show what would be deleted without deleting",
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
     cleaner = AWSResourceCleaner(profile_name=args.profile, region=args.region)
     success = cleaner.cleanup_all(dry_run=args.dry_run)
 
-    sys.exit(0 if success else 1)
+    return 0 if success else 1
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/parsl_aws_provider/modes/serverless.py
+++ b/parsl_aws_provider/modes/serverless.py
@@ -1175,10 +1175,18 @@ class ServerlessMode(OperatingMode):
         template's ``InstanceInitiatedShutdownBehavior=terminate``: the instance
         exists to run one command, so it should terminate when that is done
         instead of idling at full price.
+
+        ``worker_init`` runs first, as it does on every other EC2 path
+        (``StandardMode._build_user_data`` and
+        ``SpotFleetManager._generate_user_data``). It was previously dropped
+        here, so a fleet instance in this mode booted a bare Amazon Linux image
+        with no Parsl installed and ran ``command`` against it -- the one
+        opportunity to install anything, silently discarded (#198).
         """
-        return (
-            "#!/bin/bash\n"
-            'echo "Starting Parsl worker..."\n'
+        script = '#!/bin/bash\necho "Starting Parsl worker..."\n'
+        if self.worker_init:
+            script += f"\n# User-provided worker initialization\n{self.worker_init}\n"
+        return script + (
             "mkdir -p /tmp/parsl\n"
             f"cat > /tmp/parsl/command.sh <<'PARSL_EOF'\n{command}\nPARSL_EOF\n"
             "chmod +x /tmp/parsl/command.sh\n"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,15 @@ docs = [
     "myst-parser>=2.0.0",
 ]
 
+[project.scripts]
+# The orphan sweep has to be reachable from an installed wheel. It used to live at
+# `tools/cleanup_aws_resources.py`, which ships in neither the wheel nor the sdist,
+# so every `python tools/cleanup_aws_resources.py` line in the docs worked only
+# inside a git clone (#198). Nothing terminates instances automatically -- Parsl
+# never calls provider.shutdown() -- so this is the tool that bounds the bill after
+# a crash, and it was the one thing not distributed.
+parsl-aws-cleanup = "parsl_aws_provider.cleanup:main"
+
 [project.urls]
 "Homepage" = "https://github.com/scttfrdmn/parsl-aws-provider"
 "Bug Tracker" = "https://github.com/scttfrdmn/parsl-aws-provider/issues"

--- a/tests/unit/test_cleanup_tool.py
+++ b/tests/unit/test_cleanup_tool.py
@@ -1,0 +1,310 @@
+"""Unit tests for the ``parsl-aws-cleanup`` orphan sweep.
+
+This tool is the only thing that bounds the bill after a crash. Parsl never
+calls ``provider.shutdown()``, ``HighThroughputExecutor.shutdown()`` documents
+that it does not terminate workers, and ``dflow.py``'s ``atexit_cleanup`` only
+logs -- so after a ``KeyboardInterrupt`` or an uncaught exception, instances keep
+running until someone runs this.
+
+It had no tests at all, and it did not work. Its EC2 filters named a tag key and
+a security-group prefix that appear nowhere in the package, so it reported
+"No resources to clean up!" against an account holding orphans. These tests pin
+the filters to the tags the modes actually write, in both directions: a resource
+tagged either way is found, and a resource tagged neither way is left alone
+(#198).
+
+SPDX-License-Identifier: Apache-2.0
+SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+"""
+
+import re
+from pathlib import Path
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from parsl_aws_provider.cleanup import (
+    _INSTANCE_TAG_FILTERS,
+    _SECURITY_GROUP_NAME_PATTERNS,
+    AWSResourceCleaner,
+    main,
+)
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# What each mode actually writes onto an instance. Kept as literals rather than
+# imported, so that renaming a tag in the package fails these tests instead of
+# silently moving both sides together.
+STANDARD_MODE_TAGS = [
+    {"Key": "Name", "Value": "parsl-worker-abc12345"},
+    {"Key": "CreatedBy", "Value": "ParslEphemeralAWSProvider"},
+    {"Key": "ProviderId", "Value": "prov-1"},
+]
+DETACHED_MODE_TAGS = [
+    {"Key": "Name", "Value": "parsl-worker-def67890"},
+    {"Key": "ParslResource", "Value": "true"},
+    {"Key": "ParslWorkflowId", "Value": "prov-2"},
+]
+UNRELATED_TAGS = [
+    {"Key": "Name", "Value": "someone-elses-instance"},
+    {"Key": "CreatedBy", "Value": "Terraform"},
+]
+
+
+@pytest.fixture
+def aws(monkeypatch):
+    """A moto-backed AWS with synthetic credentials.
+
+    ``AWS_PROFILE`` is cleared so a developer's real profile cannot be reached:
+    this suite creates and deletes instances and security groups.
+    """
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+    monkeypatch.delenv("AWS_PROFILE", raising=False)
+
+    with mock_aws():
+        yield boto3.Session(region_name="us-east-1")
+
+
+def _launch(session, tags):
+    """Launch one instance carrying ``tags``, returning its ID."""
+    ec2 = session.client("ec2")
+    images = ec2.describe_images(Owners=["amazon"])["Images"]
+    response = ec2.run_instances(
+        ImageId=images[0]["ImageId"],
+        MinCount=1,
+        MaxCount=1,
+        TagSpecifications=[{"ResourceType": "instance", "Tags": tags}],
+    )
+    return response["Instances"][0]["InstanceId"]
+
+
+class TestInstanceDiscovery:
+    """The sweep has to find what every mode leaves behind."""
+
+    def test_standard_mode_tags_are_found(self, aws):
+        """``CreatedBy=ParslEphemeralAWSProvider`` -- what StandardMode writes."""
+        instance_id = _launch(aws, STANDARD_MODE_TAGS)
+
+        cleaner = AWSResourceCleaner(region="us-east-1")
+        found = {inst["id"] for inst in cleaner.get_parsl_instances()}
+
+        assert instance_id in found
+
+    def test_detached_and_serverless_tags_are_found(self, aws):
+        """``ParslResource=true`` -- what DetachedMode and the fleet path write."""
+        instance_id = _launch(aws, DETACHED_MODE_TAGS)
+
+        cleaner = AWSResourceCleaner(region="us-east-1")
+        found = {inst["id"] for inst in cleaner.get_parsl_instances()}
+
+        assert instance_id in found
+
+    def test_both_conventions_are_found_together(self, aws):
+        """Neither convention shadows the other.
+
+        The two conventions need two ``describe_instances`` calls: EC2 ANDs its
+        ``Filters``, so a single call passing both tag filters returns only
+        instances carrying *both* -- which is to say nothing. A regression to one
+        combined call would leave one mode's orphans invisible, and this is the
+        test that catches it.
+        """
+        standard = _launch(aws, STANDARD_MODE_TAGS)
+        detached = _launch(aws, DETACHED_MODE_TAGS)
+
+        cleaner = AWSResourceCleaner(region="us-east-1")
+        found = {inst["id"] for inst in cleaner.get_parsl_instances()}
+
+        assert {standard, detached} <= found
+
+    def test_an_instance_is_reported_once_not_twice(self, aws):
+        """An instance carrying both conventions is deduplicated.
+
+        The union is keyed by instance ID rather than accumulated into a list,
+        so an instance matching both filters is not offered for termination
+        twice.
+        """
+        instance_id = _launch(aws, STANDARD_MODE_TAGS + DETACHED_MODE_TAGS[1:])
+
+        cleaner = AWSResourceCleaner(region="us-east-1")
+        ids = [inst["id"] for inst in cleaner.get_parsl_instances()]
+
+        assert ids.count(instance_id) == 1
+
+    def test_someone_elses_instance_is_left_alone(self, aws):
+        """The sweep terminates instances, so a false positive is destructive.
+
+        This is the direction that matters most: the tool asks for confirmation
+        and then calls ``terminate_instances``, so matching too broadly destroys
+        a third party's work.
+        """
+        unrelated = _launch(aws, UNRELATED_TAGS)
+
+        cleaner = AWSResourceCleaner(region="us-east-1")
+        found = {inst["id"] for inst in cleaner.get_parsl_instances()}
+
+        assert unrelated not in found
+
+    def test_terminated_instances_are_not_reported(self, aws):
+        """A terminated instance keeps its tags but costs nothing.
+
+        Reporting it would make ``--dry-run`` list resources that cannot be
+        cleaned up, and the count never reaches zero.
+        """
+        instance_id = _launch(aws, STANDARD_MODE_TAGS)
+        aws.client("ec2").terminate_instances(InstanceIds=[instance_id])
+
+        cleaner = AWSResourceCleaner(region="us-east-1")
+        found = {inst["id"] for inst in cleaner.get_parsl_instances()}
+
+        assert instance_id not in found
+
+
+class TestSecurityGroupDiscovery:
+    """Pre-v0.7.0 leftovers, since #69 removed security-group creation."""
+
+    def test_the_provider_default_name_is_found(self, aws):
+        """``parsl-ephemeral-sg-<suffix>`` is what the removed path created.
+
+        Verified against a real account: five such groups were present and the
+        old ``aws-enhanced-*`` filter reported none of them.
+        """
+        ec2 = aws.client("ec2")
+        vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        group_id = ec2.create_security_group(
+            GroupName="parsl-ephemeral-sg-78050a0b",
+            Description="orphan from before #69",
+            VpcId=vpc,
+        )["GroupId"]
+
+        cleaner = AWSResourceCleaner(region="us-east-1")
+        found = {sg["id"] for sg in cleaner.get_parsl_security_groups()}
+
+        assert group_id in found
+
+    def test_an_unrelated_group_is_left_alone(self, aws):
+        """Deleting a security group the caller supplied is the #100 hazard."""
+        ec2 = aws.client("ec2")
+        vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        group_id = ec2.create_security_group(
+            GroupName="my-production-sg",
+            Description="not ours",
+            VpcId=vpc,
+        )["GroupId"]
+
+        cleaner = AWSResourceCleaner(region="us-east-1")
+        found = {sg["id"] for sg in cleaner.get_parsl_security_groups()}
+
+        assert group_id not in found
+
+
+class TestFiltersMatchThePackage:
+    """The filters must name strings the package actually writes.
+
+    The original defect was not a logic error -- the queries were well-formed and
+    returned nothing, because they searched for a tag key (``parsl_provider``)
+    and a group prefix (``aws-enhanced-``) that exist nowhere in this package.
+    Asserting the filter values against the package source is what makes that
+    class of defect visible.
+    """
+
+    def _package_source(self) -> str:
+        modes = (REPO_ROOT / "parsl_aws_provider" / "modes").glob("*.py")
+        return "\n".join(path.read_text(encoding="utf-8") for path in modes)
+
+    def test_every_instance_tag_filter_is_written_by_some_mode(self):
+        """Each filter names a tag key that appears in ``modes/``."""
+        source = self._package_source()
+
+        missing = []
+        for tag_filter in _INSTANCE_TAG_FILTERS:
+            if tag_filter["Name"] == "tag-key":
+                keys = tag_filter["Values"]
+            else:
+                keys = [tag_filter["Name"].split(":", 1)[1]]
+            for key in keys:
+                if f'"{key}"' not in source and f"'{key}'" not in source:
+                    missing.append(key)
+
+        assert not missing, f"filtered on tag keys no mode writes: {missing}"
+
+    def test_the_security_group_pattern_matches_the_constant(self):
+        """The pattern tracks ``DEFAULT_SECURITY_GROUP_NAME``.
+
+        Pinned to the constant rather than the literal, so renaming the default
+        without updating the sweep fails here instead of silently narrowing it.
+        """
+        from parsl_aws_provider.constants import DEFAULT_SECURITY_GROUP_NAME
+
+        assert any(
+            re.fullmatch(pattern.replace("*", ".*"), DEFAULT_SECURITY_GROUP_NAME)
+            for pattern in _SECURITY_GROUP_NAME_PATTERNS
+        ), (
+            f"{DEFAULT_SECURITY_GROUP_NAME!r} matches none of "
+            f"{_SECURITY_GROUP_NAME_PATTERNS}"
+        )
+
+
+class TestEntryPoint:
+    """``parsl-aws-cleanup`` is a console script, so ``main`` is the contract."""
+
+    def test_dry_run_on_an_empty_account_succeeds(self, aws):
+        """Exit status 0 and nothing deleted."""
+        assert main(["--dry-run", "--region", "us-east-1"]) == 0
+
+    def test_dry_run_deletes_nothing(self, aws):
+        """``--dry-run`` reports and returns before any delete call.
+
+        It is also what every document tells a user to run first, so a
+        ``--dry-run`` that deleted would be the worst possible defect here.
+        """
+        instance_id = _launch(aws, STANDARD_MODE_TAGS)
+
+        assert main(["--dry-run", "--region", "us-east-1"]) == 0
+
+        state = aws.client("ec2").describe_instances(InstanceIds=[instance_id])
+        assert state["Reservations"][0]["Instances"][0]["State"]["Name"] == "running"
+
+    def test_main_returns_a_status_rather_than_exiting(self, aws):
+        """``console_scripts`` uses the return value as the exit status.
+
+        Returning instead of calling ``sys.exit()`` is also what makes the two
+        tests above possible.
+        """
+        result = main(["--dry-run", "--region", "us-east-1"])
+
+        assert isinstance(result, int)
+
+    def test_importing_the_module_does_not_configure_logging(self):
+        """``basicConfig`` belongs in ``main``, not at import.
+
+        The module moved into the installed package, so configuring the root
+        logger at import would hijack logging for anyone who merely imports
+        ``parsl_aws_provider``.
+        """
+        import logging
+        import subprocess
+        import sys
+
+        result = subprocess.run(  # nosec B603 -- fixed argv, no shell
+            [
+                sys.executable,
+                "-c",
+                "import logging, parsl_aws_provider.cleanup; "
+                "print(len(logging.getLogger().handlers))",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+        assert result.stdout.strip() == "0", (
+            f"importing cleanup.py added a root logging handler: {result.stdout!r}"
+        )
+        assert logging  # the import above is the subject, not incidental

--- a/tests/unit/test_docs_examples.py
+++ b/tests/unit/test_docs_examples.py
@@ -23,6 +23,7 @@ import importlib
 import importlib.util
 import inspect
 import re
+import sys
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple
 
@@ -406,6 +407,39 @@ def test_example_disables_htex_encryption(path: Path):
         elif getattr(encrypted.value, "value", None) is not False:
             failures.append(f"{path.name}:{node.lineno}: encrypted= is not False")
     assert not failures, "\n".join(failures)
+
+
+@pytest.mark.parametrize("path", _example_files(), ids=lambda p: p.name)
+def test_example_imports(path: Path):
+    """Every example imports cleanly.
+
+    ``test_example_parses`` only AST-parses, which cannot see a name that does
+    not exist at the other end of an import. Four of the eight examples carried
+    ``from parsl.app.python import python_app`` -- valid syntax, and an
+    ``ImportError`` on every run, because that module exports ``PythonApp``
+    rather than the decorator. Among them were ``standard_mode.py``, the README's
+    headline validation command, and ``detached_mode.py``, the documented NAT
+    workaround: both dead on arrival for over a release, with a green suite
+    (#198).
+
+    Importing is safe because every example guards its entry point behind
+    ``if __name__ == "__main__"``, so only module scope runs: imports,
+    ``logging.basicConfig``, constants, and the ``@python_app`` decorators. No
+    AWS call is reachable from there, and nothing is constructed -- provider
+    construction would reach AWS, so an example that did that at module scope
+    would be a defect this test should surface anyway.
+
+    The module is loaded under a private name and dropped from ``sys.modules``
+    afterwards, so eight examples that all define ``main`` cannot collide.
+    """
+    spec = importlib.util.spec_from_file_location(f"_example_{path.stem}", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop(spec.name, None)
 
 
 @pytest.mark.parametrize("path", _example_files(), ids=lambda p: p.name)

--- a/tests/unit/test_serverless_mode_spot_fleet.py
+++ b/tests/unit/test_serverless_mode_spot_fleet.py
@@ -715,3 +715,92 @@ class TestServerlessModeSpotFleet:
         assert spot_resource["resource_type"] == RESOURCE_TYPE_SPOT_FLEET
         assert spot_resource["fleet_request_id"] == "sfr-12345"
         assert spot_resource["use_spot_fleet"] is True
+
+
+class TestFleetUserDataRunsWorkerInit:
+    """The fleet path has to honour ``worker_init`` like every other EC2 path.
+
+    ``ServerlessMode`` inherits ``self.worker_init`` from ``OperatingMode`` and
+    ``_build_fleet_user_data`` silently dropped it, so a fleet instance booted a
+    bare Amazon Linux image -- no Parsl, none of the workload's dependencies --
+    and ran the job command against it. UserData is the *only* opportunity to
+    install anything on that instance, and it was spent (#198).
+
+    ``StandardMode._build_user_data`` and
+    ``SpotFleetManager._generate_user_data`` both include it, so this was the
+    single EC2 path that did not.
+    """
+
+    @pytest.fixture
+    def mode(self):
+        """A ServerlessMode with a distinctive ``worker_init``."""
+        session = MagicMock(spec=boto3.Session)
+        session.region_name = "us-east-1"
+        return ServerlessMode(
+            provider_id="test-provider",
+            session=session,
+            state_store=MagicMock(),
+            worker_type=WORKER_TYPE_ECS,
+            use_spot_fleet=True,
+            worker_init="pip3 install --quiet numpy scipy\n",
+            vpc_id="vpc-12345",
+            subnet_id="subnet-12345",
+            security_group_id="sg-12345",
+        )
+
+    def test_worker_init_appears_in_the_user_data(self, mode):
+        """The commands reach the instance at all."""
+        user_data = mode._build_fleet_user_data("python3 -m parsl.executors.x")
+
+        assert "pip3 install --quiet numpy scipy" in user_data
+
+    def test_worker_init_runs_before_the_command(self, mode):
+        """Order is the point: dependencies must exist before the job runs.
+
+        Present-but-after would still fail with the same ``ImportError`` as
+        absent, so position is the assertion, not mere inclusion.
+        """
+        user_data = mode._build_fleet_user_data("python3 -m parsl.executors.x")
+
+        assert user_data.index("pip3 install") < user_data.index("command.sh")
+
+    def test_the_shebang_stays_first(self, mode):
+        """``worker_init`` must not displace the interpreter line.
+
+        Inserting it ahead of ``#!/bin/bash`` would make cloud-init refuse the
+        whole script, which is a worse failure than the one being fixed.
+        """
+        user_data = mode._build_fleet_user_data("run-me")
+
+        assert user_data.startswith("#!/bin/bash\n")
+
+    def test_the_command_and_shutdown_survive(self, mode):
+        """The pre-existing behaviour is unchanged.
+
+        ``shutdown -h now`` pairs with ``InstanceInitiatedShutdownBehavior=terminate``:
+        without it a one-command instance idles at full price.
+        """
+        user_data = mode._build_fleet_user_data("run-me")
+
+        assert "run-me" in user_data
+        assert "shutdown -h now" in user_data
+
+    def test_an_empty_worker_init_adds_no_stray_section(self):
+        """The default is empty, and must stay clean."""
+        session = MagicMock(spec=boto3.Session)
+        session.region_name = "us-east-1"
+        mode = ServerlessMode(
+            provider_id="test-provider",
+            session=session,
+            state_store=MagicMock(),
+            worker_type=WORKER_TYPE_ECS,
+            use_spot_fleet=True,
+            vpc_id="vpc-12345",
+            subnet_id="subnet-12345",
+            security_group_id="sg-12345",
+        )
+
+        user_data = mode._build_fleet_user_data("run-me")
+
+        assert "User-provided worker initialization" not in user_data
+        assert user_data.startswith("#!/bin/bash\n")


### PR DESCRIPTION
Closes #198.

The sweep that bounds the bill after a crash shipped in no artifact, and returned
nothing when it *was* reachable. Nothing terminates instances automatically —
Parsl never calls `provider.shutdown()`, `HighThroughputExecutor.shutdown()`
documents that it does not terminate workers, and `dflow.py`'s `atexit_cleanup`
only logs — so after a `KeyboardInterrupt` this tool is the whole recovery path.

## Defects fixed

### 1. The cleanup tool shipped in neither the wheel nor the sdist

It lived at `tools/cleanup_aws_resources.py`, and `tools/` is in neither
distribution, so every documented `python tools/cleanup_aws_resources.py` line
worked only inside a git clone.

Moved to `parsl_aws_provider/cleanup.py`, exposed as `parsl-aws-cleanup` through
`[project.scripts]`. `main()` returns an exit status rather than calling
`sys.exit()` — `console_scripts` uses the return value — which also makes it
testable. `logging.basicConfig` moved out of module scope into `main()`: the
module is now part of an installed package, so configuring the root logger at
import would hijack logging for anyone who merely imports `parsl_aws_provider`.

**Verified** by building the wheel, installing it alone into a fresh venv, and
running the console script — the exact `pip install` path the issue says was
broken:

```
$ unzip -p dist/*.whl parsl_aws_provider-0.8.0.dist-info/entry_points.txt
[console_scripts]
parsl-aws-cleanup = parsl_aws_provider.cleanup:main

$ /tmp/pap-wheel-venv/bin/parsl-aws-cleanup --help
usage: parsl-aws-cleanup [-h] [--profile PROFILE] [--region REGION] [--dry-run]
```

16 doc/CI references updated to the new invocation, including
`.github/workflows/ci.yml`'s post-E2E sweep.

### 2. Its EC2 filters matched nothing this package writes

It queried `tag:parsl_provider` for `*aws-enhanced*`, and security groups named
`aws-enhanced-*`. Neither string appears anywhere in the package — not as a tag
key, not as a value, not as a group name. The tool documented as the way to find
orphaned billable resources reported `No resources to clean up!` against an
account full of them.

It now queries both conventions the modes write:

| Written by | Tags |
|---|---|
| `StandardMode` (`modes/standard.py:1338-1342`) | `CreatedBy=ParslEphemeralAWSProvider`, `ProviderId` |
| `DetachedMode` (`detached.py:918-924`), serverless fleet (`serverless.py:1160-1163`) | `ParslResource=true`, `ParslWorkflowId` |

Two `describe_instances` calls unioned by instance ID, because **EC2 ANDs its
`Filters`** — a single call passing both tag filters returns only instances
carrying *both*, which no mode writes. Security groups now match
`DEFAULT_SECURITY_GROUP_NAME`; a match there is a pre-v0.7.0 leftover, since #69
removed SG creation.

**Verified against real AWS in us-west-2**, from the wheel-only install:

```
Found 5 security groups to clean up:
  sg-0ebe0fcabe5e93433 - parsl-ephemeral-sg-78050a0b
  sg-07613b2376e0cf29a - parsl-ephemeral-sg-aad2fbe8
  sg-0d536b23372487a71 - parsl-ephemeral-sg-7c3450d9
  sg-0cd757354358e3767 - parsl-ephemeral-sg-d81cdcbc
  sg-063be0a8e5126ba82 - parsl-ephemeral-sg-c5730a2f
```

The old filter reported zero of those five. Also 0-vs-2 on live instances tagged
one per convention (`i-05dd6ab116ef8f1fc`, `i-0a216addcd942778b`, both since
terminated).

### 3. Four examples raised `ImportError` on their first import line

`from parsl.app.python import python_app` names nothing — the decorator is
`parsl.python_app`, defined in `parsl/app/app.py`. `standard_mode.py`,
`detached_mode.py`, `serverless_mode.py` and `spot_interruption_example.py` were
all unrunnable for a full release; `spot_fleet_example.py` used a third spelling.
All five now import from `parsl` directly.

`test_example_parses` only AST-parsed each file, which **cannot see a name that
does not exist at the other end of an import**, so it stayed green over all four.
`test_example_imports` now executes each module — safe because every example
guards its entry point with `if __name__ == "__main__"`.

### 4. Serverless mode discarded `worker_init` on the fleet path (not in the issue)

Found while investigating the issue's numpy claim. `_build_fleet_user_data` never
referenced `self.worker_init`, so a fleet instance booted a bare Amazon Linux
image — no Parsl, none of the workload's dependencies — and ran the job command
against it. UserData is the *only* opportunity to install anything on that
instance, and it was spent. `StandardMode._build_user_data` and
`SpotFleetManager._generate_user_data` both include it, so this was the single
EC2 path that did not.

`examples/serverless_spot_fleet_example.py` now passes a `worker_init` installing
its own imports, which it could not do before. The issue's numpy claim was itself
imprecise: both numpy imports are inside `@python_app` bodies, so they run on the
worker — declaring numpy as a driver dependency would have fixed nothing.

## Tests

28 new tests, and every one has a negative control:

- `tests/unit/test_cleanup_tool.py` (14, new file — the tool had **none**).
  Discovery in both directions: each convention found, both found together, an
  instance carrying both deduplicated, a third party's instance left alone (the
  destructive direction — this tool calls `terminate_instances`), terminated
  instances not reported. `TestFiltersMatchThePackage` asserts each filtered tag
  key appears in `modes/*.py` and pins the SG pattern to
  `DEFAULT_SECURITY_GROUP_NAME`, so the original defect class — a well-formed
  query for a string the package never writes — cannot recur silently.
  `TestEntryPoint` covers the `main()` contract and asserts importing adds no
  root log handler.
- `TestFleetUserDataRunsWorkerInit` (5) — presence, ordering before the command,
  the shebang staying first, command/shutdown preserved, and no stray section
  when `worker_init` is unset.
- `test_example_imports` (9 parametrizations).

Negative controls: reverting the `worker_init` fix fails 2 of 5 (the other 3 pin
what must not break); reintroducing `from parsl.app.python import python_app`
reproduces the user-facing `ImportError`; restoring the `aws-enhanced-*` filters
fails 7 of 14, including `AssertionError: 'parsl-ephemeral-sg' matches none of
['aws-enhanced-*']`.

## Verification

| Check | Result |
|---|---|
| `pytest tests/unit tests/security` | **1212 passed, 2 skipped** (from 1184/2) |
| `ruff check .` / `ruff format --check .` | clean, 125 files |
| `mypy parsl_aws_provider` | **76 errors — baseline unchanged**; `cleanup.py` contributes none despite now being checked |
| `make -C docs html SPHINXOPTS="-W"` | build succeeded |
| `uv build` + fresh-venv install | console script on `PATH`, live sweep found the 5 orphans |