### PR TITLE
chore: bump the substrate pin to 0.88.0, closing the ecs_worker.yml gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
         # 0.76.0 while compose moved to 0.82.0, so CI was validating against an
         # emulator six releases older than the one developers ran. See that file
         # for what each release fixes.
-        image: ghcr.io/scttfrdmn/substrate:0.87.1
+        image: ghcr.io/scttfrdmn/substrate:0.88.0
         ports:
           - 4566:4566
         # No `--health-cmd`. The image is Alpine and ships no curl, and GitHub

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **The substrate emulator pin moves `0.87.1` → `0.88.0`**, in
+  `docker-compose.substrate.yml` and `.github/workflows/ci.yml` together. This
+  closes the last four emulation gaps filed from this repository, each verified
+  against the image rather than read from the changelog:
+
+  - [substrate#521](https://github.com/scttfrdmn/substrate/issues/521) —
+    `Fn::Split` yielded only its first element, silently dropping the rest. An
+    `Fn::Select` of index 2 over a three-element split now returns the third.
+  - [substrate#526](https://github.com/scttfrdmn/substrate/issues/526) — an
+    intrinsic nested inside a structured property was never resolved. An
+    `Fn::Sub` within a `ContainerDefinitions` entry now resolves.
+  - [substrate#527](https://github.com/scttfrdmn/substrate/issues/527) — a
+    CloudFormation-deployed task definition kept CloudFormation's PascalCase
+    keys, so `describe_task_definition` returned `[{}]`. It now parses to
+    camelCase.
+  - [substrate#528](https://github.com/scttfrdmn/substrate/issues/528) — Logs
+    returned PascalCase members, so an SDK parsed every field to `null`.
+
+  The first three are the `ecs_worker.yml` path, which is what #183 was waiting
+  on. Suite counts are unchanged — integration **131 passed**, conformance
+  **5 passed**, unit and security **1202 passed / 3 skipped** — so this is a
+  substrate capability gain, not a test-behaviour change.
+
+  Worth recording for the next bump: substrate#446, the issue the v0.9.0 hold was
+  placed on, actually shipped in **0.85.0** rather than in the release that closed
+  its issue. `git tag --contains <sha>` on the fixing commit is the reliable
+  check; the issue's close date is not.
 - **The substrate emulator pin moves `0.85.0` → `0.87.1`**, in
   `docker-compose.substrate.yml` and `.github/workflows/ci.yml` together. 0.87.0
   carries all three fixes filed from this repo while probing 0.85.0, and the

--- a/docker-compose.substrate.yml
+++ b/docker-compose.substrate.yml
@@ -70,17 +70,23 @@ services:
     # directly and raises KeyError), so on the bastion path substrate is now
     # ahead of moto rather than behind it.
     #
-    # What still keeps moto is narrower and no longer about CFN's core:
-    # substrate#521 (Fn::Split yields only its first element), substrate#526 (an
-    # intrinsic nested in a structured property is never resolved) and
-    # substrate#527 (a CFN-deployed task definition's ContainerDefinitions keep
-    # PascalCase keys, so describe_task_definition returns [{}]). All three hit
-    # ecs_worker.yml. See docs/substrate_testing.md.
+    # 0.88.0 closes the last four gaps that kept moto, all filed from here and all
+    # verified against this image rather than taken from the changelog:
+    # substrate#521 (Fn::Split yielded only its first element -- an Fn::Select of
+    # index 2 now returns the third), substrate#526 (an intrinsic nested inside a
+    # structured property was never resolved -- a Fn::Sub in a
+    # ContainerDefinitions entry now resolves), substrate#527 (a CFN-deployed task
+    # definition's ContainerDefinitions kept PascalCase keys, so
+    # describe_task_definition returned [{}] -- it now parses to camelCase) and
+    # substrate#528 (Logs returned PascalCase members, so every field parsed to
+    # null). The first three are the ecs_worker.yml path; see #183 for what
+    # retiring moto now depends on, and docs/substrate_testing.md.
     #
     # Verify a bump reaches the image, not just the git tag: substrate cuts
     # release commits, so a merged fix sits on `main` after the newest tag and is
-    # invisible to this pin. `git tag --contains <sha>` is the check.
-    image: ghcr.io/scttfrdmn/substrate:0.87.1
+    # invisible to this pin. `git tag --contains <sha>` is the check -- and note
+    # #446 landed in 0.85.0, not in the release that closed its issue.
+    image: ghcr.io/scttfrdmn/substrate:0.88.0
     container_name: parsl-substrate
     ports:
       - "4566:4566"

--- a/docs/substrate_testing.md
+++ b/docs/substrate_testing.md
@@ -37,12 +37,12 @@ any step ran.
 The compose file is pinned to a specific image tag, deliberately — an emulator that
 silently changes under CI turns an unrelated PR red.
 
-`/health` reports the real version since 0.85.0 — `{"status":"ok","version":"v0.87.1"}` —
+`/health` reports the real version since 0.85.0 — `{"status":"ok","version":"v0.88.0"}` —
 so `make substrate-status` is enough to confirm the pin. Released images used to
 report `"version":"dev"` whatever their tag
 ([substrate#402](https://github.com/scttfrdmn/substrate/issues/402)); against an
 older image, use
-`podman image inspect ghcr.io/scttfrdmn/substrate:0.87.1 --format '{{.Digest}}'`
+`podman image inspect ghcr.io/scttfrdmn/substrate:0.88.0 --format '{{.Digest}}'`
 instead.
 
 When bumping the pin, change it in **two** places — `docker-compose.substrate.yml`
@@ -182,19 +182,30 @@ provider.
 
 ## Known gaps
 
-Verified by probing substrate `0.87.1` directly, not read off the milestones.
-The remaining CloudFormation rows are why one file still uses moto (#183); the
-EventBridge row is a gap this project turns to its advantage rather than one it
-works around.
+Verified by probing substrate `0.88.0` directly, not read off the milestones.
+**`0.88.0` closed the four gaps that kept `ecs_worker.yml` on moto** — see the
+resolved list below — so `DeleteStack` is the only CloudFormation row left, and it
+is a teardown-assertion hazard rather than a blocker. The EventBridge row is a gap
+this project turns to its advantage rather than one it works around.
 
 | Gap | Effect | Upstream |
 |---|---|---|
-| `Fn::Split` resolves to its first element only | `ecs_worker.yml:208` uses `!Split [',', !Ref Command]` for a container command, so a multi-element command silently loses everything after the first item | [substrate#521](https://github.com/scttfrdmn/substrate/issues/521) |
-| An intrinsic nested inside a structured property is never resolved | The same `Command`, nested in `ContainerDefinitions`, is not walked into. `AWS::EC2::LaunchTemplate` resolves nested intrinsics because its deploy path enumerates them explicitly, so this is per-property rather than general | [substrate#526](https://github.com/scttfrdmn/substrate/issues/526) |
-| A CFN-deployed task definition's `ContainerDefinitions` keep CloudFormation's PascalCase keys | `describe_task_definition` returns `containerDefinitions: [{}]` — family, revision, cpu, memory and the ARN are all correct, only the container list reads empty | [substrate#527](https://github.com/scttfrdmn/substrate/issues/527) |
-| CloudWatch Logs read operations return PascalCase members | `describe_log_groups`, `describe_log_streams` and `get_log_events` put `LogGroupName`/`ARN`/`CreationTime` on the wire where the JSON 1.1 API uses `logGroupName`/`arn`/`creationTime`, so botocore parses every field to `None` and a caller sees `[{}]` — with HTTP 200 and no error. `filter_log_events` is correct, which makes it an inconsistency inside one plugin. Affects a directly-created group too, so it is not CFN-specific. Blocks *verifying* `compute/ecs.py`'s log-group create (`:377`) and cleanup (`:829`), both of which work — a cleanup assertion can only check the returned count, which passes for the wrong reason. `PutRetentionPolicy` is unimplemented, noted on the same issue | [substrate#528](https://github.com/scttfrdmn/substrate/issues/528) |
-| `DeleteStack` does not delete the stack's resources | The stack record goes and `describe_stacks` then raises `ValidationError` correctly, but an S3 bucket and an IAM role both outlive their stack. A teardown assertion that only checks the stack passes for the wrong reason | [substrate#518](https://github.com/scttfrdmn/substrate/issues/518) |
+| `DeleteStack` does not delete the stack's resources | The stack record goes and `describe_stacks` then raises `ValidationError` correctly, but an S3 bucket and an IAM role both outlive their stack. A teardown assertion that only checks the stack passes for the wrong reason. Re-probed against `0.88.0`: a CFN-created bucket is still listed after `DeleteStack` | [substrate#518](https://github.com/scttfrdmn/substrate/issues/518) |
 | EventBridge is not emulated; `PutRule` returns `501 service not emulated: awsevents` | The spot-warning notifier's degradation path is testable *because* of this. The warning path itself is covered end to end by wiring an SQS queue directly, since the monitor only ever reads warnings through SQS | — |
+
+### Closed in `0.88.0`
+
+All four were filed from this repository and each was re-probed against the image
+before this list was written — a closed issue is not the same as a released fix, and
+substrate cuts release commits, so a merged fix can sit on `main` past the newest
+tag.
+
+| Was | Now | Upstream |
+|---|---|---|
+| `Fn::Split` resolved to its first element only, so `ecs_worker.yml:208`'s `!Split [',', !Ref Command]` silently lost everything after the first item | An `Fn::Select` of index 2 over a three-element split returns the third element | [substrate#521](https://github.com/scttfrdmn/substrate/issues/521) |
+| An intrinsic nested inside a structured property was never resolved — the same `Command`, nested in `ContainerDefinitions`, was not walked into | An `Fn::Sub` inside a `ContainerDefinitions` entry resolves | [substrate#526](https://github.com/scttfrdmn/substrate/issues/526) |
+| A CFN-deployed task definition's `ContainerDefinitions` kept CloudFormation's PascalCase keys, so `describe_task_definition` returned `containerDefinitions: [{}]` | The container list parses to camelCase and reads back complete | [substrate#527](https://github.com/scttfrdmn/substrate/issues/527) |
+| CloudWatch Logs read operations returned PascalCase members, so botocore parsed every field to `None` and a caller saw `[{}]` with HTTP 200 and no error | `describe_log_groups` and `get_log_events` round-trip correctly, which unblocks *verifying* `compute/ecs.py`'s log-group create (`:377`) and cleanup (`:829`) rather than asserting on a count that passed for the wrong reason. `PutRetentionPolicy` was noted on the same issue — check it before relying on it | [substrate#528](https://github.com/scttfrdmn/substrate/issues/528) |
 
 ### CloudFormation
 


### PR DESCRIPTION
## What

Moves the substrate emulator pin `0.87.1` → `0.88.0` in both places that hold it —
`docker-compose.substrate.yml` and `services.substrate.image` in
`.github/workflows/ci.yml` — plus the CHANGELOG and `docs/substrate_testing.md`.

## Why it matters

0.88.0 closes the **last four emulation gaps filed from this repository**, three of
which are the `ecs_worker.yml` path that #183 was waiting on. That issue's upstream
blockers are now all closed and released.

## How each was verified

Probed against the running image, not read from the changelog — a closed issue is
not a released fix. substrate cuts release commits, so a merged fix can sit on
`main` past the newest tag.

| Upstream | Was | Verified on 0.88.0 |
|---|---|---|
| [#521](https://github.com/scttfrdmn/substrate/issues/521) | `Fn::Split` yielded only its first element | `Fn::Select` of index 2 over a three-element split returns `c` |
| [#526](https://github.com/scttfrdmn/substrate/issues/526) | an intrinsic nested in a structured property was never resolved | an `Fn::Sub` inside `ContainerDefinitions` resolves to `public.ecr.aws/000000000000/img:latest` |
| [#527](https://github.com/scttfrdmn/substrate/issues/527) | task-def `ContainerDefinitions` kept PascalCase, so `describe_task_definition` returned `[{}]` | parses to camelCase, complete: `[{'name': 'worker', 'image': …, 'command': ['a','b','c']}]` |
| [#528](https://github.com/scttfrdmn/substrate/issues/528) | Logs returned PascalCase, so every field parsed to `null` | `describe_log_groups` and `get_log_events` round-trip |

## Suite results

Counts are **unchanged**, which is the point — this is a substrate capability gain,
not a change in test behaviour.

- `tests/integration` — **131 passed**
- `tests/test_substrate_emulation.py` — **5 passed**
- `tests/unit tests/security` — **1202 passed / 3 skipped**
- ruff clean, 153 files formatted, `sphinx-build -W` clean
- `/health` on the new pin reports `{"status":"ok","version":"v0.88.0"}`

## Two things worth recording

**substrate#446 shipped in 0.85.0, not in the release that closed it.** It closed
2026-08-01, and the v0.9.0 hold was placed on it — but `git tag --contains` on the
fixing commit puts it three releases earlier. That check, not the issue's close
date, is what the docs and the compose comment now tell you to use.

**substrate#518 is still open on 0.88.0**, re-probed here: a CFN-created bucket is
still listed after `DeleteStack`. It is now the only CloudFormation gap left, and it
is a teardown-assertion hazard rather than a blocker, so `docs/substrate_testing.md`
keeps it in the gap table while moving the four closed ones to a new "Closed in
0.88.0" section.

Docs also gained a note that the unit suite's reason for staying on moto has
changed: it was "CloudFormation is `ServiceNotAvailable`", which is no longer true.
The conclusion holds, but it now rests on keeping the unit suite container-free.