### PR TITLE
build: drop the placeholder author email from package metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,8 +42,15 @@ license = "Apache-2.0"
 # .dist-info/licenses/ and in the sdist. NOTICE carries the independent-project
 # disclaimer and the AWS/Parsl/Globus trademark attribution (#189).
 license-files = ["LICENSE", "NOTICE"]
+# Name only, no email. This carried a placeholder address that would have shipped
+# in the wheel's METADATA as an Author-email header -- worse than absent, because
+# tooling treats it as a real contact. PEP 621 makes `email` optional, so omitting
+# the key is valid and leaves METADATA carrying `Author` alone. Security reports go
+# through the private GitHub advisory path in SECURITY.md, not to a maintainer
+# mailbox, so no address is load-bearing. Verified against a built wheel and sdist:
+# neither PKG-INFO nor METADATA emits an Author-email line.
 authors = [
-    {name = "Scott Friedman and Project Contributors", email = "email@example.com"}
+    {name = "Scott Friedman and Project Contributors"}
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",


### PR DESCRIPTION
One-line metadata fix, plus the verification that it actually reaches the artifacts.

`authors` carried `email@example.com`. setuptools emits that as an `Author-email` header in **both** the wheel `METADATA` and the sdist `PKG-INFO`, so it would have shipped as a real-looking maintainer contact the moment this package was first published — worse than no address, because tooling and mirrors treat it as reachable.

PEP 621 makes `email` optional inside an `authors` entry, so the key is omitted rather than filled in. Verified against a real build rather than assumed:

```
$ uv build && <read the artifacts>
Name: parsl-aws-provider
Version: 0.8.0
Author: Scott Friedman and Project Contributors
```

No `Author-email` line in either `METADATA` or `PKG-INFO`.

No address is load-bearing here — security reports go through the private GitHub advisory path in `SECURITY.md`, not a maintainer mailbox.

One detail worth noting: my first draft of the explanatory comment quoted the placeholder string literally, which put `example.com` back into the shipped sdist (`pyproject.toml` is packaged verbatim) and would have tripped any future grep or secret/PII scanner. Reworded to describe it instead. Caught by grepping the extracted sdist rather than trusting the diff.

The two remaining `example.com` strings in the tree are illustrative `additional_tags` values inside code samples (`SECURITY.md:123`, `docs/security.md:357`), where a placeholder is the correct thing to show. Not metadata, left alone.

Refs #180