### PR TITLE
chore: pin substrate 0.87.1, both CFN defects fixed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
         # 0.76.0 while compose moved to 0.82.0, so CI was validating against an
         # emulator six releases older than the one developers ran. See that file
         # for what each release fixes.
-        image: ghcr.io/scttfrdmn/substrate:0.87.0
+        image: ghcr.io/scttfrdmn/substrate:0.87.1
         ports:
           - 4566:4566
         # No `--health-cmd`. The image is Alpine and ships no curl, and GitHub
@@ -148,7 +148,7 @@ jobs:
         # outstanding -- 46 mode constructions omitted the network IDs #69 made
         # required, so the suite could not pass and gating would have made every
         # PR red. #92 closed in v0.8.0 and the suite is green (131 passed, 0
-        # skipped against substrate 0.87.0 -- 130 passed and 1 skipped on 0.85.0,
+        # skipped against substrate 0.87.1 -- 130 passed and 1 skipped on 0.85.0,
         # the skip being the CloudFormation guard that lifted itself when
         # substrate#483 landed), so the exemption now only hides regressions.
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- **The substrate emulator pin moves `0.85.0` → `0.87.0`**, in
+- **The substrate emulator pin moves `0.85.0` → `0.87.1`**, in
   `docker-compose.substrate.yml` and `.github/workflows/ci.yml` together. 0.87.0
   carries all three fixes filed from this repo while probing 0.85.0, and the
   integration suite goes from **130 passed / 1 skipped** to **131 passed / 0
@@ -30,16 +30,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `cloudformation` plugin is registered. Through 0.85.0 CFN was implemented but
     unrouted, reachable only from Go via `betty.Deploy`.
 
-  CloudFormation still is not a moto replacement, and #183 stays open for it.
-  substrate does not resolve YAML short-form intrinsics — `!Sub`, `!Ref`, `!If`
-  are stripped and the raw scalar used literally, while the `Fn::` long forms are
-  correct ([substrate#516](https://github.com/scttfrdmn/substrate/issues/516)) —
-  and `StackDeployer.dispatch` writes resources as account `123456789012` while
-  the caller is `000000000000`
-  ([substrate#517](https://github.com/scttfrdmn/substrate/issues/517)). Every template in
-  `parsl_aws_provider/templates/cloudformation/` uses the short forms, so a stack
-  reaches `CREATE_COMPLETE` having created nothing the caller can query.
-  `docs/substrate_testing.md` records both, with the evidence.
+  0.87.0's CloudFormation was still not a moto replacement, for two further
+  defects also filed from here — and **0.87.1 fixes both**, which is why the pin
+  lands on `.1` rather than `.0`:
+
+  - [substrate#516](https://github.com/scttfrdmn/substrate/issues/516) — YAML
+    short-form intrinsics were stripped and the raw scalar used literally, while
+    the `Fn::` long forms were correct. Every template in
+    `parsl_aws_provider/templates/cloudformation/` uses the short forms, so a
+    stack reached `CREATE_COMPLETE` with an unevaluated `!If` array embedded in an
+    ECS task-definition ARN. The cause was upstream of the intrinsics engine:
+    `parseCFNTemplate` unmarshals with `go.yaml.in/yaml/v3`, which has no notion
+    of the CloudFormation tag shorthands.
+  - [substrate#517](https://github.com/scttfrdmn/substrate/issues/517) —
+    `StackDeployer.dispatch` synthesised its request context from constants, so
+    resources were written as account `123456789012` while the caller read
+    `000000000000`. EC2, ECS and Logs partition their state keys by account and
+    region and so were unreachable; S3 and IAM do not, and crossed the boundary
+    invisibly.
+
+  The consequence is larger than a bug count: **`bastion.yml` now deploys against
+  substrate end to end** — the `AWS::EC2::Instance` resolves its `ImageId` through
+  the launch template, the instance is queryable, and `Outputs` are correct. That
+  is precisely the case moto cannot do, since its CloudFormation handler reads
+  `properties["ImageId"]` directly and raises `KeyError` on a stack real
+  CloudFormation accepts. On the bastion path substrate is now ahead of moto
+  rather than behind it.
+
+  #183 stays open, but for a narrower set:
+  [substrate#521](https://github.com/scttfrdmn/substrate/issues/521) (`Fn::Split`
+  yields only its first element),
+  [substrate#526](https://github.com/scttfrdmn/substrate/issues/526) (an intrinsic
+  nested in a structured property is never resolved) and
+  [substrate#527](https://github.com/scttfrdmn/substrate/issues/527) (a
+  CFN-deployed task definition's `ContainerDefinitions` keep PascalCase keys, so
+  `describe_task_definition` returns `[{}]`) — all three hitting `ecs_worker.yml`.
+  `docs/substrate_testing.md` records the evidence for each.
 - **`ruff` floor raised to `0.16.0`, and the lint rule selection made explicit.**
   0.16.0 changed the *implicit* default rule set from 59 rules to 413, which is a
   breaking change for any project that never wrote a `select` — and this was one.

--- a/docker-compose.substrate.yml
+++ b/docker-compose.substrate.yml
@@ -58,19 +58,29 @@ services:
     #     itself: tests/conftest.py probes /_localstack/health rather than
     #     hardcoding a version.
     #
-    # CFN is still not a moto replacement, for two reasons worth knowing before
-    # you try: substrate does not resolve YAML short-form intrinsics (`!Sub`,
-    # `!Ref`, `!If` are stripped and the raw scalar used literally, while the
-    # `Fn::` long forms work -- substrate#516), and StackDeployer.dispatch writes
-    # resources as account 123456789012 while the caller is 000000000000
-    # (substrate#517). A stack built from
-    # any template in templates/cloudformation/ therefore reaches CREATE_COMPLETE
-    # having created nothing the caller can find. See docs/substrate_testing.md.
+    # 0.87.1 fixes both of the CloudFormation defects 0.87.0 still had, again
+    # filed from here: substrate#516 (YAML short-form intrinsics `!Sub`/`!Ref`/
+    # `!If` were stripped and the raw scalar used literally) and substrate#517
+    # (StackDeployer.dispatch wrote resources as account 123456789012 while the
+    # caller read 000000000000). Both are verified against this image, and the
+    # consequence is bigger than a bug count: bastion.yml now deploys here
+    # end to end -- the AWS::EC2::Instance resolves its ImageId through the
+    # launch template, the instance is queryable, Outputs are correct. That is
+    # the exact case moto cannot do (its CFN handler reads properties["ImageId"]
+    # directly and raises KeyError), so on the bastion path substrate is now
+    # ahead of moto rather than behind it.
+    #
+    # What still keeps moto is narrower and no longer about CFN's core:
+    # substrate#521 (Fn::Split yields only its first element), substrate#526 (an
+    # intrinsic nested in a structured property is never resolved) and
+    # substrate#527 (a CFN-deployed task definition's ContainerDefinitions keep
+    # PascalCase keys, so describe_task_definition returns [{}]). All three hit
+    # ecs_worker.yml. See docs/substrate_testing.md.
     #
     # Verify a bump reaches the image, not just the git tag: substrate cuts
     # release commits, so a merged fix sits on `main` after the newest tag and is
     # invisible to this pin. `git tag --contains <sha>` is the check.
-    image: ghcr.io/scttfrdmn/substrate:0.87.0
+    image: ghcr.io/scttfrdmn/substrate:0.87.1
     container_name: parsl-substrate
     ports:
       - "4566:4566"

--- a/docs/substrate_testing.md
+++ b/docs/substrate_testing.md
@@ -37,12 +37,12 @@ any step ran.
 The compose file is pinned to a specific image tag, deliberately — an emulator that
 silently changes under CI turns an unrelated PR red.
 
-`/health` reports the real version since 0.85.0 — `{"status":"ok","version":"v0.87.0"}` —
+`/health` reports the real version since 0.85.0 — `{"status":"ok","version":"v0.87.1"}` —
 so `make substrate-status` is enough to confirm the pin. Released images used to
 report `"version":"dev"` whatever their tag
 ([substrate#402](https://github.com/scttfrdmn/substrate/issues/402)); against an
 older image, use
-`podman image inspect ghcr.io/scttfrdmn/substrate:0.87.0 --format '{{.Digest}}'`
+`podman image inspect ghcr.io/scttfrdmn/substrate:0.87.1 --format '{{.Digest}}'`
 instead.
 
 When bumping the pin, change it in **two** places — `docker-compose.substrate.yml`
@@ -182,13 +182,18 @@ provider.
 
 ## Known gaps
 
-Verified by probing substrate `0.87.0` directly, not read off the milestones.
-CloudFormation is why part of the suite still uses moto (#183); the EventBridge
-row is a gap this project turns to its advantage rather than one it works around.
+Verified by probing substrate `0.87.1` directly, not read off the milestones.
+The remaining CloudFormation rows are why one file still uses moto (#183); the
+EventBridge row is a gap this project turns to its advantage rather than one it
+works around.
 
 | Gap | Effect | Upstream |
 |---|---|---|
-| CloudFormation stacks reach `CREATE_COMPLETE` having created nothing the caller can find — see below, this is two distinct defects | `tests/integration/test_serverless_mode_spot_fleet_integration.py` and `test_detached_mode_spot_fleet_integration.py` stay on moto; real coverage is in `tests/aws/` | [substrate#483](https://github.com/scttfrdmn/substrate/issues/483) reopened the door; the remainder is [substrate#516](https://github.com/scttfrdmn/substrate/issues/516) and [substrate#517](https://github.com/scttfrdmn/substrate/issues/517) |
+| `Fn::Split` resolves to its first element only | `ecs_worker.yml:208` uses `!Split [',', !Ref Command]` for a container command, so a multi-element command silently loses everything after the first item | [substrate#521](https://github.com/scttfrdmn/substrate/issues/521) |
+| An intrinsic nested inside a structured property is never resolved | The same `Command`, nested in `ContainerDefinitions`, is not walked into. `AWS::EC2::LaunchTemplate` resolves nested intrinsics because its deploy path enumerates them explicitly, so this is per-property rather than general | [substrate#526](https://github.com/scttfrdmn/substrate/issues/526) |
+| A CFN-deployed task definition's `ContainerDefinitions` keep CloudFormation's PascalCase keys | `describe_task_definition` returns `containerDefinitions: [{}]` — family, revision, cpu, memory and the ARN are all correct, only the container list reads empty | [substrate#527](https://github.com/scttfrdmn/substrate/issues/527) |
+| CloudWatch Logs read operations return PascalCase members | `describe_log_groups`, `describe_log_streams` and `get_log_events` put `LogGroupName`/`ARN`/`CreationTime` on the wire where the JSON 1.1 API uses `logGroupName`/`arn`/`creationTime`, so botocore parses every field to `None` and a caller sees `[{}]`. `filter_log_events` is correct, which makes it an inconsistency inside one plugin. Affects a directly-created group too, so it is not CFN-specific | unfiled |
+| `DeleteStack` does not delete the stack's resources | The stack record goes and `describe_stacks` then raises `ValidationError` correctly, but an S3 bucket and an IAM role both outlive their stack. A teardown assertion that only checks the stack passes for the wrong reason | [substrate#518](https://github.com/scttfrdmn/substrate/issues/518) |
 | EventBridge is not emulated; `PutRule` returns `501 service not emulated: awsevents` | The spot-warning notifier's degradation path is testable *because* of this. The warning path itself is covered end to end by wiring an SQS queue directly, since the monitor only ever reads warnings through SQS | — |
 
 ### CloudFormation
@@ -208,50 +213,51 @@ with `Outputs`, `describe_stack_resources`, `delete_stack`, both waiters,
 ([substrate#501](https://github.com/scttfrdmn/substrate/issues/501)) but nothing
 here calls it.
 
-Two defects behind that surface are why moto stays.
+`0.87.0` had two further defects behind that surface, both filed from here and both
+fixed in **`0.87.1`**. They are worth keeping on record, because each one failed
+*silently with a success status* — the shape of bug that a green suite hides:
 
-**YAML short-form intrinsics are not resolved**
-([substrate#516](https://github.com/scttfrdmn/substrate/issues/516)). `!Sub`, `!Ref`, `!If`, `!GetAtt`
-are stripped and the raw scalar used as a literal, while the `Fn::`-prefixed long
-forms are correct — `Fn::Sub: 'x-${P}'` substitutes, `Fn::If` picks the right
-branch on both true and false conditions, but `!Sub 'x-${P}'` yields the physical
-ID `x-${p}`. Every template in `parsl_aws_provider/templates/cloudformation/` uses
-the short forms, so deploying `ecs_worker.yml` produces a task definition whose ARN
-embeds an unevaluated condition array:
+- **YAML short-form intrinsics were not resolved**
+  ([substrate#516](https://github.com/scttfrdmn/substrate/issues/516)) — `!Sub`,
+  `!Ref`, `!If`, `!GetAtt` were stripped and the raw scalar used as a literal, while
+  the `Fn::` long forms were correct. The cause sat upstream of the intrinsics
+  engine, which is why the long forms were unaffected: `parseCFNTemplate` unmarshals
+  with `go.yaml.in/yaml/v3`, which has no notion of the CloudFormation tag
+  shorthands and so discarded the tag and kept the node value.
+- **Resources were written to a different account than the caller read**
+  ([substrate#517](https://github.com/scttfrdmn/substrate/issues/517)) —
+  `StackDeployer.dispatch` synthesised its `RequestContext` from constants, so a
+  stack ARN said `000000000000` while its contents lived in `123456789012`. EC2, ECS
+  and Logs partition their state keys by account and region and so were unreachable;
+  S3 and IAM do not and crossed the boundary invisibly, which is what made it look
+  like the EC2 resource handlers were missing when they were not.
 
-```
-arn:aws:ecs:us-east-1:123456789012:task-definition/["HasTaskFamily","TaskFamily","parsl-task-${WorkflowId}-${JobId}"]:1
-```
+**The upshot for `bastion.yml` is that substrate is now ahead of moto, not behind
+it.** The full template deploys against `0.87.1`: `AWS::EC2::Instance` resolves its
+`ImageId` through `AWS::EC2::LaunchTemplate`, the instance is queryable with
+`describe_instances`, and `Outputs` resolve — `BastionHostId` returns the real
+`i-…`. moto cannot do this at all: its CloudFormation handler for
+`AWS::EC2::Instance` reads `properties["ImageId"]` directly
+(`moto/ec2/models/instances.py:400`) and resolves no launch template, so it raises
+`KeyError: 'ImageId'` on a stack real CloudFormation accepts. That is why
+`test_detached_mode_spot_fleet_integration.py` passes `bastion_host_type="direct"`;
+the CloudFormation bastion path is a candidate to move onto substrate now.
 
-The cause is upstream of the intrinsics engine, which is why the long forms are
-unaffected: `parseCFNTemplate` (`emulator/betty_cfn.go:3358`) unmarshals directly
-into its template struct with `go.yaml.in/yaml/v3`, and that library has no notion
-of the CloudFormation tag shorthands — it discards the tag and keeps the node value,
-so nothing downstream can tell a `!Sub` string from a literal one.
+Two related fixes shipped in `0.87.1` alongside those, both found upstream while
+fixing #516 and each worth knowing:
 
-**Resources are written to a different account than the caller reads**
-([substrate#517](https://github.com/scttfrdmn/substrate/issues/517)).
-`StackDeployer.dispatch` (`emulator/betty_cfn.go:2847`) synthesises its
-`RequestContext` from the constants `testAccountID` (`123456789012`) and
-`defaultRegion` rather than threading the inbound request's identity. The caller is
-account `000000000000`, so `AWS::EC2::Instance`, `AWS::EC2::LaunchTemplate`,
-`AWS::ECS::Cluster` and `AWS::Logs::LogGroup` all report `CREATE_COMPLETE` with
-plausible physical IDs that resolve nowhere in any region — `describe_instances`
-raises `InvalidInstanceID.NotFound`, `list_clusters` returns empty. A direct
-`run_instances` is visible immediately, so this is not general EC2 breakage; it is
-the same partitioning that
-[substrate#391](https://github.com/scttfrdmn/substrate/issues/391) covered for
-regions. `AWS::IAM::Role` and `AWS::IAM::InstanceProfile` cross the boundary
-intact because IAM is global, which is what makes the split look like missing
-resource handlers rather than one misplaced struct — the handlers exist, and
-`deployEC2Instance` really does dispatch `RunInstances`.
+- A plugin's 4xx *response* with a nil Go error was neither an error nor a status
+  ([substrate#519](https://github.com/scttfrdmn/substrate/issues/519)), so **every
+  S3 and IAM resource failure in a stack was swallowed** and reported
+  `CREATE_COMPLETE`. Now such a resource reports `CREATE_FAILED` — a behaviour
+  change to be aware of when reading a stack status against `0.87.1` or later.
+- `Default: ''` was treated as no default at all, which **inverted**
+  `!Not [!Equals [!Ref X, '']]`. That idiom is how an optional parameter is spelled
+  and appears 21 times across this project's five templates, so it would have bitten
+  immediately once #516 landed.
 
-`bastion.yml` needs `AWS::EC2::Instance` and `AWS::EC2::LaunchTemplate`, so
-`DetachedMode` gets a stack it cannot then query. Relatedly, `delete_stack` removes
-the stack record — `describe_stacks` correctly raises `ValidationError` afterwards —
-but not the stack's resources: an S3 bucket and an IAM role both outlive their
-stack. A teardown assertion that only checks the stack is gone passes for the wrong
-reason.
+Substrate still does not roll a failed stack back
+([substrate#520](https://github.com/scttfrdmn/substrate/issues/520)).
 
 Fixed since, and no longer worked around anywhere:
 


### PR DESCRIPTION
Bumps the substrate pin `0.87.0` → `0.87.1`, in `docker-compose.substrate.yml` and `.github/workflows/ci.yml` together.

## Both CFN defects filed from here are fixed

0.87.1 closes [substrate#516](https://github.com/scttfrdmn/substrate/issues/516) (PR 523) and [substrate#517](https://github.com/scttfrdmn/substrate/issues/517) (PR 524), the two defects this repo filed while probing 0.87.0.

I verified each on the wire against `ghcr.io/scttfrdmn/substrate:0.87.1` rather than trusting the closing comments:

| Was | Now |
|---|---|
| `!Sub 'short-${p}'` → physical ID `short-${p}` | → `short-live` |
| depth-3 `!If [HasVpc, !Sub …, !Sub …]` over `!Not [!Equals [!Ref VpcId, '']]` | picks the correct branch (`none-zz`) |
| `describe_instances(InstanceIds=[i-…])` → `InvalidInstanceID.NotFound` | resolves; also present in `describe_instances()` |
| `ecs_worker.yml` physical IDs carried unevaluated intrinsic arrays | `parsl-cluster-wf1`, `/aws/ecs/parsl-wf1-job1`, `arn:aws:ecs:us-east-1:000000000000:task-definition/parsl-task-wf1-job1:1` |

## The headline: `bastion.yml` deploys, and moto cannot do it

The full bastion template now reaches `CREATE_COMPLETE` on substrate with every resource queryable:

```
BastionHostRole             AWS::IAM::Role             CREATE_COMPLETE
BastionHostInstanceProfile  AWS::IAM::InstanceProfile  CREATE_COMPLETE
BastionHost                 AWS::EC2::Instance         CREATE_COMPLETE  i-54403211e020067d
BastionLaunchTemplate       AWS::EC2::LaunchTemplate   CREATE_COMPLETE  lt-0cba00c51226e275
Outputs: BastionHostId=i-54403211e020067d, BastionHostRoleArn=arn:aws:iam::000000000000:role/BastionHostRole
```

That is exactly the case **moto cannot handle**: since #86 `bastion.yml` puts `ImageId` in a launch template and has the `AWS::EC2::Instance` reference it, and moto's CFN handler reads `properties["ImageId"]` directly (`moto/ec2/models/instances.py:400`), resolving no launch template — it raises `KeyError: 'ImageId'` on a stack real CloudFormation accepts. That `KeyError` is the documented reason `test_detached_mode_spot_fleet_integration.py` passes `bastion_host_type="direct"`.

So on the bastion path substrate has overtaken moto. Worth recording plainly: CFN was never what kept that file on moto — the launch-template indirection was, and substrate now handles it.

## Two upstream fixes that change how a stack status reads

Both were found while fixing #516 and both ship in 0.87.1:

- A plugin's 4xx *response* with a nil Go error was neither an error nor a status ([substrate#519](https://github.com/scttfrdmn/substrate/issues/519)), so **every S3 and IAM resource failure in a stack was swallowed** and reported `CREATE_COMPLETE`. Such a resource now correctly reports `CREATE_FAILED`.
- `Default: ''` was treated as no default at all, which **inverted** `!Not [!Equals [!Ref X, '']]` — the idiom that spells an optional parameter, appearing 21 times across this project's five templates. It would have bitten immediately once #516 landed.

## What still keeps moto (#183 stays open)

Narrower than before, and no longer about CloudFormation's core. All three hit `ecs_worker.yml`:

- [substrate#521](https://github.com/scttfrdmn/substrate/issues/521) — `Fn::Split` resolves to its first element only
- [substrate#526](https://github.com/scttfrdmn/substrate/issues/526) — an intrinsic nested in a structured property is never resolved
- [substrate#527](https://github.com/scttfrdmn/substrate/issues/527) — a CFN-deployed task definition's `ContainerDefinitions` keep PascalCase keys, so `describe_task_definition` returns `containerDefinitions: [{}]`

Also newly found and recorded in the gaps table as **unfiled**: CloudWatch Logs read operations (`describe_log_groups`, `describe_log_streams`, `get_log_events`) put PascalCase members on the wire where the JSON 1.1 API uses camelCase, so botocore parses every field to `None` and the caller sees `[{}]`. `filter_log_events` is correct, making it an inconsistency inside one plugin; a directly-created log group fails identically, so it is not CFN-specific and not covered by #527.

## Verification

- `tests/integration`: **131 passed, 0 skipped** against 0.87.1 — identical to 0.87.0, so this is a no-regression bump
- `ruff check .` and `ruff format --check .` clean
- `/health` on the pinned image reports `{"status":"ok","version":"v0.87.1"}`

Docs: `docs/substrate_testing.md`'s "Known gaps" table is rewritten to six rows and the CloudFormation prose recast so #516/#517 read as fixed rather than current — the same contradiction #209 had to correct once already.

Refs #183
