### PR TITLE
chore: bump substrate pin to 0.87.0, record what CFN still lacks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,8 +126,8 @@ jobs:
         # two together, deliberately -- they had drifted, this pin sitting on
         # 0.76.0 while compose moved to 0.82.0, so CI was validating against an
         # emulator six releases older than the one developers ran. See that file
-        # for what 0.85.0 fixes.
-        image: ghcr.io/scttfrdmn/substrate:0.85.0
+        # for what each release fixes.
+        image: ghcr.io/scttfrdmn/substrate:0.87.0
         ports:
           - 4566:4566
         # No `--health-cmd`. The image is Alpine and ships no curl, and GitHub
@@ -147,9 +147,10 @@ jobs:
         # Now gating. This carried `continue-on-error: true` while #92's debt was
         # outstanding -- 46 mode constructions omitted the network IDs #69 made
         # required, so the suite could not pass and gating would have made every
-        # PR red. #92 closed in v0.8.0 and the suite is green (130 passed, 1
-        # skipped against substrate 0.85.0), so the exemption now only hides
-        # regressions.
+        # PR red. #92 closed in v0.8.0 and the suite is green (131 passed, 0
+        # skipped against substrate 0.87.0 -- 130 passed and 1 skipped on 0.85.0,
+        # the skip being the CloudFormation guard that lifted itself when
+        # substrate#483 landed), so the exemption now only hides regressions.
         env:
           # Structural, not secret: substrate authenticates against nothing, but
           # botocore refuses to sign a request without credentials present.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **The substrate emulator pin moves `0.85.0` → `0.87.0`**, in
+  `docker-compose.substrate.yml` and `.github/workflows/ci.yml` together. 0.87.0
+  carries all three fixes filed from this repo while probing 0.85.0, and the
+  integration suite goes from **130 passed / 1 skipped** to **131 passed / 0
+  skipped**. Nothing in the suite changed to achieve that: the CloudFormation
+  guard lifted itself, because `tests/conftest.py` probes
+  `/_localstack/health` rather than hardcoding a verdict.
+
+  - [substrate#484](https://github.com/scttfrdmn/substrate/issues/484) — IAM now
+    serves the service-role managed policies. `get_policy` on
+    `AmazonSSMManagedInstanceCore` used to raise `NoSuchEntity` for an ARN
+    `attach_role_policy` had just accepted, and that asymmetry is what made it
+    read as a consumer bug.
+  - [substrate#485](https://github.com/scttfrdmn/substrate/issues/485) — the
+    instance-type catalog covers every type this project names, an unknown type
+    raises `InvalidInstanceType`, and `describe_instance_type_offerings` honours
+    its `instance-type` filter. That last one mattered most: the filter was dead
+    code, so an offerings-based availability assertion could not fail.
+  - [substrate#483](https://github.com/scttfrdmn/substrate/issues/483) — a real
+    `cloudformation` plugin is registered. Through 0.85.0 CFN was implemented but
+    unrouted, reachable only from Go via `betty.Deploy`.
+
+  CloudFormation still is not a moto replacement, and #183 stays open for it.
+  substrate does not resolve YAML short-form intrinsics — `!Sub`, `!Ref`, `!If`
+  are stripped and the raw scalar used literally, while the `Fn::` long forms are
+  correct — and `StackDeployer.dispatch` writes resources as account
+  `123456789012` while the caller is `000000000000`. Every template in
+  `parsl_aws_provider/templates/cloudformation/` uses the short forms, so a stack
+  reaches `CREATE_COMPLETE` having created nothing the caller can query.
+  `docs/substrate_testing.md` records both, with the evidence.
 - **`ruff` floor raised to `0.16.0`, and the lint rule selection made explicit.**
   0.16.0 changed the *implicit* default rule set from 59 rules to 413, which is a
   breaking change for any project that never wrote a `select` — and this was one.

--- a/docker-compose.substrate.yml
+++ b/docker-compose.substrate.yml
@@ -42,10 +42,34 @@ services:
     #     That unblocks S3State(create_bucket_if_not_exists=True), which was
     #     xfailed and verified nowhere (#166).
     #
+    # 0.87.0 clears three more, all filed from this repo while probing 0.85.0:
+    #
+    #   substrate#484 (262b911) IAM serves the service-role managed policies, so
+    #     get_policy on AmazonSSMManagedInstanceCore resolves instead of raising
+    #     NoSuchEntity for an ARN attach_role_policy had already accepted.
+    #   substrate#485 (64912ef) the instance-type catalog covers every type this
+    #     project names, an unknown type raises InvalidInstanceType, and the
+    #     describe_instance_type_offerings `instance-type` filter discriminates
+    #     instead of being dead code that could not fail.
+    #   substrate#483 (ff3521a) a real `cloudformation` plugin is registered --
+    #     through 0.85.0 CFN was implemented but unrouted, reachable only from Go
+    #     via betty.Deploy. The whole surface this repo drives now works over the
+    #     wire, which unskips the DetachedMode bastion test. That skip lifted
+    #     itself: tests/conftest.py probes /_localstack/health rather than
+    #     hardcoding a version.
+    #
+    # CFN is still not a moto replacement, for two reasons worth knowing before
+    # you try: substrate does not resolve YAML short-form intrinsics (`!Sub`,
+    # `!Ref`, `!If` are stripped and the raw scalar used literally, while the
+    # `Fn::` long forms work), and StackDeployer.dispatch writes resources as
+    # account 123456789012 while the caller is 000000000000. A stack built from
+    # any template in templates/cloudformation/ therefore reaches CREATE_COMPLETE
+    # having created nothing the caller can find. See docs/substrate_testing.md.
+    #
     # Verify a bump reaches the image, not just the git tag: substrate cuts
     # release commits, so a merged fix sits on `main` after the newest tag and is
     # invisible to this pin. `git tag --contains <sha>` is the check.
-    image: ghcr.io/scttfrdmn/substrate:0.85.0
+    image: ghcr.io/scttfrdmn/substrate:0.87.0
     container_name: parsl-substrate
     ports:
       - "4566:4566"

--- a/docs/substrate_testing.md
+++ b/docs/substrate_testing.md
@@ -37,12 +37,12 @@ any step ran.
 The compose file is pinned to a specific image tag, deliberately — an emulator that
 silently changes under CI turns an unrelated PR red.
 
-`/health` reports the real version as of 0.85.0 — `{"status":"ok","version":"v0.85.0"}` —
+`/health` reports the real version since 0.85.0 — `{"status":"ok","version":"v0.87.0"}` —
 so `make substrate-status` is enough to confirm the pin. Released images used to
 report `"version":"dev"` whatever their tag
 ([substrate#402](https://github.com/scttfrdmn/substrate/issues/402)); against an
 older image, use
-`podman image inspect ghcr.io/scttfrdmn/substrate:0.85.0 --format '{{.Digest}}'`
+`podman image inspect ghcr.io/scttfrdmn/substrate:0.87.0 --format '{{.Digest}}'`
 instead.
 
 When bumping the pin, change it in **two** places — `docker-compose.substrate.yml`
@@ -182,33 +182,68 @@ provider.
 
 ## Known gaps
 
-Verified by probing substrate `0.85.0` directly, not read off the milestones.
-Three of the four are why part of the suite still uses moto (#183); the
-EventBridge row is a gap this project turns to its advantage rather than one it
-works around.
+Verified by probing substrate `0.87.0` directly, not read off the milestones.
+CloudFormation is why part of the suite still uses moto (#183); the EventBridge
+row is a gap this project turns to its advantage rather than one it works around.
 
 | Gap | Effect | Upstream |
 |---|---|---|
-| CloudFormation is not exposed over HTTP; `create_stack` returns `ServiceNotAvailable` | `DetachedMode`'s bastion stack and six `ServerlessMode` tests that drive `cf_client` cannot run here. `tests/integration/test_serverless_mode_spot_fleet_integration.py` stays on moto for exactly this reason; real coverage is in `tests/aws/` | [substrate#483](https://github.com/scttfrdmn/substrate/issues/483) |
+| CloudFormation stacks reach `CREATE_COMPLETE` having created nothing the caller can find — see below, this is two distinct defects | `tests/integration/test_serverless_mode_spot_fleet_integration.py` and `test_detached_mode_spot_fleet_integration.py` stay on moto; real coverage is in `tests/aws/` | [substrate#483](https://github.com/scttfrdmn/substrate/issues/483) reopened the door; the remainder is unfiled |
 | EventBridge is not emulated; `PutRule` returns `501 service not emulated: awsevents` | The spot-warning notifier's degradation path is testable *because* of this. The warning path itself is covered end to end by wiring an SQS queue directly, since the monitor only ever reads warnings through SQS | — |
-| IAM does not serve AWS-managed policies — `get_policy` on `arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore` returns `NoSuchEntity` (though `attach_role_policy` accepts it) | The unit suite keeps moto with `MOTO_IAM_LOAD_MANAGED_POLICIES=true`, which serves the real policy documents | [substrate#484](https://github.com/scttfrdmn/substrate/issues/484) |
-| The instance-type catalog is partial — `t3.micro` resolves, `m5.xlarge` does not | `describe_instance_capacity` tests stay on moto, which knows the full catalog | [substrate#485](https://github.com/scttfrdmn/substrate/issues/485) |
 
-Not a gap this suite trips over, but recorded because it makes a substrate-backed
-assertion unable to fail: `describe_instance_type_offerings` ignores the
-`instance-type` filter, returning all eight catalog types for any value —
-including one that does not exist, where real AWS returns none. Filed as item 2
-of [substrate#485](https://github.com/scttfrdmn/substrate/issues/485). Do not
-write an offerings-based availability check against the emulator and read a pass
-as meaningful.
+### CloudFormation
 
-CloudFormation is the one to read carefully before assuming it is simply absent:
-substrate *implements* it (`emulator/betty_cfn.go` and ~40
+Read this before assuming CFN either works or is absent — through `0.85.0` it was
+neither. It was *implemented* (`emulator/betty_cfn.go` plus ~40
 `betty_cfn_v*_plugins.go` files, covering parameters, outputs, conditions, change
-sets and drift), but registers no `cloudformation` plugin — `/ready` lists 64
-plugins and none is CFN, and the similarly-named `cfPlugin` is CloudFront. The
-support is reachable only from Go, through the in-process `betty.Deploy` client,
-so no amount of boto3 configuration will find it.
+sets and drift) but registered no `cloudformation` plugin, so `create_stack`
+returned `ServiceNotAvailable` and the support was reachable only from Go, through
+the in-process `betty.Deploy` client. The similarly-named `cfPlugin` is CloudFront.
+
+`0.87.0` registers a real plugin
+([substrate#483](https://github.com/scttfrdmn/substrate/issues/483)), and the whole
+API surface this repo drives works over the wire: `create_stack`, `describe_stacks`
+with `Outputs`, `describe_stack_resources`, `delete_stack`, both waiters,
+`Parameters` and `Capabilities`. `DescribeStackEvents` has no backing event model
+([substrate#501](https://github.com/scttfrdmn/substrate/issues/501)) but nothing
+here calls it.
+
+Two defects behind that surface are why moto stays. Neither is filed upstream yet.
+
+**YAML short-form intrinsics are not resolved.** `!Sub`, `!Ref`, `!If`, `!GetAtt`
+are stripped and the raw scalar used as a literal, while the `Fn::`-prefixed long
+forms are correct — `Fn::Sub: 'x-${P}'` substitutes, `Fn::If` picks the right
+branch on both true and false conditions, but `!Sub 'x-${P}'` yields the physical
+ID `x-${p}`. Every template in `parsl_aws_provider/templates/cloudformation/` uses
+the short forms, so deploying `ecs_worker.yml` produces a task definition whose ARN
+embeds an unevaluated condition array:
+
+```
+arn:aws:ecs:us-east-1:123456789012:task-definition/["HasTaskFamily","TaskFamily","parsl-task-${WorkflowId}-${JobId}"]:1
+```
+
+**Resources are written to a different account than the caller reads.**
+`StackDeployer.dispatch` (`emulator/betty_cfn.go:2847`) synthesises its
+`RequestContext` from the constants `testAccountID` (`123456789012`) and
+`defaultRegion` rather than threading the inbound request's identity. The caller is
+account `000000000000`, so `AWS::EC2::Instance`, `AWS::EC2::LaunchTemplate`,
+`AWS::ECS::Cluster` and `AWS::Logs::LogGroup` all report `CREATE_COMPLETE` with
+plausible physical IDs that resolve nowhere in any region — `describe_instances`
+raises `InvalidInstanceID.NotFound`, `list_clusters` returns empty. A direct
+`run_instances` is visible immediately, so this is not general EC2 breakage; it is
+the same partitioning that
+[substrate#391](https://github.com/scttfrdmn/substrate/issues/391) covered for
+regions. `AWS::IAM::Role` and `AWS::IAM::InstanceProfile` cross the boundary
+intact because IAM is global, which is what makes the split look like missing
+resource handlers rather than one misplaced struct — the handlers exist, and
+`deployEC2Instance` really does dispatch `RunInstances`.
+
+`bastion.yml` needs `AWS::EC2::Instance` and `AWS::EC2::LaunchTemplate`, so
+`DetachedMode` gets a stack it cannot then query. Relatedly, `delete_stack` removes
+the stack record — `describe_stacks` correctly raises `ValidationError` afterwards —
+but not the stack's resources: an S3 bucket and an IAM role both outlive their
+stack. A teardown assertion that only checks the stack is gone passes for the wrong
+reason.
 
 Fixed since, and no longer worked around anywhere:
 
@@ -221,6 +256,8 @@ Fixed since, and no longer worked around anywhere:
 | Fleet instances carried no `aws:ec2:fleet-id` tag, so tests hand-applied it | Substrate stamps it, and now *rejects* manual `aws:`-prefixed keys as reserved — so the old workaround is an error, not merely redundant | [substrate#443](https://github.com/scttfrdmn/substrate/issues/443) |
 | `?publicAccessBlock` was unrouted: `PUT` hit `CreateBucket`, `DELETE` **deleted the bucket** | Routed, so `S3State(create_bucket_if_not_exists=True)` is covered instead of xfailed | [substrate#446](https://github.com/scttfrdmn/substrate/issues/446) |
 | `/health` reported `"version":"dev"` regardless of tag | Reports the real version | [substrate#402](https://github.com/scttfrdmn/substrate/issues/402) |
+| IAM served no service-role managed policies — `get_policy` on `arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore` raised `NoSuchEntity` for an ARN `attach_role_policy` had just accepted | All five this project attaches resolve, with documents and version IDs | [substrate#484](https://github.com/scttfrdmn/substrate/issues/484) |
+| The instance-type catalog held eight hardcoded types (`m5.xlarge` absent), an unknown type returned HTTP 200 + an empty list, and `describe_instance_type_offerings` ignored the `instance-type` filter entirely — so an offerings-based availability assertion could not fail | Every type this project names resolves, unknown types raise `InvalidInstanceType`, and the offerings filter discriminates | [substrate#485](https://github.com/scttfrdmn/substrate/issues/485) |
 
 `RequestSpotFleet` and `RequestSpotInstances` are still unimplemented and are not
 coming back here: #86 moved this provider onto `CreateFleet`, so nothing calls them.


### PR DESCRIPTION
## What

Bumps the substrate emulator pin `0.85.0` → `0.87.0` in
`docker-compose.substrate.yml` and `.github/workflows/ci.yml` together, and
rewrites the CloudFormation section of `docs/substrate_testing.md` to describe
0.87.0's actual behaviour rather than 0.85.0's.

Answers the standing question on #183 — "does substrate now suffice to retire
moto?" — with **not yet, for one reason instead of three**. #183 stays open.

## The three gaps filed from this repo are fixed

All three landed in 0.87.0. Verified on the wire against
`ghcr.io/scttfrdmn/substrate:0.87.0`, not read off the milestone:

| Upstream | Commit | Verification |
|---|---|---|
| [substrate#484](https://github.com/scttfrdmn/substrate/issues/484) | `262b911` | All five service-role managed policies this project attaches resolve through `get_policy` with documents and version IDs — `AmazonSSMManagedInstanceCore` v2, `AmazonEC2ContainerRegistryReadOnly` v3, `AmazonECSTaskExecutionRolePolicy` v1, `AWSLambdaBasicExecutionRole` v1, `AWSLambdaVPCAccessExecutionRole` v3 |
| [substrate#485](https://github.com/scttfrdmn/substrate/issues/485) | `64912ef` | Every instance type this project names is in the catalog; an unknown type raises `InvalidInstanceType` instead of returning 200 + `[]`; `describe_instance_type_offerings` honours its `instance-type` filter — 3 AZs for `m5.xlarge`, 0 for a bogus type |
| [substrate#483](https://github.com/scttfrdmn/substrate/issues/483) | `ff3521a` | A real `cloudformation` plugin is registered (65 plugins, was 64). `create_stack`, `describe_stacks` with `Outputs`, `describe_stack_resources`, `delete_stack`, both waiters, `Parameters` and `Capabilities` all work over HTTP |

The 0.85.0 asymmetry in the first row is worth keeping in mind as a diagnostic
pattern: `attach_role_policy` accepted an ARN that `get_policy` then denied,
which is exactly how an emulator gap reads as a consumer bug.

## Verification

```
tests/integration                     131 passed        (was 130 passed, 1 skipped)
tests/test_substrate_emulation.py       5 passed        (unchanged)
ruff check .                          All checks passed
ruff format --check .                 153 files already formatted
```

No test changed to gain that pass. `tests/conftest.py`'s `cloudformation_available`
probes `/_localstack/health` rather than hardcoding a verdict, so the
`DetachedMode` bastion skip lifted itself the moment substrate#483 shipped — which
is the whole argument for probing over pinning.

## Why moto still stays

Two defects sit *behind* the working CFN API surface. Both are newly found here and
neither is filed upstream; the only open substrate CFN issue is
[#501](https://github.com/scttfrdmn/substrate/issues/501)
(`DescribeStackEvents` has no event model), which this project never calls.

**1. YAML short-form intrinsics are not resolved.** `!Sub`, `!Ref`, `!If`,
`!GetAtt` are stripped and the raw scalar used as a literal. The `Fn::`-prefixed
long forms are correct — `Fn::Sub: 'x-${P}'` substitutes, `Fn::If` picks the right
branch on both a true and a false condition — so this is YAML tag resolution, not
intrinsics. All five templates in `parsl_aws_provider/templates/cloudformation/`
use the short forms (29–47 occurrences each), so deploying `ecs_worker.yml` yields
a task definition whose ARN embeds the unevaluated condition array verbatim:

```
arn:aws:ecs:us-east-1:123456789012:task-definition/["HasTaskFamily","TaskFamily","parsl-task-${WorkflowId}-${JobId}"]:1
```

**2. Stack resources are written to a different account than the caller reads.**
`StackDeployer.dispatch` (`emulator/betty_cfn.go:2847`) synthesises its
`RequestContext` from the constants `testAccountID` (`123456789012`) and
`defaultRegion` instead of threading the inbound request's identity. The caller is
`000000000000`, so `AWS::EC2::Instance`, `AWS::EC2::LaunchTemplate`,
`AWS::ECS::Cluster`, `AWS::ECS::TaskDefinition` and `AWS::Logs::LogGroup` all
report `CREATE_COMPLETE` with plausible physical IDs that resolve nowhere in any
region — `describe_instances` raises `InvalidInstanceID.NotFound`, `list_clusters`
returns `[]`. A direct `run_instances` is visible immediately, so EC2 itself is
fine. `AWS::IAM::Role` and `AWS::IAM::InstanceProfile` cross intact because IAM is
global, and that split is what makes the failure look like missing resource
handlers when the handlers in fact exist and `deployEC2Instance` really does
dispatch `RunInstances`.

`bastion.yml` needs the two broken EC2 types, so `DetachedMode` gets a stack it
cannot query. Secondary: `delete_stack` removes the stack record — `describe_stacks`
correctly raises `ValidationError` afterwards — but not the stack's resources; an S3
bucket and an IAM role both outlived their stack.

Net effect on #183: `moto[cloudformation]>=5.0.0` stays in `pyproject.toml` for the
two integration files that drive stacks
(`test_detached_mode_spot_fleet_integration.py`,
`test_serverless_mode_spot_fleet_integration.py`), plus the standing argument that
the 31 `mock_aws` activations in `tests/unit/` should keep the unit suite
container-free regardless. That is down from three blocking gaps to one.

## Not done here

The two CFN defects are **not filed upstream** — that needs a decision, since the
earlier authorization covered the three gaps that are now closed.
