### PR TITLE
fix: make the generated Globus endpoint config startable (closes #196)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **`generate_endpoint_config()` writes four files and returns a different one**
+  (#196). It previously wrote `config.yaml` plus a `config.py` shim and returned
+  the path to the YAML. It now writes `config.yaml`, a
+  `user_config_template.yaml.j2` holding the `engine:` block, a
+  `user_environment.yaml`, and a `_bootstrap/sitecustomize.py`; the return value
+  is the **template** path, since that is the file an operator edits. Any stale
+  `config.py` in the target directory is removed, because Globus Compute would
+  otherwise still load it and reintroduce the failure. **Regenerate any endpoint
+  directory created by an earlier version** — the old two-file layout could never
+  start.
 - **substrate pinned to `0.85.0`, and CI's pin realigned with compose's.** The two
   pins had drifted: `.github/workflows/ci.yml` sat on `0.76.0` while
   `docker-compose.substrate.yml` had moved to `0.82.0`, so CI validated against an
@@ -153,6 +163,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   4.0.1).
 
 ### Fixed
+- **The generated Globus Compute endpoint config could never start** (#196).
+  `globus-compute-endpoint start` classifies a config by a single key:
+  `load_config_yaml()` pops `engine` and returns a `UserEndpointConfig` when it is
+  present, and `cli.py` then refuses the endpoint with *"contains an `engine`
+  field; endpoint will not start"*. The generated `config.yaml` carried `engine:`,
+  so every endpoint this provider produced hit that gate. The `engine:` block now
+  lives in `user_config_template.yaml.j2`, which is where the multi-user endpoint
+  expects it, and `config.yaml` holds only `display_name`.
+
+  `user_config_template_path` is deliberately **omitted** from `config.yaml`. Its
+  setter resolves a relative path against the *process* working directory and
+  raises if the file is missing, so writing it made the endpoint startable only
+  from the directory it was generated in. Omitting it lets Globus Compute fall
+  back to `endpoint_dir / "user_config_template.yaml.j2"`, which is correct from
+  any cwd.
+- **A rejected Globus config leaked an IAM role and instance profile on every
+  attempt** (#196). Two independent causes, both fixed:
+
+  - `StandardMode.initialize()` created the instance profile and verified the
+    network *outside* any teardown — the `try` that calls
+    `cleanup_infrastructure()` began below both. So any failure in between left
+    the role and profile standing with nothing tracking them, which is the #132
+    pathology reachable on nothing more exotic than a mistyped subnet ID. The
+    teardown boundary now opens above `_resolve_instance_profile()`. The
+    exception is re-raised **unchanged** rather than wrapped, because #77 requires
+    a bad network ID to surface as `ResourceNotFoundError` naming the ID —
+    burying it in a `ResourceCreationError` would send the caller looking for a
+    provisioning fault instead of their own typo.
+  - Moving the `engine:` block out of `config.yaml` removes the cause
+    structurally: loading the manager config now constructs no provider at all,
+    so a config the endpoint is about to reject cannot reach AWS in the first
+    place. `test_loading_the_manager_config_creates_no_provider` mocks no AWS
+    whatsoever and passes, which is the assertion form of that claim.
+
+  This mattered more than a single leaked pair suggests: a config load that ends
+  in an error message is the normal Globus debugging loop, and each iteration left
+  another standing principal with `AmazonSSMManagedInstanceCore` attached.
+- **The forked user-endpoint process could not resolve
+  `GlobusComputeProvider`** (#196). A multi-user endpoint forks and `execvpe`s a
+  fresh interpreter that reads its config from stdin as JSON, so the `config.py`
+  shim — which only `get_config()` honours — never runs there, and Globus
+  Compute's attribute lookup on `parsl.providers` fails on a class this package
+  never registered. The generated `user_environment.yaml` now puts a
+  `_bootstrap/` directory on the child's `PYTHONPATH`; its `sitecustomize.py`
+  imports `parsl_aws_provider` during `site` initialisation, before any config is
+  parsed. It swallows its own `ImportError` after writing a diagnostic to stderr,
+  since raising there would break every interpreter the endpoint starts.
+
+  This is a workaround, not the fix — #133 tracks teaching Globus Compute to
+  resolve a dotted path, which would make the bootstrap unnecessary. Note that
+  generation works anywhere but `start` is Linux-only: `pyprctl` has no macOS
+  wheel, so `start` fails earlier and for an unrelated reason there.
 - **`SECURITY.md`'s only code example was rejected outright, and its policy
   covered a version that does not ship** (#199). Four of the five kwargs in the
   security-configuration example have never existed — `encrypt_storage`,

--- a/README.md
+++ b/README.md
@@ -194,10 +194,12 @@ the block quietly falls through to a single on-demand instance
 > **Full guide**: [docs/globus_compute.md](https://scttfrdmn.github.io/parsl-aws-provider/globus_compute.html) — architecture,
 > IAM setup, spot and container examples, multi-region deployment, troubleshooting.
 
-`GlobusComputeProvider` generates the endpoint directory rather than making you
-hand-write YAML, including the `config.py` shim that makes the config loadable at
-all — Globus Compute resolves a provider by attribute lookup on `parsl.providers`,
-which does not know this class until something imports it.
+`GlobusComputeProvider` generates the whole endpoint directory rather than making
+you hand-write YAML — including the two pieces that are easy to get wrong: the
+`engine:` block belongs in `user_config_template.yaml.j2` and not in `config.yaml`,
+or `start` refuses the endpoint outright; and the forked user-endpoint process
+never imports this package, so a `sitecustomize` bootstrap on its `PYTHONPATH` is
+what makes Globus Compute's attribute lookup on `parsl.providers` find the class.
 
 ```bash
 uv sync --extra globus

--- a/docs/globus_compute.md
+++ b/docs/globus_compute.md
@@ -229,9 +229,11 @@ To reuse a UUID you already have, pass it on the first start:
 uv run globus-compute-endpoint start my_aws_endpoint --endpoint-uuid <uuid>
 ```
 
-There is no config key for it: `BaseConfig` rejects `endpoint_id`, so writing it
-into `config.yaml` makes the config unloadable. If you passed `endpoint_id=` to the
-constructor, the generated `config.yaml` carries the flag to use as a comment.
+There is no *top-level* config key for it, in either file: `BaseConfig` raises
+`Unexpected keyword argument` and the config becomes unloadable. Under
+`engine.provider` it is legal — that is a `GlobusComputeProvider` kwarg, not an
+endpoint one — so `endpoint_id=` reaches the template there, and `config.yaml`
+additionally carries the `--endpoint-uuid` invocation as a comment.
 
 ### 4. Submit from anywhere
 
@@ -511,20 +513,23 @@ It is waiting for a worker. Beyond the above:
   and `ec2messages` VPC endpoints, plus a route to whatever package index
   `worker_init` uses.
 - **AMI**: resolved from SSM for the region and architecture, and only emitted
-  into `config.yaml` when you passed it explicitly. A custom `image_id` must exist
-  in the target region.
+  into `user_config_template.yaml.j2` when you passed it explicitly. A custom
+  `image_id` must exist in the target region.
 
 ### `ResourceNotFoundException` on start
 
-The UUID in `~/.globus_compute/<name>/` no longer exists in the service. Delete
-the directory and re-register:
+The UUID in `~/.globus_compute/<name>/endpoint.json` no longer exists in the
+service. Delete the directory and let the next start register a fresh one:
 
 ```bash
 rm -rf ~/.globus_compute/my_aws_endpoint
-uv run globus-compute-endpoint configure my_aws_endpoint
 ```
 
-Regenerate the config afterwards — `configure` writes a default one.
+Then re-run `generate_endpoint_config()` and start again. Do **not** use
+`globus-compute-endpoint configure` to recreate it — that writes its own
+`config.yaml`, which this package's generator then has to overwrite, and an
+operator who forgets the second step is left with a default endpoint that runs
+nothing on AWS.
 
 ### `TaskExecutionFailed`
 

--- a/docs/globus_compute.md
+++ b/docs/globus_compute.md
@@ -6,11 +6,14 @@ environment — including behind corporate firewalls, university networks, and h
 routers.
 
 ```{note}
-Before v0.8.0 the generated `config.yaml` dropped `worker_init`, hardcoded
-`encrypted: true`, and omitted 37 of 52 provider parameters — so every endpoint
-needed two manual edits before a worker could start
+Before v0.9.0 the generated `config.yaml` put the `engine:` block at the top level,
+which makes `globus-compute-endpoint start` refuse it outright
+([#196](https://github.com/scttfrdmn/parsl-aws-provider/issues/196)); before v0.8.0
+it also dropped `worker_init`, hardcoded `encrypted: true`, and omitted 37 of 52
+provider parameters
 ([#138](https://github.com/scttfrdmn/parsl-aws-provider/issues/138)). Generated
-configs are now complete and start unedited. Read
+configs are now startable and complete, unedited. **Regenerate any endpoint
+directory created by an earlier version.** Read
 [Known limitations](#known-limitations) before deploying.
 ```
 
@@ -112,28 +115,55 @@ provider = GlobusComputeProvider(
 provider.generate_endpoint_config("~/.globus_compute/my_aws_endpoint")
 ```
 
-This writes **two** files:
+This writes **four** files, and returns the path to the second:
 
 | File | Purpose |
 |---|---|
-| `config.yaml` | the configuration — the file to edit |
-| `config.py` | a loader shim; do not edit |
+| `config.yaml` | manager configuration: `display_name`, and nothing else |
+| `user_config_template.yaml.j2` | the `engine:` block and all AWS settings — the file to edit |
+| `user_environment.yaml` | a `PYTHONPATH` pointing at `_bootstrap/` |
+| `_bootstrap/sitecustomize.py` | the import that registers the provider; do not edit |
 
-Both are needed. Globus Compute resolves a provider's `type:` key by
+**Why the split.** `globus-compute-endpoint` 4.15.0 classifies a config by one
+key: `load_config_yaml()` pops `engine`, returning a `ManagerEndpointConfig` when
+it is absent and a `UserEndpointConfig` when it is present. `start` refuses
+anything that is not a `ManagerEndpointConfig`, and the only other entry point,
+`_start-user-endpoint`, is invoked solely by a running manager. So a `config.yaml`
+carrying a top-level `engine:` block cannot be started at all — which is what the
+generator used to emit
+([#196](https://github.com/scttfrdmn/parsl-aws-provider/issues/196)). Upstream's
+own packaged `default_config.yaml` is the single line `display_name: null`, with
+the engine in the template, for the same reason.
+
+**Why the bootstrap.** Globus Compute resolves a provider's `type:` key by
 `getattr(parsl.providers, type_name, None)` and raises when that is `None`, so a
 class Parsl does not ship is unreachable — and `getattr` cannot walk a dotted
-path, so `type: parsl_aws_provider.globus_compute.GlobusComputeProvider` can
-never resolve either. Importing `parsl_aws_provider` assigns the class onto
-`parsl.providers`, but the endpoint daemon has no reason to import this package.
-The `config.py` shim does that import and then hands `config.yaml` to Globus
-Compute's own loader; `get_config()` prefers `config.py` when both are present,
-which is what makes the pair work
-([#87](https://github.com/scttfrdmn/parsl-aws-provider/issues/87)).
+path, so `type: parsl_aws_provider.globus_compute.GlobusComputeProvider` can never
+resolve either
+([#87](https://github.com/scttfrdmn/parsl-aws-provider/issues/87)). Importing
+`parsl_aws_provider` assigns the class onto `parsl.providers`, but the process
+that loads the template never imports this package: the manager forks and
+`execvpe`s a *fresh interpreter*, which reads its rendered config from stdin. The
+one seam into that child is `user_environment.yaml`, which the manager merges into
+its environment immediately before the exec. Pointing `PYTHONPATH` at a directory
+holding `sitecustomize.py` makes Python run that import during `site`
+initialisation — before any user code, and so before the config is parsed.
+
+If [#133](https://github.com/scttfrdmn/parsl-aws-provider/issues/133) lands
+upstream (dotted-path provider resolution), the bootstrap becomes unnecessary and
+`type:` can name the class directly.
+
+```{note}
+Generation works on any platform, but *running* a manager endpoint needs Linux:
+`globus-compute-endpoint` 4.15.0 requires `pyprctl`, and on macOS `start` exits
+with "multi-user endpoints are not supported on this system".
+```
 
 ### 2. Read the two keys that are set for you
 
-No edits are required. Two generated keys are worth understanding, because both
-are the difference between a worker that registers and one that dies silently:
+No edits are required. Two keys in `user_config_template.yaml.j2` are worth
+understanding, because both are the difference between a worker that registers and
+one that dies silently:
 
 ```yaml
 engine:
@@ -185,11 +215,23 @@ they can use this provider at all.
 uv run globus-compute-endpoint start my_aws_endpoint
 ```
 
-It registers and prints its UUID:
+Registration happens as part of starting — there is no separate `register`
+subcommand. The first start registers the endpoint, writes the UUID to
+`endpoint.json`, and prints it:
 
 ```
 Starting endpoint; registered endpoint ID: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 ```
+
+To reuse a UUID you already have, pass it on the first start:
+
+```bash
+uv run globus-compute-endpoint start my_aws_endpoint --endpoint-uuid <uuid>
+```
+
+There is no config key for it: `BaseConfig` rejects `endpoint_id`, so writing it
+into `config.yaml` makes the config unloadable. If you passed `endpoint_id=` to the
+constructor, the generated `config.yaml` carries the flag to use as a comment.
 
 ### 4. Submit from anywhere
 
@@ -227,15 +269,15 @@ of its own:
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `endpoint_id` | `str \| None` | `None` | Endpoint UUID. Emitted into `config.yaml` as a provider key and a trailing comment. |
+| `endpoint_id` | `str \| None` | `None` | Endpoint UUID. Emitted as a provider key in the template, and as the `--endpoint-uuid` reminder in `config.yaml`. |
 | `container_image` | `str \| None` | `None` | Image URI. Sets `container_type: docker` and `container_uri` under `engine`. |
-| `display_name` | `str` | `"Ephemeral AWS Endpoint"` | Label shown in the Globus Compute web console. |
+| `display_name` | `str` | `"Ephemeral AWS Endpoint"` | Label shown in the Globus Compute web console. The one key in `config.yaml`. |
 | `encrypted` | `bool` | `False` | CurveZMQ encryption on the engine. `True` needs [#62](https://github.com/scttfrdmn/parsl-aws-provider/issues/62) — see step 2. |
 
 `worker_init` also differs from the base class: `GlobusComputeProvider` defaults
 it to a script that installs `globus-compute-endpoint`, not just `parsl`.
 
-**Which parameters reach `config.yaml`.** Every parameter you pass, plus
+**Which parameters reach the template.** Every parameter you pass, plus
 `region`, `instance_type`, `mode`, `max_blocks`, and `worker_init` whether you
 pass them or not. The list comes from `inspect.signature`, so a parameter added to
 `EphemeralAWSProvider` is emitted without anyone updating the generator — the
@@ -386,12 +428,17 @@ start`.
   distribution exists ([#62](https://github.com/scttfrdmn/parsl-aws-provider/issues/62)),
   so `encrypted` defaults to `False` and High-Assurance endpoints — which reject
   that — cannot use this provider.
-- **Multi-user (manager) endpoints are unsupported**
-  ([#133](https://github.com/scttfrdmn/parsl-aws-provider/issues/133)). Those
-  render `user_config_template.yaml.j2` to a string and the forked user-endpoint
-  process calls `load_config_yaml()` on it directly, never going through
-  `get_config()` — so there is no `config.py` hook and the "not a valid provider"
-  failure returns. Fixing it needs dotted-path support upstream.
+- **The bootstrap is a workaround, not the fix.** Resolving the provider inside
+  the forked user-endpoint process depends on a `PYTHONPATH`/`sitecustomize` hook
+  rather than on anything Globus Compute supports for this. Dotted-path provider
+  resolution upstream
+  ([#133](https://github.com/scttfrdmn/parsl-aws-provider/issues/133)) would let
+  `type:` name the class directly and make `user_environment.yaml` and
+  `_bootstrap/` unnecessary. Until then, if you hand-edit those two away, the
+  endpoint fails with "not a valid provider".
+- **Running an endpoint needs Linux.** `globus-compute-endpoint` 4.15.0 depends on
+  `pyprctl`, which is Linux-only; `start` refuses on macOS. Config generation works
+  anywhere.
 - **The endpoint daemon must be reachable by workers.** Globus Compute removes
   the reachability requirement from your *client*, not from the daemon host.
 - **`GlobusComputeExecutor` now ships inside Parsl** and talks to a Globus
@@ -435,9 +482,24 @@ In order of likelihood:
 
 ### `'GlobusComputeProvider' is not a valid provider`
 
-`config.py` is missing or was deleted. Regenerate with
-`generate_endpoint_config()`, which writes both files. If you are using a
-multi-user endpoint, this is #133 and has no workaround yet.
+`user_environment.yaml` or `_bootstrap/sitecustomize.py` is missing, or
+`PYTHONPATH` in the former no longer points at the latter — that pair is what
+imports this package in the forked user-endpoint process. Regenerate with
+`generate_endpoint_config()`, which writes all four files.
+
+If both are present, the package is not installed in the interpreter the endpoint
+runs under. `sitecustomize.py` prints the underlying `ImportError` to stderr rather
+than raising, so check the endpoint log for a
+`parsl-aws-provider: could not import parsl_aws_provider` line.
+
+### `contains an 'engine' field; endpoint will not start`
+
+A `config.yaml` with a top-level `engine:` block, which is what this package
+generated before v0.9.0
+([#196](https://github.com/scttfrdmn/parsl-aws-provider/issues/196)). Regenerate:
+the engine block now belongs in `user_config_template.yaml.j2`, and
+`generate_endpoint_config()` also deletes any stale `config.py`, which would
+otherwise win over `config.yaml` and reinstate the old shape.
 
 ### `globus-compute-endpoint start` hangs
 

--- a/parsl_aws_provider/globus_compute.py
+++ b/parsl_aws_provider/globus_compute.py
@@ -25,34 +25,66 @@ Usage::
     )
     provider.generate_endpoint_config("~/.globus_compute/my_aws_endpoint")
 
+The shape of a startable endpoint
+---------------------------------
+Every endpoint ``globus-compute-endpoint`` 4.15.0 can start is a *manager*
+endpoint (MEP). The classification is made by one key: ``load_config_yaml()``
+pops ``engine`` and picks ``ManagerEndpointConfig`` when it is absent,
+``UserEndpointConfig`` when it is present. ``start`` then refuses anything that
+is not a ``ManagerEndpointConfig`` (``cli.py:899``), and the only other entry
+point -- ``_start-user-endpoint`` -- reads its config from stdin and is invoked
+solely by a running manager. So a ``config.yaml`` carrying a top-level
+``engine:`` block cannot be started at all: that was #196.
+
+``generate_endpoint_config()`` therefore writes the manager/template pair
+upstream's own ``configure`` produces:
+
+``config.yaml``
+    Manager configuration. ``display_name`` and nothing else that matters --
+    upstream's packaged ``default_config.yaml`` is the single line
+    ``display_name: null``.
+``user_config_template.yaml.j2``
+    The ``engine:`` block, including the ``provider:`` sub-block that names this
+    class. The manager renders this per user endpoint.
+
 How Globus Compute finds this provider
 --------------------------------------
-Globus Compute resolves the ``provider: type:`` key in ``config.yaml`` by plain
-attribute lookup on the ``parsl.providers`` module -- ``getattr(parsl.providers,
-type_name, None)``, raising if the result is ``None``
+Globus Compute resolves the ``provider: type:`` key by plain attribute lookup on
+the ``parsl.providers`` module -- ``getattr(parsl.providers, type_name, None)``,
+raising if the result is ``None``
 (``globus_compute_endpoint/endpoint/config/dispatch.py``). Two consequences,
-both verified against ``globus-compute-endpoint`` 4.15.0:
+both verified against 4.15.0:
 
 1. A dotted path can never resolve, because ``getattr`` does not walk dots. The
    type key must therefore be the bare class name.
 2. The bare name only resolves if something has already assigned the class onto
-   ``parsl.providers``. Importing this module does that (see
-   :func:`_register_with_parsl_providers`), but the endpoint daemon has no
-   reason to import it -- it reads ``config.yaml`` and nothing else.
+   ``parsl.providers``. Importing this package does that (see
+   :func:`_register_with_parsl_providers`), but nothing in the endpoint's own
+   startup has a reason to import it.
 
-So ``generate_endpoint_config()`` writes *two* files: the ``config.yaml`` that
-holds the configuration, and a small ``config.py`` shim that imports this
-package -- registering the class -- and then hands the YAML to Globus Compute's
-own loader. ``get_config()`` prefers ``config.py`` when both are present, which
-is what makes the pair work. ``config.yaml`` stays the single place to edit.
+The template is rendered and loaded in a *different interpreter* from the
+manager: ``EndpointManager`` forks and ``os.execvpe``s ``globus-compute-endpoint
+_start-user-endpoint <name>``, and that child calls ``load_config_yaml()`` on
+the rendered string handed to it on stdin. So the ``config.py`` shim this
+package used to write (#87) cannot help -- ``get_config()`` is never reached in
+the child, and the import has to happen before its first line of user code.
 
-This covers single-user endpoints, which is what ``generate_endpoint_config()``
-produces. **Multi-user (manager) endpoints are not supported** (#133): those
-render ``user_config_template.yaml.j2`` to a string and the forked user-endpoint
-process calls ``load_config_yaml()`` on it directly, never going through
-``get_config()`` -- so there is no ``config.py`` hook and the same "not a valid
-provider" failure returns. Resolving that needs dotted-path support upstream in
-``TypeDispatcher.build_instance``; see #133.
+The seam that does reach it is ``user_environment.yaml``, which the manager
+reads and merges into the child's environment immediately before ``execvpe``
+(``endpoint_manager.py:1069``). ``generate_endpoint_config()`` writes a
+``PYTHONPATH`` there pointing at a ``_bootstrap/`` directory holding a
+``sitecustomize.py`` whose body is ``import parsl_aws_provider`` -- so the
+interpreter registers the class during ``site`` initialisation, before the
+config is parsed. Verified in a genuinely fresh interpreter: with the
+``PYTHONPATH`` the bare name resolves, without it ``getattr`` returns ``None``.
+
+Dotted-path support upstream (#133) would make the bootstrap unnecessary. Until
+then this is what makes a generated endpoint start.
+
+One platform caveat: ``start`` requires ``pyprctl``, which is Linux-only, so on
+macOS it exits "multi-user endpoints are not supported on this system" before
+reading any configuration. Generation works anywhere; running an endpoint needs
+Linux, and that is true of every 4.15.0 endpoint, not just these.
 
 Minimum IAM permissions
 -----------------------
@@ -152,7 +184,6 @@ _PROVIDER_TYPE = "GlobusComputeProvider"
 # level and keeps the output human-readable with predictable ordering).
 _INDENT2 = "  "
 _INDENT4 = "    "
-_INDENT6 = "      "
 
 # Constructor parameters deliberately left out of the generated config.
 #
@@ -269,27 +300,46 @@ def _yaml_line(key: str, value: Any, indent: str = "") -> str:
     return f"{indent}{key}: {value}"
 
 
-# The ``config.py`` shim written alongside ``config.yaml``. Globus Compute
-# imports this file and reads its module-level ``config``; the import of
-# ``parsl_aws_provider`` is what puts ``GlobusComputeProvider`` on
-# ``parsl.providers`` so the YAML's ``type:`` key resolves.
-_CONFIG_PY_SHIM = '''\
-"""Loader shim generated by parsl-aws-provider. Edit config.yaml, not this file.
+# Directory holding the bootstrap ``sitecustomize.py``, relative to the endpoint
+# directory. Named with a leading underscore so it sorts away from the four
+# configuration files a site administrator actually edits.
+_BOOTSTRAP_DIRNAME = "_bootstrap"
 
-Globus Compute resolves a provider's ``type:`` by attribute lookup on the
-``parsl.providers`` module, which only knows about providers that ship with
-Parsl. Importing ``parsl_aws_provider`` registers ``GlobusComputeProvider``
-there, so this file exists purely to do that import before the YAML is parsed.
-``globus-compute-endpoint`` prefers ``config.py`` over ``config.yaml`` when both
-are present, which is what gets this executed.
+# Placed on the user endpoint's PYTHONPATH via ``user_environment.yaml``. Python
+# imports ``sitecustomize`` during ``site`` initialisation, so this runs before
+# the first line of ``globus-compute-endpoint``'s own code -- which is the only
+# window there is: the user endpoint process receives its configuration on stdin
+# and parses it immediately.
+_SITECUSTOMIZE = '''\
+"""Import hook generated by parsl-aws-provider. Do not edit.
+
+The user endpoint process is a fresh interpreter (the manager forks and
+``execvpe``s it), and it resolves the ``provider: type:`` key in the rendered
+template by ``getattr(parsl.providers, "GlobusComputeProvider", None)``. Nothing
+in that process imports this package, so the attribute is absent and the lookup
+fails with "is not a valid provider" (#196).
+
+Python imports ``sitecustomize`` automatically during ``site`` initialisation
+if it is anywhere on ``sys.path``. ``user_environment.yaml`` puts this
+directory there, so the registration happens before the configuration is
+parsed. Delete this file only together with that PYTHONPATH entry.
 """
 
-import pathlib
+try:
+    import parsl_aws_provider  # noqa: F401  registers GlobusComputeProvider
+except Exception as exc:  # pragma: no cover - diagnostic path
+    # A bare traceback here would be attributed to the interpreter rather than
+    # to the endpoint, so say where it came from. Not re-raised: breaking every
+    # interpreter that happens to inherit this PYTHONPATH would be worse than
+    # the "not a valid provider" error that follows.
+    import sys
 
-import parsl_aws_provider  # noqa: F401  registers GlobusComputeProvider
-from globus_compute_endpoint.endpoint.config.utils import load_config_yaml
-
-config = load_config_yaml((pathlib.Path(__file__).parent / "config.yaml").read_text())
+    print(
+        "parsl-aws-provider: could not import parsl_aws_provider"
+        f" ({type(exc).__name__}: {exc}). The endpoint will fail to resolve"
+        " GlobusComputeProvider. Is the package installed in this interpreter?",
+        file=sys.stderr,
+    )
 '''
 
 
@@ -323,7 +373,7 @@ class GlobusComputeProvider(EphemeralAWSProvider):
     """Globus Compute-aware wrapper around ``EphemeralAWSProvider``.
 
     Extends ``EphemeralAWSProvider`` with Globus Compute endpoint metadata
-    and a helper that generates a ready-to-use ``config.yaml`` for the
+    and a helper that generates a ready-to-start endpoint directory for the
     ``globus-compute-endpoint`` daemon.
 
     All ``EphemeralAWSProvider`` constructor parameters are accepted as-is
@@ -332,13 +382,18 @@ class GlobusComputeProvider(EphemeralAWSProvider):
     Parameters
     ----------
     endpoint_id : str, optional
-        Globus Compute endpoint UUID.  May be ``None`` during development;
-        the generated ``config.yaml`` will include a ``# TODO`` placeholder.
+        Globus Compute endpoint UUID. Optional, and it is not a configuration
+        key -- Globus Compute's ``BaseConfig`` rejects ``endpoint_id``, and the
+        UUID lives in ``endpoint.json`` written during registration. When set,
+        the generated ``config.yaml`` records it as a comment together with the
+        ``--endpoint-uuid`` invocation that adopts it; when unset, ``start``
+        registers the endpoint and assigns one.
     container_image : str, optional
         Container image URI to run Parsl workers inside a container.
         Examples: ``"python:3.11-slim"``, ``"123456789.dkr.ecr.us-east-1.amazonaws.com/my-image:latest"``.
-        When set, the generated ``config.yaml`` includes ``container_type: docker``
-        and ``container_uri: <image>`` under the ``engine`` block.
+        When set, the generated ``user_config_template.yaml.j2`` includes
+        ``container_type: docker`` and ``container_uri: <image>`` under the
+        ``engine`` block.
     display_name : str, optional
         Human-readable name for the Globus Compute endpoint.
         Default is ``"Ephemeral AWS Endpoint"``.
@@ -393,26 +448,35 @@ class GlobusComputeProvider(EphemeralAWSProvider):
     # ------------------------------------------------------------------
 
     def generate_endpoint_config(self, path: str) -> str:
-        """Write a loadable Globus Compute endpoint configuration to *path*.
+        """Write a startable Globus Compute endpoint configuration to *path*.
 
-        Creates the directory at *path* if it does not exist, then writes two
+        Creates the directory at *path* if it does not exist, then writes four
         files into it:
 
         ``config.yaml``
-            The configuration itself -- the file to edit.
-        ``config.py``
-            A three-line shim that imports ``parsl_aws_provider`` (registering
-            ``GlobusComputeProvider`` on ``parsl.providers``) and then hands
-            ``config.yaml`` to Globus Compute's own loader.
+            Manager configuration: ``display_name``, and nothing else.
+            Deliberately thin -- upstream's own packaged default is the single
+            line ``display_name: null``.
+        ``user_config_template.yaml.j2``
+            The ``engine:`` block and its ``provider:`` sub-block, which is
+            where all the AWS configuration lives. The file to edit.
+        ``user_environment.yaml``
+            A ``PYTHONPATH`` pointing at ``_bootstrap/``.
+        ``_bootstrap/sitecustomize.py``
+            ``import parsl_aws_provider``, which registers
+            ``GlobusComputeProvider`` on ``parsl.providers``.
 
-        Both are needed. Globus Compute looks a provider up by attribute on
-        ``parsl.providers``, so a ``config.yaml`` alone is unloadable: the
-        daemon never imports this package, and the lookup fails with *"'...' is
-        not a valid provider"* (#87). ``get_config()`` prefers ``config.py``
-        when both exist, so the shim runs first and the YAML then resolves.
+        The split between the first two is not cosmetic: an ``engine:`` key in
+        ``config.yaml`` makes ``load_config_yaml()`` return a
+        ``UserEndpointConfig``, and ``start`` rejects anything that is not a
+        ``ManagerEndpointConfig`` -- so the previous single-file output could
+        never be started (#196). The last two exist because the process that
+        loads the template is a fresh interpreter that never imports this
+        package; see the module docstring.
 
-        Returns the absolute path to ``config.yaml`` -- the file a caller would
-        want to read or edit.
+        Returns the absolute path to ``user_config_template.yaml.j2`` -- the
+        file a caller would want to read or edit, and the one holding everything
+        this class configures.
 
         The result is ready for the ``globus-compute-endpoint`` daemon::
 
@@ -427,46 +491,174 @@ class GlobusComputeProvider(EphemeralAWSProvider):
         Returns
         -------
         str
-            Absolute path to the written ``config.yaml``.
+            Absolute path to the written ``user_config_template.yaml.j2``.
         """
         endpoint_dir = Path(os.path.expanduser(path)).resolve()
         endpoint_dir.mkdir(parents=True, exist_ok=True)
-        config_path = endpoint_dir / "config.yaml"
 
-        yaml_content = self._build_config_yaml()
-        config_path.write_text(yaml_content, encoding="utf-8")
+        manager_path = endpoint_dir / "config.yaml"
+        manager_path.write_text(self._build_manager_config_yaml(), encoding="utf-8")
 
-        shim_path = endpoint_dir / "config.py"
-        shim_path.write_text(_CONFIG_PY_SHIM, encoding="utf-8")
+        template_path = endpoint_dir / "user_config_template.yaml.j2"
+        template_path.write_text(self._build_user_config_template(), encoding="utf-8")
+
+        bootstrap_dir = endpoint_dir / _BOOTSTRAP_DIRNAME
+        bootstrap_dir.mkdir(exist_ok=True)
+        (bootstrap_dir / "sitecustomize.py").write_text(
+            _SITECUSTOMIZE, encoding="utf-8"
+        )
+
+        env_path = endpoint_dir / "user_environment.yaml"
+        env_path.write_text(
+            self._build_user_environment_yaml(bootstrap_dir), encoding="utf-8"
+        )
+
+        # A config.py left over from a pre-#196 generation would win over
+        # config.yaml in get_config() and reinstate the unstartable shape, so
+        # remove it rather than leaving the directory in a state where the fix
+        # is present but inert.
+        legacy_shim = endpoint_dir / "config.py"
+        if legacy_shim.exists():
+            legacy_shim.unlink()
+            logger.info(
+                "Removed the pre-#196 config.py shim at %s: get_config() prefers it"
+                " over config.yaml, so leaving it would keep loading the"
+                " single-file layout that `start` rejects",
+                legacy_shim,
+            )
 
         logger.info(
-            "Globus Compute endpoint config written to %s (with loader shim %s)",
-            config_path,
-            shim_path,
+            "Globus Compute endpoint config written to %s"
+            " (manager %s, environment %s, bootstrap %s)",
+            template_path,
+            manager_path,
+            env_path,
+            bootstrap_dir,
         )
-        return str(config_path)
+        return str(template_path)
 
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
 
-    def _build_config_yaml(self) -> str:
-        """Render the endpoint ``config.yaml`` content as a string."""
+    def _build_manager_config_yaml(self) -> str:
+        """Render the manager ``config.yaml`` content as a string.
+
+        Thin by requirement, not by choice. ``load_config_yaml()`` decides which
+        config class to build from one thing -- whether an ``engine`` key is
+        present -- and ``start`` accepts only ``ManagerEndpointConfig``. So
+        anything engine-shaped here makes the endpoint unstartable (#196), and
+        the keys that remain are the handful ``BaseConfig`` and
+        ``ManagerEndpointConfig`` accept.
+
+        ``endpoint_id`` is *not* among them: ``BaseConfig`` rejects it as an
+        unexpected keyword argument. Globus Compute keeps the endpoint UUID in
+        ``endpoint.json``, written during registration, so it is emitted as a
+        comment and as ``--endpoint-uuid`` guidance instead.
+
+        Neither is ``user_config_template_path``, though it *is* accepted. Its
+        setter resolves the value against the process working directory and
+        raises ``ValueError`` if the result does not exist, so a relative path
+        breaks whenever the daemon is started from anywhere but the endpoint
+        directory -- and an absolute one hard-codes the generating machine's
+        layout. Omitting it leaves
+        ``Endpoint.user_config_template_path()`` to fall back to
+        ``<endpoint_dir>/user_config_template.yaml.j2``, which is where the
+        template is written and how upstream's own ``configure`` leaves it.
+        """
         lines: list[str] = []
 
-        # ---- Header comment ----
         lines.append(
-            "# Globus Compute endpoint configuration generated by GlobusComputeProvider"
+            "# Globus Compute *manager* endpoint configuration, generated by"
+            " GlobusComputeProvider."
         )
-        lines.append("# Edit this file to customise the endpoint, then run:")
+        lines.append(
+            "# The AWS configuration is in user_config_template.yaml.j2 -- edit that."
+        )
+        lines.append("# Then:")
         lines.append("#   globus-compute-endpoint start <endpoint-name>")
         lines.append("")
 
-        # ---- display_name ----
         lines.append(_yaml_line("display_name", self.display_name))
 
-        # ---- engine block ----
         lines.append("")
+        lines.append(
+            "# The engine and provider configuration is in"
+            " user_config_template.yaml.j2,"
+        )
+        lines.append(
+            "# alongside this file. There is deliberately no"
+            " `user_config_template_path`"
+        )
+        lines.append(
+            "# key: it is resolved against the working directory, so it breaks when the"
+        )
+        lines.append(
+            "# daemon starts from elsewhere. The default location is this directory."
+        )
+
+        lines.append("")
+        if self.endpoint_id:
+            lines.append(
+                "# This endpoint's UUID. It is not a config key -- BaseConfig rejects"
+            )
+            lines.append(
+                "# `endpoint_id` -- so pass it on the command line the first time:"
+            )
+            lines.append(
+                f"#   globus-compute-endpoint start <name> --endpoint-uuid"
+                f" {self.endpoint_id}"
+            )
+            lines.append(
+                "# After that it is recorded in endpoint.json and read from there."
+            )
+        else:
+            lines.append(
+                "# No endpoint UUID was supplied. `start` registers the endpoint and"
+            )
+            lines.append(
+                "# writes the UUID it is assigned to endpoint.json, so there is nothing"
+            )
+            lines.append(
+                "# to do here; `globus-compute-endpoint list` will show it afterwards."
+            )
+
+        lines.append("")  # trailing newline
+        return "\n".join(lines)
+
+    def _build_user_config_template(self) -> str:
+        """Render ``user_config_template.yaml.j2`` as a string.
+
+        This is where the ``engine:`` block lives, and with it everything this
+        class configures. The manager renders it per user endpoint and hands the
+        result to a forked-and-``execvpe``d child, which parses it with
+        ``load_config_yaml()``.
+
+        It is a Jinja template by extension and by upstream contract, but this
+        one contains no Jinja tags: every value is fixed at generation time from
+        the provider's own configuration. A site that wants per-user variation
+        can add ``{{ ... }}`` placeholders by hand, which is why the file is
+        written as a template rather than the ``.yaml`` fallback
+        ``load_user_config_template()`` also accepts.
+        """
+        lines: list[str] = []
+
+        lines.append(
+            "# User endpoint configuration template, generated by GlobusComputeProvider."
+        )
+        lines.append("# Edit this file to customise the endpoint, then run:")
+        lines.append("#   globus-compute-endpoint start <endpoint-name>")
+        lines.append("#")
+        lines.append(
+            "# The engine block lives here rather than in config.yaml because an"
+            " `engine:`"
+        )
+        lines.append(
+            "# key there makes the endpoint a *user* endpoint config, which `start`"
+        )
+        lines.append("# refuses to run (#196).")
+        lines.append("")
+
         lines.append("engine:")
         lines.append(f"{_INDENT2}type: GlobusComputeEngine")
         if not self.encrypted:
@@ -496,16 +688,55 @@ class GlobusComputeProvider(EphemeralAWSProvider):
         lines.append(f"{_INDENT4}type: {_PROVIDER_TYPE}")
         lines.extend(self._provider_params_yaml())
 
-        # ---- endpoint_id (trailing comment/reminder) ----
-        lines.append("")
-        if self.endpoint_id:
-            lines.append(f"# endpoint_id: {self.endpoint_id}")
-        else:
-            lines.append(
-                "# TODO: set endpoint_id after running:"
-                " globus-compute-endpoint register <endpoint-name>"
-            )
+        lines.append("")  # trailing newline
+        return "\n".join(lines)
 
+    def _build_user_environment_yaml(self, bootstrap_dir: Path) -> str:
+        """Render ``user_environment.yaml``, whose only job is ``PYTHONPATH``.
+
+        The manager reads this file and merges it into the child's environment
+        just before ``execvpe`` (``endpoint_manager.py:1069``), which makes it
+        the one seam that reaches the interpreter where the template is parsed.
+        Pointing ``PYTHONPATH`` at a directory holding ``sitecustomize.py`` gets
+        this package imported during ``site`` initialisation, so
+        ``GlobusComputeProvider`` is on ``parsl.providers`` before the first
+        ``getattr`` looks for it.
+
+        An absolute path, because the child ``chdir``s to the mapped user's home
+        (or ``/``) before exec.
+        """
+        lines: list[str] = []
+
+        lines.append(
+            "# Environment variables injected into user endpoint processes,"
+            " generated by"
+        )
+        lines.append("# GlobusComputeProvider.")
+        lines.append("#")
+        lines.append(
+            "# PYTHONPATH is load-bearing: the user endpoint process is a fresh"
+        )
+        lines.append(
+            "# interpreter that resolves `provider: type: GlobusComputeProvider` with"
+        )
+        lines.append(
+            "# getattr(parsl.providers, ...), and nothing in it imports this package."
+        )
+        lines.append(
+            f"# {_BOOTSTRAP_DIRNAME}/sitecustomize.py does that import, and Python runs"
+            " it during"
+        )
+        lines.append("# site initialisation. Remove this and the endpoint fails with")
+        lines.append('# "GlobusComputeProvider is not a valid provider" (#196).')
+        lines.append("#")
+        lines.append(
+            "# To add your own variables, append them here; anything set overrides the"
+        )
+        lines.append(
+            "# defaults, so keep this directory on PYTHONPATH if you extend it."
+        )
+        lines.append("")
+        lines.append(_yaml_line("PYTHONPATH", str(bootstrap_dir)))
         lines.append("")  # trailing newline
         return "\n".join(lines)
 
@@ -786,7 +1017,8 @@ class GlobusComputeProvider(EphemeralAWSProvider):
 
 
 # Runs on import, which is the only moment that reliably precedes a Globus
-# Compute config load: the generated ``config.py`` shim imports this package
-# before parsing the YAML. Defined above the class, called here, because it
-# references the class by name.
+# Compute config load: the generated ``_bootstrap/sitecustomize.py`` imports this
+# package during the user endpoint interpreter's ``site`` initialisation, before
+# anything parses the rendered template. Defined above the class, called here,
+# because it references the class by name.
 _register_with_parsl_providers()

--- a/parsl_aws_provider/modes/standard.py
+++ b/parsl_aws_provider/modes/standard.py
@@ -795,32 +795,53 @@ class StandardMode(OperatingMode):
         if self.initialized:
             return
 
-        # Resolve the SSM instance profile before either path below, so a
-        # resumed provider gets an ARN too — it is not persisted in state.
-        self._resolve_instance_profile()
-
-        # Confirm the caller-supplied network resources exist. This runs on both
-        # paths: verification used to sit inside the resume branch only, so a
-        # first-run provider — the common case — never checked at all, and a
-        # mistyped or cross-region ID surfaced much later as an opaque
-        # InvalidParameterValue from inside run_instances.
-        self._verify_resources()
-
-        # Try to load state first
-        if self.load_state():
-            logger.debug("Loaded state, resources already verified")
-            # A state document written before #85, or one whose template
-            # creation failed, carries no template ID. Build one now rather
-            # than leaving a resumed provider permanently on the fallback path.
-            if not self._launch_template_id:
-                self._create_launch_template()
-                self.save_state()
-            return
-
-        logger.debug("Initializing standard mode infrastructure")
-
-        # Create AWS resources
+        # This span used to sit *outside* any teardown: the try/except that calls
+        # cleanup_infrastructure() began below, after the instance profile had
+        # been created and the network verified. So a failure in between left the
+        # IAM role and instance profile standing with nothing tracking them --
+        # the #132 pathology, reachable on nothing more exotic than a mistyped
+        # subnet ID. #196 found it from the Globus side, where a config load that
+        # ends in an error message is the normal debugging loop and every attempt
+        # leaked another pair.
+        #
+        # The exception is re-raised unchanged rather than wrapped: #77 requires
+        # that a bad network ID surface as a ResourceNotFoundError naming the ID,
+        # and burying it in a ResourceCreationError would send the caller looking
+        # for a provisioning problem instead of their own typo.
         try:
+            # Resolve the SSM instance profile before either path below, so a
+            # resumed provider gets an ARN too — it is not persisted in state.
+            self._resolve_instance_profile()
+
+            # Confirm the caller-supplied network resources exist. This runs on
+            # both paths: verification used to sit inside the resume branch only,
+            # so a first-run provider — the common case — never checked at all,
+            # and a mistyped or cross-region ID surfaced much later as an opaque
+            # InvalidParameterValue from inside run_instances.
+            self._verify_resources()
+        except Exception:
+            self.cleanup_infrastructure()
+            raise
+
+        try:
+            # Try to load state first
+            if self.load_state():
+                logger.debug("Loaded state, resources already verified")
+                # A state document written before #85, or one whose template
+                # creation failed, carries no template ID. Build one now rather
+                # than leaving a resumed provider permanently on the fallback
+                # path.
+                if not self._launch_template_id:
+                    self._create_launch_template()
+                    self.save_state()
+                # State written before this line existed -- or by any version that
+                # persisted initialized=False -- would otherwise leave a resumed
+                # mode rejecting every submit_job as uninitialized.
+                self.initialized = True
+                return
+
+            logger.debug("Initializing standard mode infrastructure")
+
             # AMI baking: snapshot worker_init into a custom AMI
             if self.bake_ami and not self._baked_ami_id:
                 ami_id = self._bake_ami()

--- a/tests/aws/test_globus_compute_e2e.py
+++ b/tests/aws/test_globus_compute_e2e.py
@@ -110,13 +110,24 @@ def _skip_if_no_endpoint_id() -> str:
 # ---------------------------------------------------------------------------
 
 
+_last_start_failure: Optional[str] = None
+
+
 def _start_endpoint(
     endpoint_name: str, timeout: int = ENDPOINT_START_TIMEOUT_S
 ) -> Optional[str]:
     """Start a globus-compute-endpoint and return its UUID.
 
-    Returns None if the endpoint fails to start within *timeout* seconds.
+    Returns None if the endpoint fails to start within *timeout* seconds, and
+    records why in ``_last_start_failure`` so the caller's assertion can report it.
+
+    That reporting is the whole reason this helper is not just a ``subprocess.run``:
+    until #196 the generated config could never start, and the only signal was a
+    warning in the log plus a bare "did not start or register" assertion, which
+    reads like a timeout rather than a rejected config.
     """
+    global _last_start_failure
+    _last_start_failure = None
     try:
         result = subprocess.run(
             ["globus-compute-endpoint", "start", endpoint_name],
@@ -126,9 +137,14 @@ def _start_endpoint(
         )
         logger.info("endpoint start stdout: %s", result.stdout[:500])
         if result.returncode != 0:
-            logger.warning("endpoint start failed: %s", result.stderr[:500])
+            _last_start_failure = (
+                f"`start` exited {result.returncode}\n"
+                f"stdout: {result.stdout[-1500:]}\nstderr: {result.stderr[-1500:]}"
+            )
+            logger.warning("endpoint start failed: %s", _last_start_failure)
             return None
     except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        _last_start_failure = f"could not run globus-compute-endpoint: {exc}"
         logger.warning("globus-compute-endpoint not available: %s", exc)
         return None
 
@@ -217,14 +233,18 @@ class TestGlobusComputeProviderConfig:
     """Verify GlobusComputeProvider config generation works end-to-end.
 
     These tests exercise the Python layer only (no running Globus Compute
-    service required), verifying that the generated ``config.yaml`` is
-    a valid Globus Compute endpoint config. They are nonetheless marked ``aws``:
-    the provider validates the network IDs at construction, so they cannot run
-    without a real pre-provisioned VPC.
+    service required), verifying that the generated endpoint directory is a valid
+    Globus Compute endpoint config. They are nonetheless marked ``aws``: the
+    provider validates the network IDs at construction, so they cannot run without
+    a real pre-provisioned VPC.
+
+    Since #196 ``generate_endpoint_config()`` returns the path to
+    ``user_config_template.yaml.j2``, which is where the ``engine:`` block and all
+    AWS settings live -- so that is the file these read.
     """
 
     def test_generate_config_standard_mode(self, tmp_path, aws_region, network_ids):
-        """generate_endpoint_config() writes a valid config.yaml for standard mode."""
+        """generate_endpoint_config() writes a valid template for standard mode."""
         provider = _offline_provider(
             tmp_path,
             f"gc-test-{uuid.uuid4().hex[:8]}",
@@ -242,12 +262,15 @@ class TestGlobusComputeProviderConfig:
         assert os.path.isfile(config_path)
         content = Path(config_path).read_text()
         assert "GlobusComputeEngine" in content
-        assert "display_name: E2E Test Endpoint" in content
         assert f"region: {aws_region}" in content
         assert "instance_type: t3.medium" in content
         # The IDs must survive into the config: an endpoint reconstructs the
         # provider from this file and would otherwise hit the #69 guard itself.
         assert network_ids["subnet_id"] in content
+
+        # display_name is the manager's, and lives in the other file.
+        manager = Path(ep_dir) / "config.yaml"
+        assert "display_name: E2E Test Endpoint" in manager.read_text()
 
     def test_generate_config_spot_mode(self, tmp_path, aws_region, network_ids):
         """Config for a spot-instance endpoint includes use_spot: true."""
@@ -282,6 +305,43 @@ class TestGlobusComputeProviderConfig:
         content = Path(config_path).read_text()
         assert "container_type: docker" in content
         assert "python:3.11-slim" in content
+
+    def test_manager_config_passes_the_start_gate(
+        self, tmp_path, aws_region, network_ids
+    ):
+        """The assertion whose absence let #196 ship.
+
+        Every other test here reads the generated *text*, which is exactly the blind
+        spot: the old single-file output was well-formed, internally consistent, and
+        rejected by ``start`` on the first thing it checks. ``start`` accepts a
+        ``ManagerEndpointConfig`` and nothing else, and ``load_config_yaml`` returns
+        that only when there is no top-level ``engine:`` key -- so asserting on the
+        class is asserting on startability.
+
+        Mirrors ``tests/unit/test_globus_config_loading.py``, which does the same
+        without needing real network IDs. Kept here too because this is the file that
+        claims to cover the endpoint lifecycle end to end.
+        """
+        from globus_compute_endpoint.endpoint.config import ManagerEndpointConfig
+        from globus_compute_endpoint.endpoint.config.utils import get_config
+
+        provider = _offline_provider(
+            tmp_path,
+            f"gc-gate-{uuid.uuid4().hex[:8]}",
+            network_ids,
+            region=aws_region,
+            image_id="ami-12345678",
+            display_name="Gate Endpoint",
+        )
+        ep_dir = tmp_path / "gate_ep"
+        provider.generate_endpoint_config(str(ep_dir))
+
+        config = get_config(ep_dir)
+
+        assert isinstance(config, ManagerEndpointConfig)
+        # No provider was constructed on the way here, which is why this test needs
+        # no AWS mocking: a rejected config can no longer leak an IAM pair.
+        assert getattr(config, "engine", None) is None
 
 
 # ---------------------------------------------------------------------------
@@ -502,6 +562,7 @@ class TestGlobusComputeEndpointLifecycle:
         assert endpoint_id, (
             f"Endpoint '{endpoint_name}' did not start or register within "
             f"{ENDPOINT_START_TIMEOUT_S}s"
+            + (f"\n{_last_start_failure}" if _last_start_failure else "")
         )
         logger.info("Endpoint started: id=%s", endpoint_id)
 

--- a/tests/unit/test_globus_compute_provider.py
+++ b/tests/unit/test_globus_compute_provider.py
@@ -1,13 +1,15 @@
 """Unit tests for GlobusComputeProvider.
 
 Verifies config generation for standard, spot, and container variants, the
-``parsl.providers`` registration and ``config.py`` shim that make a generated
-config loadable (#87), and the minimum_iam_policy() helper.
+``parsl.providers`` registration (#87) and the ``sitecustomize`` bootstrap that
+makes it reach the exec'd user-endpoint process (#196), and the
+minimum_iam_policy() helper.
 
 SPDX-License-Identifier: Apache-2.0
 SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
 """
 
+import ast
 import os
 import uuid
 from pathlib import Path
@@ -15,10 +17,11 @@ from unittest.mock import MagicMock, patch
 
 import parsl.providers
 import pytest
+import yaml
 
 from parsl_aws_provider import GlobusComputeProvider
 from parsl_aws_provider.globus_compute import (
-    _CONFIG_PY_SHIM,
+    _BOOTSTRAP_DIRNAME,
     _PROVIDER_TYPE,
     _register_with_parsl_providers,
 )
@@ -200,9 +203,17 @@ class TestGlobusComputeProviderConstruction:
 
 @pytest.mark.unit
 class TestGenerateEndpointConfig:
-    """Verify generate_endpoint_config() writes a correct config.yaml."""
+    """Verify generate_endpoint_config() writes a startable four-file layout.
 
-    def test_creates_directory_and_file(self, tmp_path):
+    Before #196 everything went into one ``config.yaml``, engine block included.
+    That single key is what ``load_config_yaml()`` classifies on: present means
+    ``UserEndpointConfig``, and ``start`` refuses anything that is not a
+    ``ManagerEndpointConfig``. So the output could never be started, and each
+    attempt to debug it leaked another IAM pair. The engine block now lives in
+    ``user_config_template.yaml.j2``, which is what these tests read.
+    """
+
+    def test_creates_directory_and_returns_the_template(self, tmp_path):
         provider = _make_provider(tmp_path)
         endpoint_dir = str(tmp_path / "my_endpoint")
 
@@ -210,50 +221,96 @@ class TestGenerateEndpointConfig:
 
         assert os.path.isdir(endpoint_dir)
         assert os.path.isfile(result_path)
-        assert result_path == str(tmp_path / "my_endpoint" / "config.yaml")
+        assert result_path == str(
+            tmp_path / "my_endpoint" / "user_config_template.yaml.j2"
+        )
 
     def test_returns_absolute_path(self, tmp_path):
         provider = _make_provider(tmp_path)
         result_path = provider.generate_endpoint_config(str(tmp_path / "ep"))
         assert os.path.isabs(result_path)
 
-    def test_config_contains_display_name(self, tmp_path):
+    def test_writes_all_four_files(self, tmp_path):
+        """Every one of them is load-bearing; a missing one is a broken endpoint."""
+        provider = _make_provider(tmp_path)
+        provider.generate_endpoint_config(str(tmp_path / "ep"))
+        ep = tmp_path / "ep"
+
+        assert (ep / "config.yaml").is_file()
+        assert (ep / "user_config_template.yaml.j2").is_file()
+        assert (ep / "user_environment.yaml").is_file()
+        assert (ep / _BOOTSTRAP_DIRNAME / "sitecustomize.py").is_file()
+
+    def test_manager_config_has_no_engine_key(self, tmp_path):
+        """The #196 blocker, asserted at its narrowest.
+
+        ``load_config_yaml`` does ``config_dict.pop("engine", None)`` and picks
+        ``ManagerEndpointConfig`` only when the result is ``None``. One key
+        decides whether the endpoint can start at all.
+        """
+        provider = _make_provider(tmp_path)
+        provider.generate_endpoint_config(str(tmp_path / "ep"))
+        loaded = yaml.safe_load((tmp_path / "ep" / "config.yaml").read_text())
+
+        assert "engine" not in loaded
+
+    def test_manager_config_omits_the_template_path(self, tmp_path):
+        """``user_config_template_path`` must not be emitted.
+
+        Its setter resolves the value against the *process* working directory and
+        raises ``ValueError`` if the result does not exist, so naming the file
+        relatively breaks ``start`` from anywhere but the endpoint directory.
+        Omitting it lets ``Endpoint.user_config_template_path()`` fall back to
+        ``endpoint_dir / "user_config_template.yaml.j2"`` -- the file we wrote.
+        """
+        provider = _make_provider(tmp_path)
+        provider.generate_endpoint_config(str(tmp_path / "ep"))
+        loaded = yaml.safe_load((tmp_path / "ep" / "config.yaml").read_text())
+
+        assert "user_config_template_path" not in loaded
+
+    def test_manager_config_contains_display_name(self, tmp_path):
         provider = _make_provider(tmp_path, display_name="Test Endpoint")
-        config_path = provider.generate_endpoint_config(str(tmp_path / "ep"))
-        content = Path(config_path).read_text()
+        provider.generate_endpoint_config(str(tmp_path / "ep"))
+        content = (tmp_path / "ep" / "config.yaml").read_text()
         assert "display_name: Test Endpoint" in content
 
-    def test_config_contains_engine_type(self, tmp_path):
+    def test_template_contains_engine_type(self, tmp_path):
         provider = _make_provider(tmp_path)
-        config_path = provider.generate_endpoint_config(str(tmp_path / "ep"))
-        content = Path(config_path).read_text()
+        content = Path(
+            provider.generate_endpoint_config(str(tmp_path / "ep"))
+        ).read_text()
         assert "type: GlobusComputeEngine" in content
 
-    def test_config_contains_provider_type(self, tmp_path):
+    def test_template_contains_provider_type(self, tmp_path):
         provider = _make_provider(tmp_path)
-        config_path = provider.generate_endpoint_config(str(tmp_path / "ep"))
-        content = Path(config_path).read_text()
+        content = Path(
+            provider.generate_endpoint_config(str(tmp_path / "ep"))
+        ).read_text()
         assert f"type: {_PROVIDER_TYPE}" in content
 
-    def test_config_contains_region(self, tmp_path):
+    def test_template_contains_region(self, tmp_path):
         provider = _make_provider(tmp_path)
-        config_path = provider.generate_endpoint_config(str(tmp_path / "ep"))
-        content = Path(config_path).read_text()
+        content = Path(
+            provider.generate_endpoint_config(str(tmp_path / "ep"))
+        ).read_text()
         assert "region: us-east-1" in content
 
-    def test_config_contains_instance_type(self, tmp_path):
+    def test_template_contains_instance_type(self, tmp_path):
         provider = _make_provider(tmp_path)
-        config_path = provider.generate_endpoint_config(str(tmp_path / "ep"))
-        content = Path(config_path).read_text()
+        content = Path(
+            provider.generate_endpoint_config(str(tmp_path / "ep"))
+        ).read_text()
         assert "instance_type: t3.micro" in content
 
-    def test_config_contains_mode(self, tmp_path):
+    def test_template_contains_mode(self, tmp_path):
         provider = _make_provider(tmp_path)
-        config_path = provider.generate_endpoint_config(str(tmp_path / "ep"))
-        content = Path(config_path).read_text()
+        content = Path(
+            provider.generate_endpoint_config(str(tmp_path / "ep"))
+        ).read_text()
         assert "mode: standard" in content
 
-    def test_config_encrypted_flag(self, tmp_path):
+    def test_template_encrypted_flag(self, tmp_path):
         """False by default, and reflects the constructor argument (#138).
 
         This asserted ``true`` while the value was hardcoded, which is how a
@@ -262,12 +319,12 @@ class TestGenerateEndpointConfig:
         ``FileNotFoundError`` before registering (#62).
         """
         provider = _make_provider(tmp_path)
-        config_path = provider.generate_endpoint_config(str(tmp_path / "ep"))
-        assert "encrypted: false" in Path(config_path).read_text()
+        path = provider.generate_endpoint_config(str(tmp_path / "ep"))
+        assert "encrypted: false" in Path(path).read_text()
 
         explicit = _make_provider(tmp_path, encrypted=True)
-        config_path = explicit.generate_endpoint_config(str(tmp_path / "ep2"))
-        assert "encrypted: true" in Path(config_path).read_text()
+        path = explicit.generate_endpoint_config(str(tmp_path / "ep2"))
+        assert "encrypted: true" in Path(path).read_text()
 
     def test_existing_directory_is_ok(self, tmp_path):
         """Calling generate_endpoint_config twice does not raise."""
@@ -277,21 +334,41 @@ class TestGenerateEndpointConfig:
         # Second call should overwrite without error
         provider.generate_endpoint_config(ep_dir)
 
-    def test_todo_placeholder_when_no_endpoint_id(self, tmp_path):
-        """When endpoint_id is None the config includes a TODO reminder."""
-        provider = _make_provider(tmp_path)
-        assert provider.endpoint_id is None
-        config_path = provider.generate_endpoint_config(str(tmp_path / "ep"))
-        content = Path(config_path).read_text()
-        assert "TODO" in content
+    def test_endpoint_id_is_never_a_top_level_config_key(self, tmp_path):
+        """``BaseConfig`` rejects ``endpoint_id`` -- it is not a Globus config field.
 
-    def test_endpoint_id_written_when_set(self, tmp_path):
+        It stays legal where it is emitted, nested under ``engine.provider``, because
+        there it binds to a ``GlobusComputeProvider`` kwarg. At the top level of
+        either file it would raise ``Unexpected keyword argument``, which is exactly
+        what the old output's ``TODO`` instructed the reader to do.
+        """
         ep_id = str(uuid.uuid4())
         provider = _make_provider(tmp_path, endpoint_id=ep_id)
-        config_path = provider.generate_endpoint_config(str(tmp_path / "ep"))
-        content = Path(config_path).read_text()
+        provider.generate_endpoint_config(str(tmp_path / "ep"))
+
+        for name in ("config.yaml", "user_config_template.yaml.j2"):
+            loaded = yaml.safe_load((tmp_path / "ep" / name).read_text())
+            assert "endpoint_id" not in loaded
+
+        template = yaml.safe_load(
+            (tmp_path / "ep" / "user_config_template.yaml.j2").read_text()
+        )
+        assert template["engine"]["provider"]["endpoint_id"] == ep_id
+
+    def test_endpoint_id_is_surfaced_as_a_start_flag(self, tmp_path):
+        """It is reachable by the manager too, via ``--endpoint-uuid``.
+
+        The manager writes the UUID to ``endpoint.json``; that flag is the only way
+        to supply a pre-existing one, so ``config.yaml`` says so rather than
+        pretending there is a key for it.
+        """
+        ep_id = str(uuid.uuid4())
+        provider = _make_provider(tmp_path, endpoint_id=ep_id)
+        provider.generate_endpoint_config(str(tmp_path / "ep"))
+        content = (tmp_path / "ep" / "config.yaml").read_text()
+
         assert ep_id in content
-        assert "TODO" not in content
+        assert "--endpoint-uuid" in content
 
     def test_network_ids_written(self, tmp_path):
         """The IDs #69 made required appear in the provider block.
@@ -307,37 +384,68 @@ class TestGenerateEndpointConfig:
         assert "subnet_id: subnet-test001" in content
         assert "security_group_id: sg-test00001" in content
 
-    def test_writes_config_py_shim(self, tmp_path):
-        """``config.py`` is written alongside ``config.yaml`` (#87)."""
-        provider = _make_provider(tmp_path)
-        provider.generate_endpoint_config(str(tmp_path / "ep"))
-        assert (tmp_path / "ep" / "config.py").is_file()
+    def test_bootstrap_imports_the_package(self, tmp_path):
+        """The whole purpose of the bootstrap is the registering import.
 
-    def test_shim_imports_the_package(self, tmp_path):
-        """The shim's whole purpose is the import that registers the class."""
-        provider = _make_provider(tmp_path)
-        provider.generate_endpoint_config(str(tmp_path / "ep"))
-        shim = (tmp_path / "ep" / "config.py").read_text()
-        assert "import parsl_aws_provider" in shim
-        assert "load_config_yaml" in shim
-
-    def test_shim_defines_module_level_config(self, tmp_path):
-        """``_load_config_py`` reads a module-level ``config``; compile the shim.
-
-        Compiling proves the generated file is syntactically valid without
-        executing it (execution would need globus-compute-endpoint installed).
+        The manager forks and ``execvpe``s a fresh interpreter for the user
+        endpoint, which reads its config from stdin -- so nothing in this package
+        is imported there and the bare ``GlobusComputeProvider`` name does not
+        resolve. ``sitecustomize`` runs during ``site`` initialisation, before any
+        user code, which is early enough.
         """
         provider = _make_provider(tmp_path)
         provider.generate_endpoint_config(str(tmp_path / "ep"))
-        shim_path = tmp_path / "ep" / "config.py"
-        compile(shim_path.read_text(), str(shim_path), "exec")
-        assert "\nconfig = " in _CONFIG_PY_SHIM
+        bootstrap = tmp_path / "ep" / _BOOTSTRAP_DIRNAME / "sitecustomize.py"
 
-    def test_returned_path_is_the_yaml_not_the_shim(self, tmp_path):
-        """The return value stays the file a caller would edit."""
+        assert "import parsl_aws_provider" in bootstrap.read_text()
+        compile(bootstrap.read_text(), str(bootstrap), "exec")
+
+    def test_bootstrap_does_not_re_raise(self, tmp_path):
+        """A missing package must not break every interpreter on the PYTHONPATH.
+
+        ``sitecustomize`` is imported by *any* process that inherits the path.
+        Raising there would take out unrelated commands; the endpoint failing
+        with "not a valid provider" is the narrower blast radius.
+        """
         provider = _make_provider(tmp_path)
-        result = provider.generate_endpoint_config(str(tmp_path / "ep"))
-        assert result.endswith("config.yaml")
+        provider.generate_endpoint_config(str(tmp_path / "ep"))
+        source = (tmp_path / "ep" / _BOOTSTRAP_DIRNAME / "sitecustomize.py").read_text()
+
+        # Parsed rather than grepped: the file's own comment says "re-raised".
+        tree = ast.parse(source)
+        assert not [n for n in ast.walk(tree) if isinstance(n, ast.Raise)]
+        assert "file=sys.stderr" in source
+
+    def test_user_environment_points_at_the_bootstrap(self, tmp_path):
+        """The only seam into the exec'd child is ``user_environment.yaml``.
+
+        The manager reads it and merges it into ``env`` immediately before
+        ``os.execvpe``. The path must be absolute: the child's working directory
+        is not the endpoint directory.
+        """
+        provider = _make_provider(tmp_path)
+        provider.generate_endpoint_config(str(tmp_path / "ep"))
+        loaded = yaml.safe_load((tmp_path / "ep" / "user_environment.yaml").read_text())
+
+        expected = tmp_path.resolve() / "ep" / _BOOTSTRAP_DIRNAME
+        assert loaded["PYTHONPATH"] == str(expected)
+        assert os.path.isabs(loaded["PYTHONPATH"])
+
+    def test_a_stale_config_py_is_removed(self, tmp_path):
+        """``get_config`` prefers ``config.py``, so leaving one keeps the bug.
+
+        Anyone regenerating a directory built before #196 would otherwise get the
+        fix on disk and the old unstartable shape at load time.
+        """
+        ep = tmp_path / "ep"
+        ep.mkdir()
+        stale = ep / "config.py"
+        stale.write_text("config = None\n")
+
+        provider = _make_provider(tmp_path)
+        provider.generate_endpoint_config(str(ep))
+
+        assert not stale.exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_globus_config_loading.py
+++ b/tests/unit/test_globus_config_loading.py
@@ -181,6 +181,13 @@ def _load_in_child(endpoint_dir: Path, *, with_bootstrap: bool = True) -> dict:
         [sys.executable, "-c", _CHILD_LOADER],
         input=_render(endpoint_dir),
         env=env,
+        # The child really constructs the provider, and `state_file_path` defaults
+        # to a *relative* `ephemeral_aws_state.json`, so without this the state
+        # document lands in whatever cwd the test runner happened to have -- the
+        # checkout -- which `_no_default_state_file_left_behind` fails on. It is
+        # also the truer shape: the endpoint manager's exec'd child inherits the
+        # manager's working directory, never this repository.
+        cwd=str(endpoint_dir.parent),
         capture_output=True,
         text=True,
         timeout=180,

--- a/tests/unit/test_globus_config_loading.py
+++ b/tests/unit/test_globus_config_loading.py
@@ -1,11 +1,24 @@
-"""Regression test for #87: a generated endpoint config must actually load.
+"""Regression tests for #87 and #196: a generated config must actually start.
 
 Every other test in `test_globus_compute_provider.py` asserts on the *text* of
-the generated files, which is exactly the blind spot that let #87 ship: the old
-`config.yaml` was well-formed, internally consistent, and unloadable. The only
-assertion that would have caught it is the one made here -- hand the generated
-directory to `globus_compute_endpoint`'s own `get_config()` and see what comes
-back.
+the generated files, which is exactly the blind spot that let both issues ship:
+the old `config.yaml` was well-formed, internally consistent, loadable -- and
+unstartable. The only assertions that catch that are the ones made here: hand the
+generated directory to `globus_compute_endpoint`'s own loader and check the
+*class* that comes back, then follow the second half of the path the daemon
+actually takes.
+
+That path has two stages, and a test that stops after the first proves nothing:
+
+1. `get_config(endpoint_dir)` reads `config.yaml`. `start` accepts the result only
+   if it is a `ManagerEndpointConfig`, which `load_config_yaml` returns only when
+   there is no top-level `engine:` key. That is #196.
+2. The manager renders `user_config_template.yaml.j2`, forks, and `execvpe`s a
+   *fresh interpreter* that reads the rendered config from stdin. Nothing in that
+   child ever imports this package, so `getattr(parsl.providers, ...)` fails
+   there even though it succeeds in-process. The `sitecustomize` bootstrap on
+   `PYTHONPATH` is what fixes it, and only a subprocess can test it -- this
+   process has already imported the package.
 
 These tests are skipped when `globus-compute-endpoint` is not installed
 (`uv sync --extra globus`), so they do not gate a default `uv sync` run. They
@@ -16,20 +29,36 @@ SPDX-License-Identifier: Apache-2.0
 SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
 """
 
+import os
+import pwd
+import subprocess
+import sys
 import uuid
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+import yaml
 
 from parsl_aws_provider import GlobusComputeProvider
 from parsl_aws_provider.provider import EphemeralAWSProvider
 from parsl_aws_provider.state.file import FileStateStore
 
-get_config = pytest.importorskip(
+_config_utils = pytest.importorskip(
     "globus_compute_endpoint.endpoint.config.utils",
     reason="globus-compute-endpoint not installed (uv sync --extra globus)",
-).get_config
+)
+get_config = _config_utils.get_config
+load_user_config_template = _config_utils.load_user_config_template
+render_config_user_template = _config_utils.render_config_user_template
+
+from globus_compute_endpoint.endpoint.config import (  # noqa: E402
+    ManagerEndpointConfig,
+    UserEndpointConfig,
+)
+from globus_compute_endpoint.endpoint.identity_mapper import (  # noqa: E402
+    MappedPosixIdentity,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -37,6 +66,32 @@ pytestmark = pytest.mark.unit
 VPC_ID = "vpc-0123456789abcdef0"
 SUBNET_ID = "subnet-0123456789abcdef0"
 SG_ID = "sg-0123456789abcdef0"
+
+# Run in the exec'd child. Deliberately never names `parsl_aws_provider`:
+# `patch("parsl_aws_provider.provider.create_session")` would *import* the
+# package by name, which is the very thing the negative control has to rule out.
+# Patching botocore instead keeps the AWS calls in the constructor mocked without
+# touching the import under test.
+_CHILD_LOADER = r"""
+import json, sys
+from unittest.mock import MagicMock, patch
+from globus_compute_endpoint.endpoint.config.utils import load_config_yaml
+
+out = {"sitecustomize_ran": "sitecustomize" in sys.modules,
+       "package_imported": "parsl_aws_provider" in sys.modules}
+with patch("boto3.Session", MagicMock()), patch("botocore.session.Session", MagicMock()):
+    try:
+        cfg = load_config_yaml(sys.stdin.read())
+    except Exception as exc:
+        out["error"] = f"{type(exc).__name__}: {exc}"
+    else:
+        out["config_class"] = type(cfg).__name__
+        out["provider_class"] = type(cfg.engine.provider).__name__
+        out["region"] = cfg.engine.provider.region
+        out["encrypted"] = cfg.engine.encrypted
+        cfg.engine.shutdown()
+print("RESULT " + json.dumps(out))
+"""
 
 
 def _make_provider(tmp_path, **extra_kwargs) -> GlobusComputeProvider:
@@ -76,16 +131,82 @@ def _make_provider(tmp_path, **extra_kwargs) -> GlobusComputeProvider:
         )
 
 
-def _load(endpoint_dir: Path):
-    """Load a generated endpoint directory through Globus Compute's own loader.
+def _load_manager(endpoint_dir: Path) -> ManagerEndpointConfig:
+    """Load `config.yaml` the way `start` does, via Globus Compute's loader.
 
-    The loader really does construct the provider named in the YAML, so the AWS
-    session has to be mocked for the duration -- `EphemeralAWSProvider.__init__`
-    calls `GetCallerIdentity`, which fails against the synthetic credentials the
-    non-`aws` suites run under. Everything under test happens before that point:
-    the dispatcher's `getattr(parsl.providers, ...)` lookup, the YAML parse, and
-    the binding of the YAML keys to constructor kwargs.
+    No AWS mocking is needed and none is done, which is itself the point: since
+    #196 moved the `engine:` block out of this file, loading it constructs no
+    provider and so reaches no AWS API. Before the fix, every rejected load
+    created an IAM role and instance profile on the way to failing.
     """
+    return get_config(endpoint_dir)
+
+
+def _render(endpoint_dir: Path) -> str:
+    """Render `user_config_template.yaml.j2` as the endpoint manager would."""
+    template_path = endpoint_dir / "user_config_template.yaml.j2"
+    return render_config_user_template(
+        parent_config=_load_manager(endpoint_dir),
+        user_config_template=load_user_config_template(template_path),
+        user_config_template_path=template_path,
+        mapped_identity=MappedPosixIdentity(
+            local_user_record=pwd.getpwuid(os.getuid()),
+            matched_identity=uuid.UUID(int=0),
+            globus_identity_candidates=[],
+        ),
+    )
+
+
+def _load_in_child(endpoint_dir: Path, *, with_bootstrap: bool = True) -> dict:
+    """Load the rendered template in a fresh interpreter, as the manager does.
+
+    `endpoint_manager` forks and `execvpe`s `globus-compute-endpoint
+    _start-user-endpoint`, which reads its config from stdin; the only seam into
+    that child's environment is `user_environment.yaml`, which the manager merges
+    into `env` immediately before the exec. This reproduces that shape exactly.
+
+    A subprocess is not incidental here. This process imported
+    `parsl_aws_provider` at module scope, so `parsl.providers` already carries the
+    class and any in-process assertion is answering the wrong question.
+    """
+    env = dict(os.environ)
+    env.pop("AWS_PROFILE", None)  # the child must not resolve a named profile
+    if with_bootstrap:
+        data = yaml.safe_load((endpoint_dir / "user_environment.yaml").read_text())
+        env.update({k: str(v) for k, v in (data or {}).items()})
+    else:
+        env.pop("PYTHONPATH", None)
+
+    completed = subprocess.run(
+        [sys.executable, "-c", _CHILD_LOADER],
+        input=_render(endpoint_dir),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    for line in completed.stdout.splitlines():
+        if line.startswith("RESULT "):
+            import json
+
+            return json.loads(line[len("RESULT ") :])
+    raise AssertionError(
+        f"child produced no result\nstdout:\n{completed.stdout}\n"
+        f"stderr:\n{completed.stderr[-2000:]}"
+    )
+
+
+def _load(endpoint_dir: Path):
+    """Load the rendered user config in-process, for parameter round-tripping.
+
+    The provider really is constructed, so the AWS session has to be mocked --
+    `EphemeralAWSProvider.__init__` calls `GetCallerIdentity`, which fails against
+    the synthetic credentials the non-`aws` suites run under. Everything the
+    parameter tests care about happens before that: the dispatcher's
+    `getattr(parsl.providers, ...)` lookup, the YAML parse, and the binding of the
+    YAML keys to constructor kwargs.
+    """
+    rendered = _render(endpoint_dir)
     with (
         patch("parsl_aws_provider.provider.create_session") as mock_session,
         patch.object(
@@ -95,7 +216,7 @@ def _load(endpoint_dir: Path):
         ),
     ):
         mock_session.return_value = MagicMock()
-        config = get_config(endpoint_dir)
+        config = _config_utils.load_config_yaml(rendered)
 
     # An engine holds a live ZMQ-bound HighThroughputEngine; shut it down so the
     # test does not leak sockets or a process into the rest of the session.
@@ -105,8 +226,125 @@ def _load(endpoint_dir: Path):
     return config
 
 
+class TestManagerConfigIsStartable:
+    """#196: `start` accepts one class, and the old output was the other one.
+
+    `load_config_yaml` pops `engine` and returns `ManagerEndpointConfig` when it is
+    absent, `UserEndpointConfig` when present. `_start_endpoint_manager` then
+    refuses anything that is not the former, and `start` routes there
+    unconditionally. So the whole blocker reduces to which class comes back --
+    which is what these assert, rather than the text that produced it.
+    """
+
+    def test_manager_config_is_the_class_start_accepts(self, tmp_path):
+        provider = _make_provider(tmp_path)
+        provider.generate_endpoint_config(str(tmp_path / "ep"))
+
+        config = _load_manager(tmp_path / "ep")
+
+        assert isinstance(config, ManagerEndpointConfig)
+        assert not isinstance(config, UserEndpointConfig)
+
+    def test_display_name_survives_to_the_manager(self, tmp_path):
+        """The one value the manager config carries has to arrive."""
+        provider = _make_provider(tmp_path, display_name="Manager Named")
+        provider.generate_endpoint_config(str(tmp_path / "ep"))
+
+        assert _load_manager(tmp_path / "ep").display_name == "Manager Named"
+
+    def test_template_path_resolves_from_a_foreign_cwd(self, tmp_path, monkeypatch):
+        """Why `user_config_template_path` is deliberately not emitted.
+
+        Its setter resolves the value against the process working directory and
+        raises if the result does not exist, so emitting a relative path makes
+        `start` work from the endpoint directory and fail from anywhere else.
+        Omitting it lets `Endpoint.user_config_template_path()` derive the path
+        from the endpoint directory, which is correct from any cwd.
+        """
+        provider = _make_provider(tmp_path)
+        provider.generate_endpoint_config(str(tmp_path / "ep"))
+
+        monkeypatch.chdir(tmp_path.parent)
+        config = _load_manager(tmp_path / "ep")
+
+        assert config.user_config_template_path is None
+
+    def test_loading_the_manager_config_creates_no_provider(self, tmp_path):
+        """The IAM leak, fixed structurally rather than by better teardown.
+
+        Before #196 the `engine:` block sat in `config.yaml`, so *every* load --
+        including the ones that went on to be rejected -- constructed a provider,
+        and `EphemeralAWSProvider.__init__` calls `initialize()`, which creates an
+        IAM role and instance profile. A rejected config now creates nothing
+        because nothing is constructed: note that this test mocks no AWS at all
+        and still passes.
+        """
+        provider = _make_provider(tmp_path)
+        provider.generate_endpoint_config(str(tmp_path / "ep"))
+
+        config = _load_manager(tmp_path / "ep")
+
+        assert getattr(config, "engine", None) is None
+
+
+class TestUserEndpointLoadsInAForkedInterpreter:
+    """The second half of #196: the fix must reach the process that execs.
+
+    Moving the engine block to the template is only half a fix. The template is
+    loaded by a fresh interpreter that reads its config from stdin, so the
+    `config.py` shim -- which only `get_config()` honours -- can never run there.
+    Without the `sitecustomize` bootstrap this change would push every endpoint
+    into the #133 failure instead of the #196 one.
+    """
+
+    def test_rendered_template_loads_in_the_child(self, tmp_path):
+        provider = _make_provider(tmp_path)
+        provider.generate_endpoint_config(str(tmp_path / "ep"))
+
+        result = _load_in_child(tmp_path / "ep")
+
+        assert "error" not in result, result.get("error")
+        assert result["config_class"] == "UserEndpointConfig"
+        assert result["provider_class"] == "GlobusComputeProvider"
+        assert result["region"] == "us-east-1"
+        assert result["encrypted"] is False
+
+    def test_the_package_is_imported_before_any_user_code(self, tmp_path):
+        """`sitecustomize` runs during `site` initialisation, which is why this works.
+
+        A later hook would be too late: the dispatcher's `getattr` happens while
+        the config is being parsed, before anything the endpoint owner controls.
+        """
+        provider = _make_provider(tmp_path)
+        provider.generate_endpoint_config(str(tmp_path / "ep"))
+
+        result = _load_in_child(tmp_path / "ep")
+
+        assert result["sitecustomize_ran"] is True
+        assert result["package_imported"] is True
+
+    def test_without_the_bootstrap_the_child_cannot_resolve_the_provider(
+        self, tmp_path
+    ):
+        """Negative control: the bootstrap is load-bearing, not incidental.
+
+        This is the #133 failure, and it is what the generated output would hit if
+        `user_environment.yaml` were dropped as an implementation detail.
+        `ProviderDispatcher` does `getattr(parsl.providers, type_name, None)` and
+        `parsl.providers` has no module `__getattr__`, so a name nothing
+        registered simply is not there.
+        """
+        provider = _make_provider(tmp_path)
+        provider.generate_endpoint_config(str(tmp_path / "ep"))
+
+        result = _load_in_child(tmp_path / "ep", with_bootstrap=False)
+
+        assert result["package_imported"] is False
+        assert "not a valid provider" in result.get("error", "")
+
+
 class TestGeneratedConfigLoads:
-    """The generated pair loads, and the provider is the class we registered."""
+    """The rendered template loads, and the provider is the class we registered."""
 
     def test_config_loads(self, tmp_path):
         provider = _make_provider(tmp_path, endpoint_id=str(uuid.uuid4()))
@@ -138,76 +376,13 @@ class TestGeneratedConfigLoads:
         )
         provider.generate_endpoint_config(str(tmp_path / "ep"))
 
-        config = _load(tmp_path / "ep")
+        assert _load_manager(tmp_path / "ep").display_name == "Round Trip Endpoint"
 
-        assert config.display_name == "Round Trip Endpoint"
-        assert config.engine.provider.region == "us-east-1"
-        assert config.engine.provider.instance_type == "t3.micro"
-        assert config.engine.provider.max_blocks == 7
-        assert config.engine.provider.use_spot is True
-
-    def test_yaml_alone_does_not_load(self, tmp_path):
-        """Negative control: without the shim the load fails as it did in #87.
-
-        This is what makes the passing tests above meaningful -- it shows the
-        shim is load-bearing and not incidental. `get_config()` prefers
-        `config.py`, so deleting it falls back to the bare `config.yaml`, which
-        is the pre-fix state: nothing has imported this package, so
-        `getattr(parsl.providers, "GlobusComputeProvider", None)` is None.
-        """
-        import parsl.providers
-
-        provider = _make_provider(tmp_path)
-        provider.generate_endpoint_config(str(tmp_path / "ep"))
-        (tmp_path / "ep" / "config.py").unlink()
-
-        # Un-register for the duration: this process has already imported the
-        # package, whereas the endpoint daemon never does.
-        delattr(parsl.providers, "GlobusComputeProvider")
-        try:
-            with pytest.raises(Exception, match="not a valid provider"):
-                _load(tmp_path / "ep")
-        finally:
-            from parsl_aws_provider.globus_compute import (
-                _register_with_parsl_providers,
-            )
-
-            _register_with_parsl_providers()
-
-
-class TestMultiUserLimitation:
-    """Pin the known #133 gap so a future change to it is a deliberate one.
-
-    Multi-user endpoints render `user_config_template.yaml.j2` to a string and
-    call `load_config_yaml()` on it in a forked process -- `get_config()` is
-    never reached, so the `config.py` shim does not apply. This test asserts the
-    *mechanism*, not the failure: if upstream adds dotted-path resolution, or we
-    ship a `.pth`, this is the test that should start failing and be rewritten.
-    """
-
-    def test_load_config_yaml_needs_prior_registration(self, tmp_path):
-        import parsl.providers
-        from globus_compute_endpoint.endpoint.config.utils import load_config_yaml
-
-        from parsl_aws_provider.globus_compute import _register_with_parsl_providers
-
-        rendered = (
-            "engine:\n"
-            "  type: GlobusComputeEngine\n"
-            "  provider:\n"
-            "    type: GlobusComputeProvider\n"
-            "    region: us-east-1\n"
-            f"    vpc_id: {VPC_ID}\n"
-            f"    subnet_id: {SUBNET_ID}\n"
-            f"    security_group_id: {SG_ID}\n"
-        )
-
-        delattr(parsl.providers, "GlobusComputeProvider")
-        try:
-            with pytest.raises(Exception, match="not a valid provider"):
-                load_config_yaml(rendered)
-        finally:
-            _register_with_parsl_providers()
+        engine = _load(tmp_path / "ep").engine
+        assert engine.provider.region == "us-east-1"
+        assert engine.provider.instance_type == "t3.micro"
+        assert engine.provider.max_blocks == 7
+        assert engine.provider.use_spot is True
 
 
 class TestEveryParameterSurvivesTheRoundTrip:
@@ -335,27 +510,50 @@ class TestEveryParameterSurvivesTheRoundTrip:
         """The four `GlobusComputeProvider` params, which the signature loop misses.
 
         `_provider_params_yaml` walks `EphemeralAWSProvider.__init__`, so these
-        need naming individually -- and they land in three different places:
-        `display_name` at the top level, `encrypted` and `container_uri` on the
-        engine, `endpoint_id` and `container_image` on the provider. Asserting
-        after a real load is what proves each one reached a key its consumer
-        actually reads.
+        need naming individually -- and since #196 they land in three different
+        places across *two* files: `display_name` in the manager `config.yaml`,
+        `encrypted` and `container_uri` on the engine in the template, and
+        `container_image` on the provider. Asserting after a real load is what
+        proves each one reached a key its consumer actually reads.
+
+        `endpoint_id` is the exception and is checked separately below: it is not a
+        config key in any file, because `BaseConfig` rejects it.
         """
-        endpoint_id = str(uuid.uuid4())
         provider = _make_provider(
             tmp_path,
-            endpoint_id=endpoint_id,
+            endpoint_id=str(uuid.uuid4()),
             container_image="python:3.11-slim",
             display_name="Subclass Params",
         )
         provider.generate_endpoint_config(str(tmp_path / "ep"))
 
-        config = _load(tmp_path / "ep")
+        assert _load_manager(tmp_path / "ep").display_name == "Subclass Params"
 
-        assert config.display_name == "Subclass Params"
-        assert config.engine.container_uri == "python:3.11-slim"
-        assert config.engine.provider.endpoint_id == endpoint_id
-        assert config.engine.provider.container_image == "python:3.11-slim"
+        engine = _load(tmp_path / "ep").engine
+        assert engine.container_uri == "python:3.11-slim"
+        assert engine.provider.container_image == "python:3.11-slim"
+
+    def test_endpoint_id_reaches_the_provider_but_not_the_manager(self, tmp_path):
+        """Both halves, each asserted after a real load.
+
+        Nested under `engine.provider` it binds to a `GlobusComputeProvider` kwarg
+        and survives. At the top level of `config.yaml` it would raise `Unexpected
+        keyword argument` from `BaseConfig` -- which is what the old output's `TODO`
+        told the reader to do. The manager writes the real UUID to `endpoint.json`;
+        the way to supply one is `start --endpoint-uuid`.
+        """
+        endpoint_id = str(uuid.uuid4())
+        provider = _make_provider(tmp_path, endpoint_id=endpoint_id)
+        provider.generate_endpoint_config(str(tmp_path / "ep"))
+
+        assert _load(tmp_path / "ep").engine.provider.endpoint_id == endpoint_id
+
+        # Reachable in the manager config as guidance, not as a key -- so the load
+        # that would have failed succeeds.
+        manager_text = (tmp_path / "ep" / "config.yaml").read_text()
+        assert endpoint_id in manager_text
+        assert "endpoint_id" not in yaml.safe_load(manager_text)
+        assert isinstance(_load_manager(tmp_path / "ep"), ManagerEndpointConfig)
 
     def test_resolved_ami_is_not_pinned_into_the_config(self, tmp_path):
         """The emitter keys on what the caller passed, not on what differs.
@@ -393,7 +591,7 @@ class TestEveryParameterSurvivesTheRoundTrip:
                 security_group_id=SG_ID,
             )
 
-        assert "image_id" not in provider._build_config_yaml()
+        assert "image_id" not in provider._build_user_config_template()
 
     def test_explicit_image_id_is_emitted(self, tmp_path):
         """The other half: an AMI the caller chose must survive.
@@ -462,7 +660,7 @@ class TestEveryParameterSurvivesTheRoundTrip:
             "use_spot": True,
         }
         provider = _make_provider(tmp_path, **sample)
-        yaml_text = provider._build_config_yaml()
+        yaml_text = provider._build_user_config_template()
 
         missing = [
             name
@@ -476,4 +674,4 @@ class TestEveryParameterSurvivesTheRoundTrip:
         one_shot = _make_provider(
             tmp_path, one_shot=True, auto_create_instance_profile=True
         )
-        assert "    one_shot:" in one_shot._build_config_yaml()
+        assert "    one_shot:" in one_shot._build_user_config_template()

--- a/tests/unit/test_instance_profile.py
+++ b/tests/unit/test_instance_profile.py
@@ -16,6 +16,7 @@ import pytest
 from botocore.exceptions import ClientError
 from moto import mock_aws
 
+from parsl_aws_provider.exceptions import ResourceNotFoundError
 from parsl_aws_provider.modes.standard import StandardMode
 from parsl_aws_provider.utils.aws import (
     _wait_for_instance_profile,
@@ -621,3 +622,43 @@ class TestStandardModeProfileOwnership:
 
         # And the ARN is dropped either way: it no longer names anything usable.
         assert mode.iam_instance_profile_arn is None
+
+    def test_a_failed_verification_still_deletes_the_pair(
+        self, mock_session, mock_state_store
+    ):
+        """The remaining leak after #132: initialize() failing before its own teardown.
+
+        ``_resolve_instance_profile`` creates the pair; ``_verify_resources`` runs
+        next and raises on a network ID that does not resolve. Both used to sit
+        *above* the try/except that calls ``cleanup_infrastructure``, so a mistyped
+        subnet ID -- an ordinary typo, and one you make repeatedly while debugging
+        -- leaked a role and a profile on every attempt. #196 hit this from the
+        Globus side, where each rejected config load was another pair.
+        """
+        ec2 = MagicMock()
+        mock_session.client.return_value = ec2
+        ec2.describe_subnets.side_effect = ClientError(
+            {"Error": {"Code": "InvalidSubnetID.NotFound", "Message": "nope"}},
+            "DescribeSubnets",
+        )
+
+        mode = self._mode(
+            mock_session,
+            mock_state_store,
+            one_shot=True,
+            auto_create_instance_profile=True,
+        )
+
+        with (
+            patch(
+                "parsl_aws_provider.modes.standard.get_or_create_ssm_instance_profile",
+                return_value="arn:aws:iam::1:instance-profile/auto",
+            ),
+            patch(
+                "parsl_aws_provider.modes.standard.delete_ssm_instance_profile"
+            ) as delete,
+            pytest.raises(ResourceNotFoundError, match="subnet-12345"),
+        ):
+            mode.initialize()
+
+        delete.assert_called_once_with(mock_session, "test-provider")


### PR DESCRIPTION
Closes #196.

## The blocker

`globus-compute-endpoint` classifies a config by the presence of **one key**.
`load_config_yaml()` does `config_dict.pop("engine", None)` and returns
`ManagerEndpointConfig` when it is absent, `UserEndpointConfig` when present.
`cli.py:899-904` then refuses to start anything that is not the former:

```python
if not isinstance(ep_config, ManagerEndpointConfig):
    raise ClickException(
        f"Configuration for endpoint {ep_dir.name} contains an `engine` field;"
        " endpoint will not start. (Hint: move the `engine` block to"
        " `user_config_template.yaml.j2`)"
    )
```

`generate_endpoint_config()` wrote `engine:` into `config.yaml`, so **every
endpoint this provider has ever generated hit that gate**. There was no partial
success mode: the endpoint never started.

## What changed

`generate_endpoint_config()` now writes four files instead of two, and returns
the **template** path rather than the YAML, because the template is the file an
operator edits:

| File | Holds |
|---|---|
| `config.yaml` | `display_name`, and nothing else |
| `user_config_template.yaml.j2` | the `engine:` block, including `engine.provider` |
| `user_environment.yaml` | `PYTHONPATH` pointing at `_bootstrap/` |
| `_bootstrap/sitecustomize.py` | `import parsl_aws_provider` |

Any stale `config.py` in the target directory is **removed** — Globus Compute
would otherwise still load it and reintroduce the old behaviour. Regenerating an
existing endpoint directory is therefore safe and is the required upgrade step.

Three details that are load-bearing:

- **`user_config_template_path` is deliberately omitted from `config.yaml`.** Its
  setter resolves relative paths against the *process* working directory and
  raises if the file is missing, so writing it would make the endpoint startable
  only from the directory it was generated in. Omitting it takes
  `Endpoint.user_config_template_path()`'s `endpoint_dir / "user_config_template.yaml.j2"`
  fallback, which is correct from any cwd. `test_template_path_resolves_from_a_foreign_cwd`
  pins that.
- **`endpoint_id` stays nested under `engine.provider`**, where it is a genuine
  `GlobusComputeProvider` kwarg. At the top level of *either* file `BaseConfig`
  raises `Unexpected keyword argument`. There is no `register` subcommand: the
  manager writes the real UUID to `endpoint.json`, and a pre-existing one is
  supplied via `start --endpoint-uuid`. The docs now say so.
- **The `engine:` move fixes the IAM leak structurally.** Loading the manager
  config constructs no provider at all, so a config the endpoint is about to
  reject cannot reach AWS. `test_loading_the_manager_config_creates_no_provider`
  mocks **no AWS whatsoever** and passes — that is the assertion form of the
  claim, and it would fail loudly if the engine block ever drifted back.

## Part 2 is mandatory, not a nice-to-have

The shape fix alone would have pushed every endpoint into #133. A multi-user
endpoint **forks and `execvpe`s a fresh interpreter** that reads its config from
**stdin as JSON**, so the old `config.py` shim — honoured only by `get_config()`
— can never run there, and Globus Compute's attribute lookup on `parsl.providers`
fails on a class nothing registered.

`user_environment.yaml` is the only seam: the manager merges it into `env`
immediately before the exec. A `PYTHONPATH` entry holding `sitecustomize.py` gets
`import parsl_aws_provider` executed during `site` initialisation, before any
config is parsed. It swallows its own `ImportError` after writing a diagnostic to
stderr, because raising there would break every interpreter the endpoint starts —
`test_bootstrap_does_not_re_raise` asserts that by parsing for `ast.Raise` nodes
rather than grepping, since the file's own comment contains the word "re-raised".

`TestUserEndpointLoadsInAForkedInterpreter` runs the real
`render_config_user_template` → real `execvpe` → real `load_config_yaml` path in a
child interpreter and asserts the provider class resolves. Its negative control
(`test_without_the_bootstrap_the_child_cannot_resolve_the_provider`) is
**mutation-tested**: forcing `with_bootstrap = True` inside `_load_in_child` makes
it FAIL, so it discriminates rather than passing vacuously. The child loader
deliberately never names `parsl_aws_provider` — `patch("parsl_aws_provider.provider...")`
would *import the package by name*, contaminating the very thing the control has
to rule out — so it patches `boto3.Session` / `botocore.session.Session` instead.

## The IAM leak

`StandardMode.initialize()` created the instance profile and verified the network
**outside any teardown**: the `try` that calls `cleanup_infrastructure()` began
*below* both. Any failure in between left the role and instance profile standing
with nothing tracking them — the #132 pathology, reachable on nothing more exotic
than a mistyped subnet ID. #196 found it from the Globus side, where a config load
that ends in an error message is the normal debugging loop, so every attempt
leaked another privileged principal with `AmazonSSMManagedInstanceCore` attached.

The boundary now opens above `_resolve_instance_profile()`. It **re-raises
unchanged** rather than wrapping in `ResourceCreationError`, because #77's
contract requires a bad network ID to surface as `ResourceNotFoundError` naming
the ID, and an unrelated `ClientError` (e.g. `RequestLimitExceeded`) to propagate
untouched. My first attempt used one `try` and broke 6 existing tests for exactly
that reason; the fix is two blocks. `test_a_failed_verification_still_deletes_the_pair`
pins the new behaviour.

## Two claims in #196 that do not hold

Recording these so the issue history is accurate — neither changes the fix:

1. **`tests/aws/test_globus_compute_e2e.py` does exist** (613 lines, 10 tests,
   added in `761051a`). The reason it never caught the blocker is that
   `_start_endpoint()` only *logged* a failed `globus-compute-endpoint start` and
   returned `None`, so the caller's bare "did not start or register" assertion read
   like a timeout rather than a rejected config. It now records the exit code plus
   stdout/stderr into `_last_start_failure` and appends that to the assertion
   message. New `test_manager_config_passes_the_start_gate` calls the real
   `get_config(ep_dir)` and asserts `isinstance(config, ManagerEndpointConfig)`.
2. **The `cli.py:899` gate is in `_start_endpoint_manager`**, not a generic start
   path — but `start_endpoint` routes there unconditionally in 4.15.0, so the
   conclusion is unchanged.

## Platform note

Generation works anywhere. **`start` is Linux-only**: `pyprctl` ships no macOS
wheel, so `start` fails earlier and for an unrelated reason there. Documented as a
known limitation rather than worked around.

## Verification

```
uv run pytest tests/unit tests/security --no-cov -q   # 1226 passed, 2 skipped (baseline 1215/2, net +11)
uv run ruff check parsl_aws_provider tests            # All checks passed
uv run ruff format --check parsl_aws_provider tests   # 114 files already formatted
uv run mypy parsl_aws_provider                        # 76 errors == baseline, none new
uv run pytest tests/aws/test_globus_compute_e2e.py --collect-only   # 11 tests
```

`tests/aws/` needs real credentials and is not run here; the E2E additions are
collection-verified only.

Docs: `docs/globus_compute.md` gains the four-file table, "Why the split" / "Why
the bootstrap" sections, the corrected step 2/3 walkthrough, the Linux-only note,
and a troubleshooting entry headed with the **verbatim** upstream error string so
it is greppable. `README.md`'s Globus section now names both traps.
