### PR TITLE
build(deps): sweep the three uv bumps, and fix the build floor they exposed

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -55,8 +55,9 @@ Add any other context about the problem here. This might include:
 If possible, please provide debugging output by setting:
 ```python
 import logging
+
 logging.basicConfig(level=logging.DEBUG)
-logging.getLogger('parsl_aws_provider').setLevel(logging.DEBUG)
+logging.getLogger("parsl_aws_provider").setLevel(logging.DEBUG)
 ```
 
 **Screenshots**

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,12 +18,16 @@ repos:
     -   id: mixed-line-ending
         args: ['--fix=lf']
 
-# Pinned to the same ruff that uv.lock resolves (0.15.4) and CI runs. At v0.2.2
+# Pinned to the same ruff that uv.lock resolves (0.16.1) and CI runs. At v0.2.2
 # the hook and `uv run ruff` disagreed on comprehension-conditional
 # parenthesization, so a pre-commit pass and a CI format check could each demand
-# the other's output be undone.
+# the other's output be undone. 0.16.0 makes that hazard sharper, not milder: it
+# stabilised Markdown formatting, which 0.15.4 refused without preview mode, so a
+# hook and a CI check on different sides of that line disagree about every fenced
+# Python block in the docs. Bump this rev and the `ruff` floor in pyproject.toml
+# together, never one alone.
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.4
+    rev: v0.16.1
     hooks:
     -   id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,6 +1,19 @@
 # Ruff configuration for Parsl AWS Provider
 
 [lint]
+# Explicit because ruff 0.16.0 changed the *implicit* default from 59 rules to
+# 413, which is a breaking change for any project that never wrote a `select`.
+# This repo was one: 0.16.0 reported 1,128 errors here against 0.15.4's zero, all
+# from newly-defaulted rules (PLW1510, PLR2004, and the rest), none of them a
+# regression in this code.
+#
+# `["E4", "E7", "E9", "F"]` is the previous default reproduced exactly -- verified
+# by diffing `ruff check --show-settings`'s enabled-rule list between 0.15.4 with
+# no select and 0.16.0 with this one: identical, 57 rules. So the bump changes no
+# lint outcome, which is the point. Adopting any of the 354 new rules is a
+# separate decision with its own diff, not something to smuggle in on a
+# dependabot PR.
+select = ["E4", "E7", "E9", "F"]
 extend-ignore = [
     # F821: Undefined name - ignore in template strings where variables are defined in generated code
     "F821",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **`ruff` floor raised to `0.16.0`, and the lint rule selection made explicit.**
+  0.16.0 changed the *implicit* default rule set from 59 rules to 413, which is a
+  breaking change for any project that never wrote a `select` — and this was one.
+  0.16.0 reported **1,128 errors** here against 0.15.4's zero, every one of them a
+  newly-defaulted rule (`PLW1510`, `PLR2004`, and the rest) rather than a
+  regression in this code.
+
+  `.ruff.toml` now sets `select = ["E4", "E7", "E9", "F"]`, which reproduces the
+  previous default **exactly** — verified by diffing `ruff check --show-settings`'s
+  enabled-rule list between 0.15.4 with no `select` and 0.16.0 with this one:
+  identical, 57 rules. So the bump changes no lint outcome. Adopting any of the
+  354 newly-defaulted rules is a separate decision with its own diff, not
+  something to fold into a dependency bump.
+
+  0.16.0 also **stabilised Markdown formatting**, which 0.15.4 refused outright
+  ("Markdown formatting is experimental, enable preview mode"). Since CI runs
+  `ruff format --check .` across the whole repo, 12 Markdown files came into scope
+  and are now formatted: the changes are confined to fenced Python blocks and are
+  whitespace-only — aligned trailing comments collapsed to a single space, and two
+  call expressions rewrapped. `.pre-commit-config.yaml`'s `ruff-pre-commit` rev
+  moves to `v0.16.1` in the same commit, matching what `uv.lock` resolves; the
+  Markdown change makes that lockstep sharper, since a hook and a CI check on
+  opposite sides of it disagree about every fenced block in the docs.
+- **`pytest-cov` floor raised to `7.1.0`**, which makes the total coverage figure
+  independent of reporting options (pytest-cov#641). That is a correctness fix for
+  the thing this repo gates on — `--cov-fail-under=65` in CI and `=25` in
+  `[tool.pytest.ini_options]` were comparing against a total that could shift with
+  `--cov-report`. Measured total after the bump: **72.44%**.
 - **`generate_endpoint_config()` writes four files and returns a different one**
   (#196). It previously wrote `config.yaml` plus a `config.py` shim and returned
   the path to the YAML. It now writes `config.yaml`, a
@@ -163,6 +191,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   4.0.1).
 
 ### Fixed
+- **The declared build requirement could not build this package.**
+  `[build-system] requires` read `setuptools>=42`, but PEP 639 support — the
+  `license = "Apache-2.0"` SPDX string and `license-files = [...]` this project
+  adopted in #189 — landed only in setuptools 77.0. Verified: 76.0.0 rejects
+  `pyproject.toml` outright with *"project.license must be one of [{file},
+  {text}]"*, so `>=42` advertised a build that cannot happen. The floor is now
+  `>=77.0.1` (77.0.0 was yanked).
+
+  This mattered because it was invisible locally — every environment here resolves
+  a current setuptools — and becomes reachable precisely when an **sdist** is
+  published (#180) and a consumer builds it against a pinned older setuptools.
+  Dependabot's own suggestion of 83.0.0 would have hidden it: its advisory
+  (GHSA-h35f-9h28-mq5c, Unicode-normalisation in `MANIFEST.in` matching) does not
+  apply here, since this project has no `MANIFEST.in`, so raising to 83.0.0 would
+  have moved the floor for no reason while leaving the real defect in place.
 - **The generated Globus Compute endpoint config could never start** (#196).
   `globus-compute-endpoint start` classifies a config by a single key:
   `load_config_yaml()` pops `engine` and returns a `UserEndpointConfig` when it is

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ provider = EphemeralAWSProvider(
     security_group_id="sg-0123456789abcdef0",
     instance_type="m5.large",
     bastion_instance_type="t3.micro",
-    state_store_type="parameter_store",   # readable by client and bastion alike
+    state_store_type="parameter_store",  # readable by client and bastion alike
     parameter_store_path="/parsl/my-workflow-state",
 )
 ```
@@ -154,9 +154,9 @@ provider = EphemeralAWSProvider(
 provider = EphemeralAWSProvider(
     mode="serverless",
     region="us-east-1",
-    compute_type="lambda",   # or "ecs"
-    memory_size=1024,        # MB
-    timeout=300,             # seconds
+    compute_type="lambda",  # or "ecs"
+    memory_size=1024,  # MB
+    timeout=300,  # seconds
     max_blocks=100,
 )
 ```
@@ -176,10 +176,10 @@ provider = EphemeralAWSProvider(
     subnet_id="subnet-0123456789abcdef0",
     security_group_id="sg-0123456789abcdef0",
     use_spot=True,
-    use_spot_fleet=True,   # both flags are required; see below
+    use_spot_fleet=True,  # both flags are required; see below
     instance_types=["c5.large", "c5a.large", "m5.large"],
-    spot_max_price_percentage=80,      # cap at 80% of on-demand
-    spot_interruption_handling=True,   # act on the two-minute warning
+    spot_max_price_percentage=80,  # cap at 80% of on-demand
+    spot_interruption_handling=True,  # act on the two-minute warning
 )
 ```
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -104,23 +104,19 @@ provider = EphemeralAWSProvider(
     # Network: pre-provisioned by you, and never modified by the provider.
     # It creates no VPC, subnet, or security group, and deletes none.
     vpc_id="vpc-...",
-    subnet_id="subnet-...",           # a private subnet, if your workers can use one
+    subnet_id="subnet-...",  # a private subnet, if your workers can use one
     security_group_id="sg-...",
-    use_public_ips=False,             # no public IP; reach instances over SSM instead
-
+    use_public_ips=False,  # no public IP; reach instances over SSM instead
     # Credentials on the instance: an instance profile, never static keys.
     # Supply your own ARN, or let the provider create a least-privilege role
     # carrying only AmazonSSMManagedInstanceCore. A profile it created is
     # deleted on shutdown; one you supplied is never touched.
     auto_create_instance_profile=True,
-
     # No SSH. Omitting key_name launches instances with no key pair, so the
     # only access path is SSM Session Manager, which is IAM-authorized and
     # CloudTrail-logged. Set key_name only if you need SSH.
-
     # Terminate rather than stop, so no EBS volume outlives the work.
     auto_shutdown=True,
-
     # Tags, for attribution and for the orphan sweep to find leftovers.
     additional_tags={
         "Environment": "Production",

--- a/archive/TESTING.md
+++ b/archive/TESTING.md
@@ -86,19 +86,32 @@ Moto tests are marked to be skipped if the Moto library is not available:
 
 ```python
 try:
-    from moto import mock_ec2, mock_s3, mock_ssm, mock_iam, mock_lambda, mock_ecs, mock_cloudformation
+    from moto import (
+        mock_ec2,
+        mock_s3,
+        mock_ssm,
+        mock_iam,
+        mock_lambda,
+        mock_ecs,
+        mock_cloudformation,
+    )
+
     MOTO_AVAILABLE = True
 except ImportError:
     MOTO_AVAILABLE = False
+
     # Create placeholder decorators if moto is not available
     def mock_decorator(func):
         return pytest.mark.skip(reason="Moto library not available")(func)
-    mock_ec2 = mock_s3 = mock_ssm = mock_iam = mock_lambda = mock_ecs = mock_cloudformation = mock_decorator
+
+    mock_ec2 = mock_s3 = mock_ssm = mock_iam = mock_lambda = mock_ecs = (
+        mock_cloudformation
+    ) = mock_decorator
 
 # Mark tests as requiring moto
 pytestmark = pytest.mark.skipif(
     not MOTO_AVAILABLE,
-    reason="Moto library not available. Install with: pip install moto"
+    reason="Moto library not available. Install with: pip install moto",
 )
 ```
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -146,7 +146,7 @@ provider = EphemeralAWSProvider(
     mode="serverless",
     compute_type="lambda",
     memory_size=1024,  # MB; Lambda CPU scales with memory
-    timeout=300,       # seconds
+    timeout=300,  # seconds
     max_blocks=50,
 )
 
@@ -267,10 +267,10 @@ provider = EphemeralAWSProvider(
     security_group_id="sg-0123456789abcdef0",
     mode="standard",
     max_blocks=10,
-    use_spot=True,                  # required: use_spot_fleet alone is ignored (#137)
+    use_spot=True,  # required: use_spot_fleet alone is ignored (#137)
     use_spot_fleet=True,
     instance_types=["m5.large", "m5a.large", "m6i.large", "c5.large"],
-    spot_max_price_percentage=80,   # cap at 80% of on-demand
+    spot_max_price_percentage=80,  # cap at 80% of on-demand
     spot_allocation_strategy="price-capacity-optimized",
 )
 ```
@@ -292,7 +292,7 @@ provider = EphemeralAWSProvider(
     vpc_id="vpc-0123456789abcdef0",
     subnet_id="subnet-0123456789abcdef0",
     security_group_id="sg-0123456789abcdef0",
-    instance_type="c7g.large",   # arm64 AMI resolved automatically
+    instance_type="c7g.large",  # arm64 AMI resolved automatically
     mode="standard",
     max_blocks=4,
 )
@@ -352,7 +352,7 @@ provider = EphemeralAWSProvider(
     instance_type="t3.micro",
     mode="standard",
     warm_pool_size=2,
-    warm_pool_ttl=300,                  # seconds held before termination
+    warm_pool_ttl=300,  # seconds held before termination
     auto_create_instance_profile=True,  # required: dispatch is over SSM
     max_blocks=10,
 )
@@ -378,7 +378,7 @@ provider = EphemeralAWSProvider(
     mode="standard",
     bake_ami=True,
     worker_init="dnf install -y python3.11 gcc gcc-c++ make\n"
-                "pip3.11 install --quiet parsl numpy scipy pandas\n",
+    "pip3.11 install --quiet parsl numpy scipy pandas\n",
     max_blocks=10,
 )
 ```
@@ -496,8 +496,8 @@ provider = EphemeralAWSProvider(
 for resource_type, entries in provider.list_resources().items():
     print(f"{resource_type}: {len(entries)}")
 
-provider.cleanup_all()   # terminate compute, keep the provider usable
-provider.shutdown()      # ...or tear everything down and delete the state
+provider.cleanup_all()  # terminate compute, keep the provider usable
+provider.shutdown()  # ...or tear everything down and delete the state
 ```
 
 Every resource is tagged `ParslResource=true` and
@@ -535,7 +535,7 @@ provider = EphemeralAWSProvider(
     key_name="my-key",
     state_file_path="ec2_state.json",
     use_spot=True,
-    spot_max_price="0.1",       # was spot_max_bid
+    spot_max_price="0.1",  # was spot_max_bid
     # New and required: this provider never creates network resources
     vpc_id="vpc-0123456789abcdef0",
     subnet_id="subnet-0123456789abcdef0",

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -126,9 +126,9 @@ Lambda or ECS/Fargate, no EC2 instances. Lambda needs no network IDs at all.
 provider = EphemeralAWSProvider(
     mode="serverless",
     region="us-east-1",
-    compute_type="lambda",   # or "ecs", which does need subnet + security group
-    memory_size=1024,        # MB
-    timeout=300,             # seconds
+    compute_type="lambda",  # or "ecs", which does need subnet + security group
+    memory_size=1024,  # MB
+    timeout=300,  # seconds
     max_blocks=100,
 )
 ```
@@ -145,7 +145,7 @@ provider = EphemeralAWSProvider(
     security_group_id="sg-0123456789abcdef0",
     instance_type="t3.medium",
     use_spot=True,
-    spot_max_price_percentage=80,     # cap at 80% of on-demand
+    spot_max_price_percentage=80,  # cap at 80% of on-demand
     spot_interruption_handling=True,  # act on the two-minute warning
 )
 ```
@@ -159,7 +159,7 @@ instance already `shutting-down`.
 ```python
 provider = EphemeralAWSProvider(
     # ... network and compute options ...
-    min_blocks=0,     # no floor; nothing runs when nothing is queued
+    min_blocks=0,  # no floor; nothing runs when nothing is queued
     max_blocks=10,
     auto_shutdown=True,  # a worker terminates itself when its command finishes
 )
@@ -213,7 +213,7 @@ inferred from the type name.
 ```python
 provider = EphemeralAWSProvider(
     # ... network options ...
-    instance_type="c7g.large",   # arm64 AMI resolved automatically
+    instance_type="c7g.large",  # arm64 AMI resolved automatically
 )
 ```
 

--- a/docs/globus_compute.md
+++ b/docs/globus_compute.md
@@ -248,7 +248,7 @@ def square(x):
 
 
 with Executor(endpoint_id=ENDPOINT_ID) as ex:
-    print(ex.submit(square, 7).result())   # → 49
+    print(ex.submit(square, 7).result())  # → 49
 ```
 
 ### 5. Stop it

--- a/docs/operating_modes.md
+++ b/docs/operating_modes.md
@@ -51,7 +51,7 @@ provider = EphemeralAWSProvider(
     instance_type="t3.medium",
     min_blocks=0,
     max_blocks=4,
-    use_public_ips=True,     # False if reaching the subnet over VPN/Direct Connect
+    use_public_ips=True,  # False if reaching the subnet over VPN/Direct Connect
     key_name="your-key-pair",  # optional; SSM Session Manager needs no key
     use_spot=True,
 )
@@ -144,7 +144,7 @@ provider = EphemeralAWSProvider(
     bastion_instance_type="t3.micro",
     min_blocks=0,
     max_blocks=10,
-    state_store_type="parameter_store",   # readable by client and bastion alike
+    state_store_type="parameter_store",  # readable by client and bastion alike
     parameter_store_path="/parsl/my-workflow-state",
 )
 ```
@@ -226,8 +226,8 @@ provider = EphemeralAWSProvider(
     mode="serverless",
     region="us-west-2",
     compute_type="lambda",
-    memory_size=1024,    # MB
-    timeout=300,         # seconds; Lambda's own ceiling is 900
+    memory_size=1024,  # MB
+    timeout=300,  # seconds; Lambda's own ceiling is 900
     min_blocks=0,
     max_blocks=100,
 )
@@ -274,7 +274,9 @@ provider = EphemeralAWSProvider(
     ecs_container_image="123456789012.dkr.ecr.us-east-1.amazonaws.com/my-worker:latest",
     ecs_task_cpu=2048,
     ecs_task_memory=4096,
-    vpc_id="vpc-...", subnet_id="subnet-...", security_group_id="sg-...",
+    vpc_id="vpc-...",
+    subnet_id="subnet-...",
+    security_group_id="sg-...",
 )
 ```
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -410,8 +410,8 @@ If your workflows touch regulated data:
 To tear down everything a provider owns:
 
 ```python
-provider.cleanup_all()   # terminate compute, keep the provider usable
-provider.shutdown()      # ...and delete the launch template, AMI, and state
+provider.cleanup_all()  # terminate compute, keep the provider usable
+provider.shutdown()  # ...and delete the launch template, AMI, and state
 ```
 
 Neither takes a `force` argument. To reach the resources of a workflow started by

--- a/docs/spot_fleet.md
+++ b/docs/spot_fleet.md
@@ -44,15 +44,12 @@ provider = EphemeralAWSProvider(
     vpc_id="vpc-0123456789abcdef0",
     subnet_id="subnet-0123456789abcdef0",
     security_group_id="sg-0123456789abcdef0",
-
     use_spot=True,
     use_spot_fleet=True,
     instance_types=["m5.large", "m5a.large", "m6i.large", "c5.large"],
-
-    nodes_per_block=2,             # instances per fleet
+    nodes_per_block=2,  # instances per fleet
     spot_max_price_percentage=80,  # cap at 80% of on-demand
     spot_allocation_strategy="price-capacity-optimized",  # the default
-
     mode="standard",
     max_blocks=4,
 )
@@ -100,7 +97,7 @@ Choose types yourself. Effective pools share a size and mix families and
 generations:
 
 ```python
-instance_types=["m5.xlarge", "m5a.xlarge", "m5n.xlarge", "m6i.xlarge"]
+instance_types = ["m5.xlarge", "m5a.xlarge", "m5n.xlarge", "m6i.xlarge"]
 ```
 
 Keep vCPU and memory comparable across the list, since Parsl sizes its worker pool

--- a/docs/state_persistence.md
+++ b/docs/state_persistence.md
@@ -26,7 +26,7 @@ provider = EphemeralAWSProvider(
     vpc_id="vpc-0123456789abcdef0",
     subnet_id="subnet-0123456789abcdef0",
     security_group_id="sg-0123456789abcdef0",
-    state_store_type="file",                      # "file" | "s3" | "parameter_store"
+    state_store_type="file",  # "file" | "s3" | "parameter_store"
     state_file_path="./aws_provider_state.json",  # used by "file"
 )
 ```

--- a/docs/substrate_testing.md
+++ b/docs/substrate_testing.md
@@ -108,15 +108,15 @@ vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
 # Read the AZ rather than assuming f"{region}a": that guess is how the real-AWS
 # suite ended up pinned to a zone that does not offer t3.micro.
 az = ec2.describe_availability_zones()["AvailabilityZones"][0]["ZoneName"]
-subnet = ec2.create_subnet(
-    VpcId=vpc, CidrBlock="10.0.0.0/24", AvailabilityZone=az
-)["Subnet"]["SubnetId"]
+subnet = ec2.create_subnet(VpcId=vpc, CidrBlock="10.0.0.0/24", AvailabilityZone=az)[
+    "Subnet"
+]["SubnetId"]
 sg = ec2.create_security_group(
     GroupName="parsl-test", Description="Parsl test", VpcId=vpc
 )["GroupId"]
 
 provider = EphemeralAWSProvider(
-    image_id="ami-12345678",   # any value; the emulator does not resolve AMIs
+    image_id="ami-12345678",  # any value; the emulator does not resolve AMIs
     instance_type="t3.micro",
     region="us-east-1",
     vpc_id=vpc,
@@ -139,11 +139,11 @@ inside the shipped package, because no package code imports it — its predecess
 
 ```python
 from tests.substrate_support import (
-    get_substrate_session,     # boto3.Session pointed at the emulator
-    is_substrate_available,    # never raises; gate a module skip on this
-    reset_substrate_state,     # POST /v1/state/reset
-    setup_substrate_vpc,       # provision vpc + subnet + igw + route table + sg
-    cleanup_substrate_vpc,     # tear it down, dependents first
+    get_substrate_session,  # boto3.Session pointed at the emulator
+    is_substrate_available,  # never raises; gate a module skip on this
+    reset_substrate_state,  # POST /v1/state/reset
+    setup_substrate_vpc,  # provision vpc + subnet + igw + route table + sg
+    cleanup_substrate_vpc,  # tear it down, dependents first
 )
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,15 @@
 # SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
 
 [build-system]
-requires = ["setuptools>=42", "wheel"]
+# 77.0.1, not the inherited 42: PEP 639 support -- the `license = "Apache-2.0"`
+# SPDX string and `license-files` below -- landed in setuptools 77.0. Anything
+# older rejects this file outright; 76.0.0 fails validation with "project.license
+# must be one of [{file}, {text}]". So `>=42` advertised a build that cannot
+# happen. It went unnoticed because every environment here resolves something
+# current, and only a consumer pinning an old setuptools would have hit it --
+# which is exactly what publishing an sdist to PyPI invites (#180). 77.0.0 was
+# yanked, so 77.0.1 is the lowest installable release that works.
+requires = ["setuptools>=77.0.1", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
@@ -68,13 +76,18 @@ dev = [
     # 9.0.3 fixes GHSA-6w46-j5rx-g56g, insecure tmpdir handling. Dev-only, so the
     # exposure is a developer's own machine rather than a consumer's.
     "pytest>=9.0.3",
-    "pytest-cov>=2.12.0",
+    # 7.1.0 makes the total coverage figure independent of reporting options
+    # (pytest-cov#641). That is a correctness fix for the thing this repo gates
+    # on: `--cov-fail-under=65` in CI and `=25` in `[tool.pytest.ini_options]`
+    # were comparing against a total that could shift with `--cov-report`.
+    "pytest-cov>=7.1.0",
     "pytest-mock>=3.0.0",
     "coverage>=6.0",
     # Floor matches the ruff-pre-commit pin so the hook and `uv run ruff` cannot
     # disagree on formatting; at 0.2.x they differed on comprehension-conditional
-    # parenthesization and each would undo the other's output.
-    "ruff>=0.15.4",
+    # parenthesization and each would undo the other's output. Both move together
+    # or neither does -- see .pre-commit-config.yaml.
+    "ruff>=0.16.0",
     "mypy>=0.812",
     "bandit>=1.7.0",
     "pre-commit>=2.15.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1530,10 +1530,10 @@ requires-dist = [
     { name = "parsl", specifier = ">=2026.4.20" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=2.15.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=2.12.0" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.1.0" },
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.0.0" },
     { name = "requests", marker = "extra == 'test'", specifier = ">=2.33.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.4" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.16.0" },
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=4.0.0" },
     { name = "sphinx-autodoc-typehints", marker = "extra == 'docs'", specifier = ">=1.12.0" },
     { name = "sphinx-rtd-theme", marker = "extra == 'docs'", specifier = ">=1.0.0" },
@@ -1853,16 +1853,16 @@ wheels = [
 
 [[package]]
 name = "pytest-cov"
-version = "7.0.0"
+version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "coverage", extra = ["toml"] },
     { name = "pluggy" },
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
 ]
 
 [[package]]
@@ -2435,27 +2435,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.4"
+version = "0.16.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/da/31/d6e536cdebb6568ae75a7f00e4b4819ae0ad2640c3604c305a0428680b0c/ruff-0.15.4.tar.gz", hash = "sha256:3412195319e42d634470cc97aa9803d07e9d5c9223b99bcb1518f0c725f26ae1", size = 4569550, upload-time = "2026-02-26T20:04:14.959Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/25/7113f6d5498888c5fb7db34081cba7d5971c4cb1bfb26819966eee68f003/ruff-0.16.1.tar.gz", hash = "sha256:fedad7c801dabd3fb9741d76aca39246e6ddd9ca446a015875207bf19f1e6bc7", size = 4877500, upload-time = "2026-07-30T19:37:01.379Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/82/c11a03cfec3a4d26a0ea1e571f0f44be5993b923f905eeddfc397c13d360/ruff-0.15.4-py3-none-linux_armv6l.whl", hash = "sha256:a1810931c41606c686bae8b5b9a8072adac2f611bb433c0ba476acba17a332e0", size = 10453333, upload-time = "2026-02-26T20:04:20.093Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/5d/6a1f271f6e31dffb31855996493641edc3eef8077b883eaf007a2f1c2976/ruff-0.15.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:5a1632c66672b8b4d3e1d1782859e98d6e0b4e70829530666644286600a33992", size = 10853356, upload-time = "2026-02-26T20:04:05.808Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/d8/0fab9f8842b83b1a9c2bf81b85063f65e93fb512e60effa95b0be49bfc54/ruff-0.15.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a4386ba2cd6c0f4ff75252845906acc7c7c8e1ac567b7bc3d373686ac8c222ba", size = 10187434, upload-time = "2026-02-26T20:03:54.656Z" },
-    { url = "https://files.pythonhosted.org/packages/85/cc/cc220fd9394eff5db8d94dec199eec56dd6c9f3651d8869d024867a91030/ruff-0.15.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b2496488bdfd3732747558b6f95ae427ff066d1fcd054daf75f5a50674411e75", size = 10535456, upload-time = "2026-02-26T20:03:52.738Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/0f/bced38fa5cf24373ec767713c8e4cadc90247f3863605fb030e597878661/ruff-0.15.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3f1c4893841ff2d54cbda1b2860fa3260173df5ddd7b95d370186f8a5e66a4ac", size = 10287772, upload-time = "2026-02-26T20:04:08.138Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/90/58a1802d84fed15f8f281925b21ab3cecd813bde52a8ca033a4de8ab0e7a/ruff-0.15.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:820b8766bd65503b6c30aaa6331e8ef3a6e564f7999c844e9a547c40179e440a", size = 11049051, upload-time = "2026-02-26T20:04:03.53Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/ac/b7ad36703c35f3866584564dc15f12f91cb1a26a897dc2fd13d7cb3ae1af/ruff-0.15.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c9fb74bab47139c1751f900f857fa503987253c3ef89129b24ed375e72873e85", size = 11890494, upload-time = "2026-02-26T20:04:10.497Z" },
-    { url = "https://files.pythonhosted.org/packages/93/3d/3eb2f47a39a8b0da99faf9c54d3eb24720add1e886a5309d4d1be73a6380/ruff-0.15.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f80c98765949c518142b3a50a5db89343aa90f2c2bf7799de9986498ae6176db", size = 11326221, upload-time = "2026-02-26T20:04:12.84Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/90/bf134f4c1e5243e62690e09d63c55df948a74084c8ac3e48a88468314da6/ruff-0.15.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:451a2e224151729b3b6c9ffb36aed9091b2996fe4bdbd11f47e27d8f2e8888ec", size = 11168459, upload-time = "2026-02-26T20:04:00.969Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/e5/a64d27688789b06b5d55162aafc32059bb8c989c61a5139a36e1368285eb/ruff-0.15.4-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a8f157f2e583c513c4f5f896163a93198297371f34c04220daf40d133fdd4f7f", size = 11104366, upload-time = "2026-02-26T20:03:48.099Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/f6/32d1dcb66a2559763fc3027bdd65836cad9eb09d90f2ed6a63d8e9252b02/ruff-0.15.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:917cc68503357021f541e69b35361c99387cdbbf99bd0ea4aa6f28ca99ff5338", size = 10510887, upload-time = "2026-02-26T20:03:45.771Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/92/22d1ced50971c5b6433aed166fcef8c9343f567a94cf2b9d9089f6aa80fe/ruff-0.15.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:e9737c8161da79fd7cfec19f1e35620375bd8b2a50c3e77fa3d2c16f574105cc", size = 10285939, upload-time = "2026-02-26T20:04:22.42Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/f4/7c20aec3143837641a02509a4668fb146a642fd1211846634edc17eb5563/ruff-0.15.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:291258c917539e18f6ba40482fe31d6f5ac023994ee11d7bdafd716f2aab8a68", size = 10765471, upload-time = "2026-02-26T20:03:58.924Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/09/6d2f7586f09a16120aebdff8f64d962d7c4348313c77ebb29c566cefc357/ruff-0.15.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:3f83c45911da6f2cd5936c436cf86b9f09f09165f033a99dcf7477e34041cbc3", size = 11263382, upload-time = "2026-02-26T20:04:24.424Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/fa/2ef715a1cd329ef47c1a050e10dee91a9054b7ce2fcfdd6a06d139afb7ec/ruff-0.15.4-py3-none-win32.whl", hash = "sha256:65594a2d557d4ee9f02834fcdf0a28daa8b3b9f6cb2cb93846025a36db47ef22", size = 10506664, upload-time = "2026-02-26T20:03:50.56Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/a8/c688ef7e29983976820d18710f955751d9f4d4eb69df658af3d006e2ba3e/ruff-0.15.4-py3-none-win_amd64.whl", hash = "sha256:04196ad44f0df220c2ece5b0e959c2f37c777375ec744397d21d15b50a75264f", size = 11651048, upload-time = "2026-02-26T20:04:17.191Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/0a/9e1be9035b37448ce2e68c978f0591da94389ade5a5abafa4cf99985d1b2/ruff-0.15.4-py3-none-win_arm64.whl", hash = "sha256:60d5177e8cfc70e51b9c5fad936c634872a74209f934c1e79107d11787ad5453", size = 10966776, upload-time = "2026-02-26T20:03:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/bd/694da69368e0973de65df2ddc73ab18d43c469d5963d9b150911de6bc513/ruff-0.16.1-py3-none-linux_armv6l.whl", hash = "sha256:58edb313b88f0c5460a26adf5f39a37a3be789494a15e3e411e35fa78b89f9a0", size = 10839126, upload-time = "2026-07-30T19:36:13.697Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/f0/b626e5d5bd0dd9576263658ef12885e2288afd1029a48e26ffed65ec1ac1/ruff-0.16.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:fde5a99e2f97479af66edd6622c6d5a2a7592c77cf4153d9e4428f5eeb55b60c", size = 11070253, upload-time = "2026-07-30T19:36:17.14Z" },
+    { url = "https://files.pythonhosted.org/packages/83/63/f40acfb6b35b88623e71684942b552c3edd96035f5d98f313815f7b277de/ruff-0.16.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e0d4c20532fca4f7fa609369161d968dd28f65d83dabbd61d8e9c7edbf7001f6", size = 10561425, upload-time = "2026-07-30T19:36:20.04Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/dd/14ec0e9c2b4d315547dd38765004b4863e354e1b52cb308272215d9f6f6d/ruff-0.16.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:30affbcedf59ad5703d9c91f82266e02b47739f797e1a7b6e158e5526a6dae38", size = 10948879, upload-time = "2026-07-30T19:36:22.476Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e9/9d870cbae575030fdef595f04b4b97573c525b5497cce4f4498cf2f85446/ruff-0.16.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:24e9c631573cbca9d20f1283f8f479b2afa4a8503504822bd71a293889f16743", size = 10643691, upload-time = "2026-07-30T19:36:24.914Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/09/12743d544e2173f53ecd27217c65f90d2bc0f8424a66a60339e56bbc0457/ruff-0.16.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b41bdd48fb420987a9b5212e4957c26ad4abce401fa9ea9d4d85843727945f4f", size = 11435354, upload-time = "2026-07-30T19:36:28.447Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/89/a1652b2daee52083c9554a6333b678a8b01d0400f976827bb87857f9449a/ruff-0.16.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b0d1e1393b7648079e13669de1c1f4fde06d4583e84d8fd5c1551e0a77a2aa75", size = 12259033, upload-time = "2026-07-30T19:36:31.326Z" },
+    { url = "https://files.pythonhosted.org/packages/16/96/ecdcb8c54ee7b123b487f807eb014e6e019155a0b81dfb669acd52f28ce3/ruff-0.16.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:07bf434b1c95f4e093be4532068ef4fcf00924eb2ade8796075980902d6fd54a", size = 11667981, upload-time = "2026-07-30T19:36:34.394Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/90/c52e12e0d862e9572f2a33aa227409143520abe53111e9a6babbac7b4af8/ruff-0.16.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39897739f112253ee4fdd2e8aa9a4f9ded99fb2be367d5f31dfa4ded6025584c", size = 11468183, upload-time = "2026-07-30T19:36:37.339Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6b/4ffb7ad1d83eb16cf8cbb3c8815d3f11c88460fd162d4b372a2059be1c2a/ruff-0.16.1-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:82ae3c0c0d74daf17b968a10b7b3bb3ef297ab7de0c1f749646b25e690ccb150", size = 11470071, upload-time = "2026-07-30T19:36:39.91Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/72/32ae7db4c0b5e32ab611787caa19d1546800676d79f7483b7100a3561bf4/ruff-0.16.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4d5f2ed10f8242d83fc08d521301089364e3375375705356f20c0e31606ef3ef", size = 10919503, upload-time = "2026-07-30T19:36:42.65Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/ca/3d901ba6ad6fc38da39c3448fc6c59ac945679293a17c3ceb6d6c1cba13e/ruff-0.16.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a4665b309891f83f3e3c25447935f1213e9abbd4b5640af7a1f2def9f8d413c1", size = 10649861, upload-time = "2026-07-30T19:36:45.18Z" },
+    { url = "https://files.pythonhosted.org/packages/92/79/894ef1ced26552d5f8c9cf6d85b0687840e1128c55aeab7b9c2d54a0d880/ruff-0.16.1-py3-none-musllinux_1_2_i686.whl", hash = "sha256:26e9ca5c9bc3971f20d3cf18a957f52ffd6a5f6564ff15c4912a144dcac22494", size = 11148137, upload-time = "2026-07-30T19:36:47.936Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/69/3609a09fa1cb46cc28b762363e440a354204e5dff01bd0c8d7437874d6b9/ruff-0.16.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:67e1e1e3fa4f0c82f0e36d4cd61e661f6e7a6196cb1aa92fe0828fa7b8f257cd", size = 11559211, upload-time = "2026-07-30T19:36:50.448Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/8a/fb22af2fd78a736e241fabf67e30ce1799a64244026377a49e133af90762/ruff-0.16.1-py3-none-win32.whl", hash = "sha256:d31765e131295b8445caf301e3e8a85b34d1b9b211b4109b7ba457888b051806", size = 10838258, upload-time = "2026-07-30T19:36:53.298Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/35/e57fd9fb5d423961df087a00b12d42c0a830288dc2f3b45ecca299158b4f/ruff-0.16.1-py3-none-win_amd64.whl", hash = "sha256:09b05e8b90c2cb06ad63464350e7a45e8e44a2dfe52072ebfba6666ca8d3f596", size = 11961111, upload-time = "2026-07-30T19:36:56.107Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/46/240ea004bf6dc4feb40e9832f2205a476a47dd5b8a3f8211a5fc5f95e20e/ruff-0.16.1-py3-none-win_arm64.whl", hash = "sha256:dbaadaac38c70239f056d306b7476f246b0bf000fa6b3876402acbf5b227eaf8", size = 11309414, upload-time = "2026-07-30T19:36:58.79Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Supersedes #186, #187, and #188. Swept as one PR after the suite went green, so a dependency bump
cannot be confused with a functional regression — the same pattern `e10561d` used for the action
bumps.

All three dependabot branches were cut **before** the #189 rename, which is why #187's red `lint`
run reported against `parsl_ephemeral_aws/` paths that no longer exist. That made the stale base a
plausible explanation for the failure, and it was not the real one.

## ruff 0.16.0 is a breaking change, not a routine bump

The **implicit** default rule set went from **59 rules to 413**. This repo never wrote a `select`,
so it inherited that default:

```
uvx ruff@0.15.4 check .   →  All checks passed!
uvx ruff@0.16.0 check .   →  Found 1128 errors.
```

Every one is a newly-defaulted rule (`PLW1510`, `PLR2004`, …), not a regression in this code.

`.ruff.toml` now sets `select = ["E4", "E7", "E9", "F"]`, which reproduces the previous default
**exactly**. Verified rather than assumed — diffing the enabled-rule list that
`ruff check --show-settings` prints, between 0.15.4 with no `select` and 0.16.0 with this one:

```
0.16 with explicit select: 57 rules
0.15.4 default (no select): 57 rules
diff → IDENTICAL
```

So the bump changes no lint outcome. Adopting any of the 354 newly-defaulted rules is a separate
decision with its own diff, and folding it into a dependency PR would have been the wrong place to
make it.

## …and it stabilised Markdown formatting

0.15.4 refused outright: `error: Failed to format docs/globus_compute.md: Markdown formatting is
experimental, enable preview mode.` 0.16.0 does it by default. CI runs `ruff format --check .`
repo-wide, so **12 Markdown files** came into scope and would have failed the `lint` job.

Formatted here. The changes are confined to fenced Python blocks and are whitespace-only — aligned
trailing comments collapsed to a single space, plus two call expressions rewrapped:

```diff
-    spot_max_price_percentage=80,      # cap at 80% of on-demand
-    spot_interruption_handling=True,   # act on the two-minute warning
+    spot_max_price_percentage=80,  # cap at 80% of on-demand
+    spot_interruption_handling=True,  # act on the two-minute warning
```

No prose changed. `tests/unit/test_docs_examples.py` scans these files for kwargs that do not exist,
and passes 132.

`.pre-commit-config.yaml`'s `ruff-pre-commit` rev moves to **`v0.16.1`** in the same commit,
matching what `uv.lock` resolves — `uv lock` picked 0.16.1, not 0.16.0, and the existing comment's
rule is that the hook tracks the lock. That lockstep is now sharper than the v0.2.2 hazard it was
written for: a hook and a CI check on opposite sides of the Markdown change disagree about every
fenced block in the docs. Both `pre-commit run ruff --all-files` and `ruff-format --all-files` pass.

## pytest-cov 7.1.0 fixes the thing this repo gates on

Its headline fix (pytest-dev/pytest-cov#641) makes the total coverage figure **independent of
reporting options**. That is not cosmetic here: `--cov-fail-under=65` in CI and `=25` in
`[tool.pytest.ini_options]` were comparing against a total that could shift with `--cov-report`.
Measured after the bump: **72.44%**, comfortably over the gate.

## setuptools — dependabot was wrong in both directions

**Its suggestion doesn't apply.** 83.0.0's advisory (GHSA-h35f-9h28-mq5c) is about Unicode
normalisation in `MANIFEST.in` matching. **This project has no `MANIFEST.in`**, so #186 would have
moved the floor for no reason.

**Meanwhile the declared floor could not build the package.** `requires = ["setuptools>=42"]`, but
PEP 639 — the `license = "Apache-2.0"` SPDX string and `license-files = [...]` that #189 adopted —
landed only in setuptools **77.0**. Verified against real versions:

| setuptools | reading this `pyproject.toml` |
|---|---|
| 76.0.0 | **fails**: `project.license must be one of [{file}, {text}]` |
| 77.0.1 | OK |
| 82.0.0 (locked) | OK |

So `>=42` advertised a build that cannot happen. Now `>=77.0.1` — 77.0.0 was yanked, so it is the
lowest *installable* release that works, consistent with this repo's "lowest release that clears the
problem" floor policy.

Invisible locally, because every environment here resolves something current. It becomes reachable
exactly when an **sdist** is published (#180) and a consumer builds it against a pinned older
setuptools — so this was worth catching before the first publish rather than after.

## Verification

```
uv run pytest tests/unit tests/security --no-cov -q          # 1226 passed, 2 skipped
uv run pytest tests/unit tests/security --cov-fail-under=65  # Total coverage: 72.44%
uv run ruff check .                                          # All checks passed (0.16.1)
uv run ruff format --check .                                 # 153 files already formatted
uv run bandit -r parsl_aws_provider -c pyproject.toml        # Medium: 0, High: 0
uv run pre-commit run ruff --all-files                       # Passed
uv run pre-commit run ruff-format --all-files                # Passed
uv build && uvx twine check dist/*                           # both PASSED
```

The build check matters for the setuptools claim specifically: the wheel carries
`dist-info/licenses/LICENSE` **and** `dist-info/licenses/NOTICE`, which is the PEP 639 metadata that
the old floor could not have produced.

`uv.lock` is committed with the change, as CI installs from it via `uv sync --locked`.
