### PR TITLE
docs: point the substrate gap table at its upstream issues (refs #183)

### DIFF
--- a/docs/substrate_testing.md
+++ b/docs/substrate_testing.md
@@ -183,14 +183,32 @@ provider.
 ## Known gaps
 
 Verified by probing substrate `0.85.0` directly, not read off the milestones.
-Only two gaps remain, and both are why part of the suite still uses moto:
+Three of the four are why part of the suite still uses moto (#183); the
+EventBridge row is a gap this project turns to its advantage rather than one it
+works around.
 
 | Gap | Effect | Upstream |
 |---|---|---|
-| CloudFormation is not exposed over HTTP; `create_stack` returns `ServiceNotAvailable` | `DetachedMode`'s bastion stack and six `ServerlessMode` tests that drive `cf_client` cannot run here. `tests/integration/test_serverless_mode_spot_fleet_integration.py` stays on moto for exactly this reason; real coverage is in `tests/aws/` | — |
+| CloudFormation is not exposed over HTTP; `create_stack` returns `ServiceNotAvailable` | `DetachedMode`'s bastion stack and six `ServerlessMode` tests that drive `cf_client` cannot run here. `tests/integration/test_serverless_mode_spot_fleet_integration.py` stays on moto for exactly this reason; real coverage is in `tests/aws/` | [substrate#483](https://github.com/scttfrdmn/substrate/issues/483) |
 | EventBridge is not emulated; `PutRule` returns `501 service not emulated: awsevents` | The spot-warning notifier's degradation path is testable *because* of this. The warning path itself is covered end to end by wiring an SQS queue directly, since the monitor only ever reads warnings through SQS | — |
-| IAM does not serve AWS-managed policies — `get_policy` on `arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore` returns `NoSuchEntity` (though `attach_role_policy` accepts it) | The unit suite keeps moto with `MOTO_IAM_LOAD_MANAGED_POLICIES=true`, which serves the real policy documents | — |
-| The instance-type catalog is partial — `t3.micro` resolves, `m5.xlarge` does not | `describe_instance_capacity` tests stay on moto, which knows the full catalog | — |
+| IAM does not serve AWS-managed policies — `get_policy` on `arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore` returns `NoSuchEntity` (though `attach_role_policy` accepts it) | The unit suite keeps moto with `MOTO_IAM_LOAD_MANAGED_POLICIES=true`, which serves the real policy documents | [substrate#484](https://github.com/scttfrdmn/substrate/issues/484) |
+| The instance-type catalog is partial — `t3.micro` resolves, `m5.xlarge` does not | `describe_instance_capacity` tests stay on moto, which knows the full catalog | [substrate#485](https://github.com/scttfrdmn/substrate/issues/485) |
+
+Not a gap this suite trips over, but recorded because it makes a substrate-backed
+assertion unable to fail: `describe_instance_type_offerings` ignores the
+`instance-type` filter, returning all eight catalog types for any value —
+including one that does not exist, where real AWS returns none. Filed as item 2
+of [substrate#485](https://github.com/scttfrdmn/substrate/issues/485). Do not
+write an offerings-based availability check against the emulator and read a pass
+as meaningful.
+
+CloudFormation is the one to read carefully before assuming it is simply absent:
+substrate *implements* it (`emulator/betty_cfn.go` and ~40
+`betty_cfn_v*_plugins.go` files, covering parameters, outputs, conditions, change
+sets and drift), but registers no `cloudformation` plugin — `/ready` lists 64
+plugins and none is CFN, and the similarly-named `cfPlugin` is CloudFront. The
+support is reachable only from Go, through the in-process `betty.Deploy` client,
+so no amount of boto3 configuration will find it.
 
 Fixed since, and no longer worked around anywhere:
 


### PR DESCRIPTION
`docs/substrate_testing.md`'s "Known gaps" table had an empty **Upstream** column
for three of its four rows. Those three are precisely why
`moto[cloudformation]>=5.0.0` stays in `pyproject.toml` (#183), so tracking them
only in a docs table meant nothing upstream would ever move them.

Filed against substrate, each probed against `ghcr.io/scttfrdmn/substrate:0.85.0`
and read against the source before filing:

| Gap | Upstream |
|---|---|
| CloudFormation unreachable over the wire | [substrate#483](https://github.com/scttfrdmn/substrate/issues/483) |
| No service-role managed policies seeded | [substrate#484](https://github.com/scttfrdmn/substrate/issues/484) |
| Instance-type catalog and its filters | [substrate#485](https://github.com/scttfrdmn/substrate/issues/485) |

## Two corrections to the page

**"Only two gaps remain" sat above a four-row table.**

**CloudFormation is unrouted, not unimplemented.** Substrate models CFN across
`emulator/betty_cfn.go` and ~40 `betty_cfn_v*_plugins.go` files — parameters,
outputs, conditions, change sets, drift. But `RegisterDefaultPlugins` makes 64
`registry.Register` calls and none is CloudFormation; `/ready` confirms 64 plugins
with no `cloudformation`, and the similarly-named `cfPlugin` at `plugins.go:341`
is **CloudFront**. Betty is an in-process **Go** client (`betty.Deploy`), so no
boto3 configuration can reach it. Saying "not emulated" invites waiting for a
feature that already exists behind a Go-only door — #483 accordingly offers
documenting it as out of scope as an equally valid resolution.

## One new finding

`describe_instance_type_offerings` **ignores the `instance-type` filter**,
returning all 8 catalog types × 3 AZs for any value — including a type that does
not exist, where real AWS returns 0. Cause: it filters on `InstanceType.N` request
params, but that parameter does not exist on this operation (botocore rejects it
outright), so the filter loop is dead code and only `location` is read.

This suite does not currently trip over it, but it makes an offerings-based
availability assertion against the emulator *unable to fail*, so the page now
warns against writing one. Filed as item 2 of #485.

## Verification

Real-AWS behaviour was confirmed before asserting it upstream, not assumed:

```
real AWS: describe_instance_types(["zz9.nonexistent"]) -> InvalidInstanceType
real AWS: offerings filter m5.xlarge -> 5 offerings, distinct types ['m5.xlarge']
real AWS: offerings filter zz9.bogus -> 0 offerings
substrate 0.85.0: 0 results / 24 offerings / 24 offerings
```

- `uv run make -C docs html SPHINXOPTS="-W"` → build succeeded (warnings are errors)
- `uv run ruff check .` → All checks passed; `ruff format --check` → already formatted
- `uv run pytest tests/integration` (as CI invokes it, `SUBSTRATE_ENDPOINT`) → **130 passed, 1 skipped**

Docs-only; no code paths touched. #183 stays open — its own blocker
(substrate#446) is satisfied and released, but the moto-retirement decision it
records is unchanged.