### PR TITLE
docs: link the two open substrate CFN defects (refs #183)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   CloudFormation still is not a moto replacement, and #183 stays open for it.
   substrate does not resolve YAML short-form intrinsics — `!Sub`, `!Ref`, `!If`
   are stripped and the raw scalar used literally, while the `Fn::` long forms are
-  correct — and `StackDeployer.dispatch` writes resources as account
-  `123456789012` while the caller is `000000000000`. Every template in
+  correct ([substrate#516](https://github.com/scttfrdmn/substrate/issues/516)) —
+  and `StackDeployer.dispatch` writes resources as account `123456789012` while
+  the caller is `000000000000`
+  ([substrate#517](https://github.com/scttfrdmn/substrate/issues/517)). Every template in
   `parsl_aws_provider/templates/cloudformation/` uses the short forms, so a stack
   reaches `CREATE_COMPLETE` having created nothing the caller can query.
   `docs/substrate_testing.md` records both, with the evidence.

--- a/docker-compose.substrate.yml
+++ b/docker-compose.substrate.yml
@@ -61,8 +61,9 @@ services:
     # CFN is still not a moto replacement, for two reasons worth knowing before
     # you try: substrate does not resolve YAML short-form intrinsics (`!Sub`,
     # `!Ref`, `!If` are stripped and the raw scalar used literally, while the
-    # `Fn::` long forms work), and StackDeployer.dispatch writes resources as
-    # account 123456789012 while the caller is 000000000000. A stack built from
+    # `Fn::` long forms work -- substrate#516), and StackDeployer.dispatch writes
+    # resources as account 123456789012 while the caller is 000000000000
+    # (substrate#517). A stack built from
     # any template in templates/cloudformation/ therefore reaches CREATE_COMPLETE
     # having created nothing the caller can find. See docs/substrate_testing.md.
     #

--- a/docs/substrate_testing.md
+++ b/docs/substrate_testing.md
@@ -188,7 +188,7 @@ row is a gap this project turns to its advantage rather than one it works around
 
 | Gap | Effect | Upstream |
 |---|---|---|
-| CloudFormation stacks reach `CREATE_COMPLETE` having created nothing the caller can find — see below, this is two distinct defects | `tests/integration/test_serverless_mode_spot_fleet_integration.py` and `test_detached_mode_spot_fleet_integration.py` stay on moto; real coverage is in `tests/aws/` | [substrate#483](https://github.com/scttfrdmn/substrate/issues/483) reopened the door; the remainder is unfiled |
+| CloudFormation stacks reach `CREATE_COMPLETE` having created nothing the caller can find — see below, this is two distinct defects | `tests/integration/test_serverless_mode_spot_fleet_integration.py` and `test_detached_mode_spot_fleet_integration.py` stay on moto; real coverage is in `tests/aws/` | [substrate#483](https://github.com/scttfrdmn/substrate/issues/483) reopened the door; the remainder is [substrate#516](https://github.com/scttfrdmn/substrate/issues/516) and [substrate#517](https://github.com/scttfrdmn/substrate/issues/517) |
 | EventBridge is not emulated; `PutRule` returns `501 service not emulated: awsevents` | The spot-warning notifier's degradation path is testable *because* of this. The warning path itself is covered end to end by wiring an SQS queue directly, since the monitor only ever reads warnings through SQS | — |
 
 ### CloudFormation
@@ -208,9 +208,10 @@ with `Outputs`, `describe_stack_resources`, `delete_stack`, both waiters,
 ([substrate#501](https://github.com/scttfrdmn/substrate/issues/501)) but nothing
 here calls it.
 
-Two defects behind that surface are why moto stays. Neither is filed upstream yet.
+Two defects behind that surface are why moto stays.
 
-**YAML short-form intrinsics are not resolved.** `!Sub`, `!Ref`, `!If`, `!GetAtt`
+**YAML short-form intrinsics are not resolved**
+([substrate#516](https://github.com/scttfrdmn/substrate/issues/516)). `!Sub`, `!Ref`, `!If`, `!GetAtt`
 are stripped and the raw scalar used as a literal, while the `Fn::`-prefixed long
 forms are correct — `Fn::Sub: 'x-${P}'` substitutes, `Fn::If` picks the right
 branch on both true and false conditions, but `!Sub 'x-${P}'` yields the physical
@@ -222,7 +223,14 @@ embeds an unevaluated condition array:
 arn:aws:ecs:us-east-1:123456789012:task-definition/["HasTaskFamily","TaskFamily","parsl-task-${WorkflowId}-${JobId}"]:1
 ```
 
-**Resources are written to a different account than the caller reads.**
+The cause is upstream of the intrinsics engine, which is why the long forms are
+unaffected: `parseCFNTemplate` (`emulator/betty_cfn.go:3358`) unmarshals directly
+into its template struct with `go.yaml.in/yaml/v3`, and that library has no notion
+of the CloudFormation tag shorthands — it discards the tag and keeps the node value,
+so nothing downstream can tell a `!Sub` string from a literal one.
+
+**Resources are written to a different account than the caller reads**
+([substrate#517](https://github.com/scttfrdmn/substrate/issues/517)).
 `StackDeployer.dispatch` (`emulator/betty_cfn.go:2847`) synthesises its
 `RequestContext` from the constants `testAccountID` (`123456789012`) and
 `defaultRegion` rather than threading the inbound request's identity. The caller is


### PR DESCRIPTION
## What

Follow-up to #208, which had to say "the remainder is unfiled". Both remaining
CloudFormation defects are now filed upstream, so the docs, the CHANGELOG entry and
the compose comment cite them instead.

- **[substrate#516](https://github.com/scttfrdmn/substrate/issues/516)** — YAML
  short-form intrinsics (`!Sub`, `!Ref`, `!If`, `!GetAtt`) are dropped.
- **[substrate#517](https://github.com/scttfrdmn/substrate/issues/517)** —
  `StackDeployer.dispatch` hardcodes account/region, so stack-created EC2 and ECS
  resources are invisible to the caller. Carries the `DeleteStack`-leaves-resources
  finding as a secondary.

## Also: the cause of #516, not just its symptom

#208 recorded the observable behaviour. Reading substrate's source found the
mechanism, and it explains the otherwise-odd shape of the bug — why the `Fn::` long
forms work perfectly while the short forms silently degrade:

`parseCFNTemplate` (`emulator/betty_cfn.go:3358`) unmarshals directly into its
template struct with `go.yaml.in/yaml/v3`. That library has no notion of the
CloudFormation tag shorthands, so it discards the tag and keeps the node value —
after which nothing downstream can distinguish a `!Sub` string from a literal one.
The intrinsics engine is fine; tag resolution never happens.

Verified against the library on its own, independent of substrate:

```go
Short:   !Sub 'x-${P}'        ->  "x-${P}"                      // tag gone, scalar kept
Long:    {Fn::Sub: 'x-${P}'}  ->  {"Fn::Sub": "x-${P}"}          // intact
ShortIf: !If [C, a, b]        ->  ["C","a","b"]                  // tag gone, sequence kept
LongIf:  {Fn::If: [C,a,b]}    ->  {"Fn::If": ["C","a","b"]}      // intact
```

That mattered for the report: it makes the upstream fix concrete (decode into
`yaml.Node`, which preserves `.Tag`, and rewrite tagged nodes before unmarshalling)
rather than leaving substrate to reverse-engineer the cause from a symptom.

## Verification

Documentation only — no code, no test, no dependency change.

```
ruff format --check .    153 files already formatted
```
