### PR TITLE
test: retire moto from the integration suite (closes #183)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **moto is retired from the integration suite** (#183). The two remaining
+  moto-backed files —
+  `tests/integration/test_serverless_mode_spot_fleet_integration.py` and
+  `tests/integration/test_detached_mode_spot_fleet_integration.py`, 7 `mock_aws`
+  sites — now run against substrate, leaving no `mock_aws` anywhere under
+  `tests/integration/`. The 37 sites in `tests/unit/` stay on moto deliberately:
+  that suite must remain container-free, so `moto[cloudformation]` remains a
+  dependency.
+
+  The move adds coverage rather than swapping like for like:
+
+  - **The detached tests exercise the default CloudFormation bastion.** They
+    passed `bastion_host_type="direct"` only because moto's CloudFormation
+    handler reads `properties["ImageId"]` directly and resolves no launch
+    template, raising `KeyError` on a `bastion.yml` real CloudFormation accepts.
+    Substrate deploys it end to end, so the path users actually get is now
+    covered.
+  - **The `aws:ec2:fleet-id` workaround is deleted, not ported.** Two fleet-status
+    tests hand-applied the tag because moto does not, which meant the lookup was
+    only ever passing on a tag the test itself supplied. Substrate stamps it, as
+    real EC2 does.
+  - **A fleet deletion is now observable.** The old cleanup test patched
+    `boto3.client` and asserted a `MagicMock` had received
+    `cancel_spot_fleet_requests` — the legacy API #86 removed and the provider no
+    longer calls, so that assertion could not fail whatever the code did. It now
+    creates a real fleet and asserts cleanup deletes it.
+  - **A deployed ECS task definition is read back.** New coverage of the
+    `!Split`-inside-`ContainerDefinitions` path that substrate#521/#526/#527 each
+    broke while still reporting success.
+
+  Integration goes **131 → 133 passed**; conformance **5 passed** and unit and
+  security **1202 passed / 3 skipped** are unchanged.
 - **The substrate emulator pin moves `0.87.1` → `0.88.0`**, in
   `docker-compose.substrate.yml` and `.github/workflows/ci.yml` together. This
   closes the last four emulation gaps filed from this repository, each verified
@@ -346,6 +378,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   4.0.1).
 
 ### Fixed
+- **The integration suite is idempotent against a long-lived emulator.** Four
+  tests derived resource names from IDs that collided after truncation, so a
+  second run without `make substrate-reset` failed on `AlreadyExists`. Provider
+  resource names truncate the ID they embed — `parsl-bastion-{workflow_id[:8]}`,
+  `parsl-{ecs,lambda}-{job_id[:8]}`, `parsl-lambda-code-{provider_id[:8]}` — so
+  `f"test-job-{uuid…}"` is the same name for every test. The random component now
+  leads. Three of the four are pre-existing in `test_substrate_modes.py`; moto hid
+  the class of bug entirely by giving each test a fresh mock. Worth knowing beyond
+  the tests: two live workflows whose IDs share eight characters collide on one
+  stack.
 - **The declared build requirement could not build this package.**
   `[build-system] requires` read `setuptools>=42`, but PEP 639 support — the
   `license = "Apache-2.0"` SPDX string and `license-files = [...]` this project

--- a/docs/substrate_testing.md
+++ b/docs/substrate_testing.md
@@ -77,6 +77,16 @@ design: a fixed resource name collides with `ResourceConflictException` on a sec
 run against a long-lived emulator, so tests that create named resources should
 suffix them with `uuid.uuid4().hex[:8]` or call `make substrate-reset` between runs.
 
+**Put the random part first, not last.** The provider truncates the IDs it embeds in
+resource names — `parsl-bastion-{workflow_id[:8]}` (`modes/detached.py:458`),
+`parsl-{ecs,lambda}-{job_id[:8]}` (`modes/serverless.py:564,717`),
+`parsl-lambda-code-{provider_id[:8]}` (`:645`) — so `f"test-job-{uuid…}"` yields the
+single name `test-job` for every test that uses it. #183 found four such collisions.
+This is the failure mode moto structurally hid: a fresh mock per test meant a
+same-named resource never met its predecessor. It is also a real provider constraint
+rather than a test artefact — two live workflows whose IDs share eight characters
+collide on one stack.
+
 ## Pointing the provider at substrate
 
 There is no `use_substrate=` or `endpoint_url=` provider argument, and there never
@@ -160,8 +170,9 @@ real AWS and everything else to substrate.
 
 Two pytest markers are relevant:
 
-- `integration` — lives in `tests/integration/`. A subset is pure-moto and needs no
-  endpoint at all.
+- `integration` — lives in `tests/integration/`. Every file there needs a running
+  emulator as of #183; moto is gone from this directory. It is still a dependency,
+  and still used by `tests/unit/`, which must stay container-free.
 - `substrate` — requires a running emulator. Pair it with a
   `skipif(not is_substrate_available())`: a marker only *selects* tests, it never
   skips them, so a marker alone leaves the test erroring rather than skipping when
@@ -184,13 +195,16 @@ provider.
 
 Verified by probing substrate `0.88.0` directly, not read off the milestones.
 **`0.88.0` closed the four gaps that kept `ecs_worker.yml` on moto** — see the
-resolved list below — so `DeleteStack` is the only CloudFormation row left, and it
-is a teardown-assertion hazard rather than a blocker. The EventBridge row is a gap
-this project turns to its advantage rather than one it works around.
+resolved list below. What remains is three CloudFormation rows, none of them a
+blocker: each is a hazard to what a *teardown or assertion* can be trusted to prove.
+The EventBridge row is a gap this project turns to its advantage rather than one it
+works around.
 
 | Gap | Effect | Upstream |
 |---|---|---|
 | `DeleteStack` does not delete the stack's resources | The stack record goes and `describe_stacks` then raises `ValidationError` correctly, but an S3 bucket and an IAM role both outlive their stack. A teardown assertion that only checks the stack passes for the wrong reason. Re-probed against `0.88.0`: a CFN-created bucket is still listed after `DeleteStack` | [substrate#518](https://github.com/scttfrdmn/substrate/issues/518) |
+| Neither `DeleteStack` nor `DescribeStacks` resolves a stack **ARN**, only a name | `delete_stack(StackName=<arn>)` returns **HTTP 200 and leaves the stack standing**; `describe_stacks(StackName=<arn>)` raises `ValidationError … does not exist`. Real CloudFormation accepts either form. This bites teardown directly: `DetachedMode.cleanup_infrastructure()` deletes by `self.bastion_id`, which *is* an ARN, so bastion teardown silently no-ops and the next test in the file meets `AlreadyExists`. Found while moving `test_detached_mode_spot_fleet_integration.py` off moto in #183 | not yet filed |
+| A CFN-deployed `AWS::Lambda::Function` reports `CodeSize: 0` | A direct `create_function` reports the true size; only the CloudFormation path zeroes it, and `invoke` still returns 200. So `CodeSize` cannot be used to prove a stack staged real code — which is why `test_submit_lambda_job_stages_a_real_zip_in_s3` asserts on the `DescribeStacks` parameter echo instead. That is the better assertion regardless: #116's actual symptom was an unparseable parameter echo, not a wrong size | not yet filed |
 | EventBridge is not emulated; `PutRule` returns `501 service not emulated: awsevents` | The spot-warning notifier's degradation path is testable *because* of this. The warning path itself is covered end to end by wiring an SQS queue directly, since the monitor only ever reads warnings through SQS | — |
 
 ### Closed in `0.88.0`
@@ -251,8 +265,10 @@ it.** The full template deploys against `0.87.1`: `AWS::EC2::Instance` resolves 
 `AWS::EC2::Instance` reads `properties["ImageId"]` directly
 (`moto/ec2/models/instances.py:400`) and resolves no launch template, so it raises
 `KeyError: 'ImageId'` on a stack real CloudFormation accepts. That is why
-`test_detached_mode_spot_fleet_integration.py` passes `bastion_host_type="direct"`;
-the CloudFormation bastion path is a candidate to move onto substrate now.
+`test_detached_mode_spot_fleet_integration.py` used to pass
+`bastion_host_type="direct"`. It no longer does: #183 moved that file onto substrate
+and onto the **default** `cloudformation` bastion path, so the tests now exercise
+what users get rather than a fallback chosen to route around a simulator gap.
 
 Two related fixes shipped in `0.87.1` alongside those, both found upstream while
 fixing #516 and each worth knowing:

--- a/tests/integration/test_detached_mode_spot_fleet_integration.py
+++ b/tests/integration/test_detached_mode_spot_fleet_integration.py
@@ -1,26 +1,35 @@
 """Integration tests for the SpotFleet functionality in DetachedMode.
 
-These tests use the moto library to mock AWS services for realistic integration testing.
+These run the mode against [substrate](https://github.com/scttfrdmn/substrate),
+the emulator this suite standardised on in #125, rather than moto (#183). The
+switch is not like-for-like: it *adds* coverage.
+
+The old moto version passed ``bastion_host_type="direct"``, because since #86
+``bastion.yml`` puts ``ImageId`` in a launch template and has the
+``AWS::EC2::Instance`` reference it -- one template serving both the on-demand and
+the spot bastion. moto's CloudFormation handler reads ``properties["ImageId"]``
+directly (``moto/ec2/models/instances.py:400``) and resolves no launch template,
+so it raises ``KeyError: 'ImageId'`` on a stack real CloudFormation accepts.
+Substrate deploys that template end to end as of ``0.87.1``
+([substrate#516](https://github.com/scttfrdmn/substrate/issues/516),
+[#517](https://github.com/scttfrdmn/substrate/issues/517)), so these tests now
+exercise the **default** ``cloudformation`` bastion path -- the one users get --
+instead of the fallback chosen to work around a simulator gap.
+
+The spot-fleet lifecycle is likewise real here: ``test_cleanup_deletes_the_fleet``
+creates an actual ``CreateFleet`` fleet and asserts cleanup deletes it. The moto
+version patched ``boto3.client`` and asserted against a ``MagicMock``'s
+``cancel_spot_fleet_requests`` -- an API the provider stopped calling in #86, so
+that assertion could not have failed however the code behaved.
 
 SPDX-License-Identifier: Apache-2.0
 SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
 """
 
-import unittest
-from unittest.mock import MagicMock, patch
-import boto3
-import pytest
 import json
+import uuid
 
-try:
-    # Check if moto is available — importing the decorator is the probe; a
-    # bare `import moto` alongside it was redundant. moto 5 replaced the
-    # per-service decorators with a single mock_aws.
-    from moto import mock_aws
-
-    MOTO_AVAILABLE = True
-except ImportError:
-    MOTO_AVAILABLE = False
+import pytest
 
 from parsl_ephemeral_provider.modes.detached import DetachedMode
 from parsl_ephemeral_provider.constants import (
@@ -31,181 +40,163 @@ from parsl_ephemeral_provider.constants import (
     STATUS_CANCELED,
 )
 
-
-# Skip all tests if moto is not installed
-pytestmark = pytest.mark.skipif(not MOTO_AVAILABLE, reason="moto not installed")
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.substrate,
+]
 
 
 class MockStateStore:
-    """Mock state store implementation for testing.
-
-    Keyed like the real stores, so writing one key does not disturb another.
-    """
+    """Keyed state store, matching the real stores' two-argument interface."""
 
     def __init__(self):
-        """Initialize with empty state."""
         self.states = {}
 
     def save_state(self, state_key, state_data):
-        """Save state under a key."""
         self.states[state_key] = state_data
         return True
 
     def load_state(self, state_key):
-        """Load state stored under a key."""
         return self.states.get(state_key)
 
     def delete_state(self, state_key):
-        """Delete state stored under a key."""
         self.states.pop(state_key, None)
 
 
-@mock_aws
-class TestDetachedModeSpotFleetIntegration(unittest.TestCase):
-    """Integration tests for DetachedMode SpotFleet functionality using moto."""
+class TestDetachedModeSpotFleetIntegration:
+    """Integration tests for DetachedMode SpotFleet functionality."""
 
-    def setUp(self):
-        """Set up test environment."""
-        # Create boto3 clients directly with moto
-        self.ec2_client = boto3.client("ec2", region_name="us-east-1")
-        self.iam_client = boto3.client("iam", region_name="us-east-1")
-        self.ssm_client = boto3.client("ssm", region_name="us-east-1")
-        self.cf_client = boto3.client("cloudformation", region_name="us-east-1")
+    @pytest.fixture
+    def image_id(self, substrate_session):
+        """A registered AMI, rather than a made-up ``ami-`` string.
 
-        # Create boto3 session
-        self.session = boto3.Session(region_name="us-east-1")
-
-        # Create state store
-        self.state_store = MockStateStore()
-
-        # Create a VPC for testing
-        vpc_response = self.ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
-        self.vpc_id = vpc_response["Vpc"]["VpcId"]
-
-        # Create a subnet
-        subnet_response = self.ec2_client.create_subnet(
-            VpcId=self.vpc_id, CidrBlock="10.0.0.0/24"
-        )
-        self.subnet_id = subnet_response["Subnet"]["SubnetId"]
-
-        # Create a security group
-        sg_response = self.ec2_client.create_security_group(
-            GroupName="test-sg", Description="Test security group", VpcId=self.vpc_id
-        )
-        self.security_group_id = sg_response["GroupId"]
-
-        # Create a dummy AMI
-        ami_response = self.ec2_client.register_image(
-            Name="test-ami",
+        ``bastion.yml`` passes it into a launch template that the bastion instance
+        resolves, so it has to be an image the emulator will actually serve.
+        """
+        return substrate_session.client("ec2").register_image(
+            Name=f"parsl-test-ami-{uuid.uuid4().hex[:8]}",
             RootDeviceName="/dev/sda1",
             BlockDeviceMappings=[{"DeviceName": "/dev/sda1", "Ebs": {"VolumeSize": 8}}],
-        )
-        self.ami_id = ami_response["ImageId"]
+        )["ImageId"]
 
-        # Create IAM role for spot fleet
-        trust_policy = {
-            "Version": "2012-10-17",
-            "Statement": [
-                {
-                    "Effect": "Allow",
-                    "Principal": {"Service": "spotfleet.amazonaws.com"},
-                    "Action": "sts:AssumeRole",
-                }
-            ],
-        }
+    @pytest.fixture
+    def workflow_id(self):
+        """Unique per test, and unique **in its first eight characters**.
 
-        # Create role
-        self.iam_client.create_role(
-            RoleName="SpotFleetRole",
-            AssumeRolePolicyDocument=json.dumps(trust_policy),
-            Description="Role for Spot Fleet",
-        )
+        Two reasons it has to be unique. SSM parameter paths are keyed on it, and
+        emulator state lives for the server process's lifetime, so a fixed value
+        meets the previous run's parameters rather than starting clean.
 
-        # Create SSM parameters path for workflow
-        self.workflow_id = "test-workflow-id"
-        self.provider_id = "test-provider-id"
+        The eight-character part is the subtle one: the bastion stack is named
+        ``parsl-bastion-{workflow_id[:8]}`` (``modes/detached.py:458``), so an id
+        like ``test-workflow-<random>`` truncates to ``test-wor`` for every test in
+        the file and the second ``initialize()`` dies on ``AlreadyExists``. The
+        random part therefore leads.
 
-        # Create DetachedMode instance with SpotFleet enabled.
-        #
-        # `bastion_host_type="direct"` rather than the "cloudformation" default:
-        # since #86 bastion.yml puts `ImageId` in a launch template and has the
-        # AWS::EC2::Instance reference it, which is what lets one template serve
-        # both the on-demand and the spot bastion. moto's CloudFormation handler
-        # for AWS::EC2::Instance reads `properties["ImageId"]` directly
-        # (moto/ec2/models/instances.py:400) and resolves no launch template, so
-        # it raises `KeyError: 'ImageId'` on a stack real CloudFormation accepts.
-        # The direct path launches with `run_instances`, which moto does model.
-        # The CloudFormation bastion is covered in `tests/aws/` against real AWS.
-        #
-        # `create_vpc=False` used to be passed here. #69 removed the parameter --
-        # every mode now requires the three network IDs, which are supplied
-        # above -- and the mode's `**kwargs` swallowed it silently rather than
-        # rejecting it, so it read as configuration while doing nothing.
-        self.detached_mode = DetachedMode(
-            provider_id=self.provider_id,
-            session=self.session,
-            state_store=self.state_store,
-            workflow_id=self.workflow_id,
-            bastion_host_type="direct",
-            bastion_instance_type="t2.micro",
-            instance_type="t2.micro",
-            image_id=self.ami_id,
-            vpc_id=self.vpc_id,
-            subnet_id=self.subnet_id,
-            security_group_id=self.security_group_id,
+        That truncation is a real provider constraint, not a test artefact: two
+        concurrent workflows whose ids share a prefix collide on the same stack.
+        Worth knowing before it is met in an account rather than an emulator.
+        """
+        return f"{uuid.uuid4().hex[:8]}-test-workflow"
+
+    @pytest.fixture
+    def detached_mode(
+        self, substrate_session, substrate_network, image_id, workflow_id
+    ):
+        """A spot-fleet DetachedMode on the default CloudFormation bastion path.
+
+        No ``create_vpc``: #69 removed the parameter -- every mode now requires the
+        three network IDs, which ``substrate_network`` provisions -- and the mode's
+        ``**kwargs`` swallowed it silently rather than rejecting it, so it read as
+        configuration while doing nothing.
+
+        No ``region`` either. The mode would merely store it, while its clients
+        come from the session, which follows ``AWS_TEST_REGION``. Substrate
+        partitions state by region, so naming a different one here is how you get
+        a ``NotFound`` for a resource that was just created successfully.
+        """
+        mode = DetachedMode(
+            provider_id=f"test-provider-{uuid.uuid4().hex[:8]}",
+            session=substrate_session,
+            state_store=MockStateStore(),
+            workflow_id=workflow_id,
+            bastion_instance_type="t3.micro",
+            instance_type="t3.micro",
+            image_id=image_id,
+            vpc_id=substrate_network["vpc_id"],
+            subnet_id=substrate_network["subnet_id"],
+            security_group_id=substrate_network["security_group_id"],
             use_spot_fleet=True,
-            instance_types=["t2.micro", "t2.small", "m5.small"],
+            instance_types=["t3.micro", "t3.small", "m5.large"],
             nodes_per_block=2,
             spot_max_price_percentage=80,
         )
+        try:
+            yield mode
+        finally:
+            mode.cleanup_infrastructure()
 
-    @patch("time.sleep", return_value=None)  # Don't actually sleep during tests
-    def test_submit_job_with_spot_fleet(self, mock_sleep):
-        """Test submitting a job with SpotFleet options."""
-        # Submit a job
+    def test_initialize_deploys_the_bastion_stack(self, detached_mode):
+        """The default bastion path deploys ``bastion.yml`` and reports its stack.
+
+        This is the case moto could not run at all, and the reason the file moved:
+        the template's ``AWS::EC2::Instance`` resolves its ``ImageId`` through an
+        ``AWS::EC2::LaunchTemplate``, which moto's CloudFormation handler does not
+        do.
+        """
+        detached_mode.initialize()
+
+        assert detached_mode.initialized is True
+        assert detached_mode.bastion_id
+        # A stack ARN, not an `i-`: the bastion is stack-managed on this path.
+        assert ":stack/" in detached_mode.bastion_id
+
+    def test_submit_job_with_spot_fleet(self, detached_mode, workflow_id):
+        """A submitted job hands the bastion its full spot-fleet configuration.
+
+        The real ``bastion.yml`` is deployed rather than stubbed: patching
+        ``get_cf_template`` out is what let #112 -- it raised
+        ``ModuleNotFoundError`` on every call, and the templates never shipped in
+        the wheel -- go unnoticed at all four of its call sites.
+        """
+        detached_mode.initialize()
+
         job_id = "test-job-1"
-        command = "echo 'Hello, world!'"
-        tasks_per_node = 1
+        resource_id = detached_mode.submit_job(job_id, "echo 'Hello, world!'", 1)
 
-        # The real bastion.yml is used here rather than a stub: patching
-        # get_cf_template out is what let #112 (it raised ModuleNotFoundError on
-        # every call, and the templates never shipped in the wheel) go unnoticed
-        # at all four of its call sites.
-        self.detached_mode.initialize()
-        resource_id = self.detached_mode.submit_job(job_id, command, tasks_per_node)
+        assert resource_id in detached_mode.resources
+        assert detached_mode.resources[resource_id]["job_id"] == job_id
+        assert detached_mode.resources[resource_id]["status"] == STATUS_PENDING
 
-        # Verify resource is tracked
-        self.assertIn(resource_id, self.detached_mode.resources)
-        self.assertEqual(self.detached_mode.resources[resource_id]["job_id"], job_id)
-        self.assertEqual(
-            self.detached_mode.resources[resource_id]["status"], STATUS_PENDING
+        ssm = detached_mode.session.client("ssm")
+        job_param = ssm.get_parameter(
+            Name=f"/parsl/workflows/{workflow_id}/jobs/{job_id}"
+        )
+        status_param = ssm.get_parameter(
+            Name=f"/parsl/workflows/{workflow_id}/status/{job_id}"
         )
 
-        # Verify SSM parameters were created
-        job_param = self.ssm_client.get_parameter(
-            Name=f"/parsl/workflows/{self.workflow_id}/jobs/{job_id}"
-        )
-        status_param = self.ssm_client.get_parameter(
-            Name=f"/parsl/workflows/{self.workflow_id}/status/{job_id}"
-        )
-
-        # Verify job data contains SpotFleet options
+        # The bastion polls these parameters and is the thing that launches the
+        # fleet, so anything the fleet needs has to be in the job document.
         job_data = json.loads(job_param["Parameter"]["Value"])
-        self.assertTrue(job_data["use_spot_fleet"])
-        self.assertEqual(len(job_data["instance_types"]), 3)
-        self.assertIn("t2.micro", job_data["instance_types"])
-        self.assertIn("t2.small", job_data["instance_types"])
-        self.assertEqual(job_data["nodes_per_block"], 2)
-        self.assertEqual(job_data["spot_max_price_percentage"], 80)
+        assert job_data["use_spot_fleet"] is True
+        assert job_data["instance_types"] == ["t3.micro", "t3.small", "m5.large"]
+        assert job_data["nodes_per_block"] == 2
+        assert job_data["spot_max_price_percentage"] == 80
 
-        # Verify job status is PENDING
-        status_data = json.loads(status_param["Parameter"]["Value"])
-        self.assertEqual(status_data["status"], STATUS_PENDING)
+        assert (
+            json.loads(status_param["Parameter"]["Value"])["status"] == STATUS_PENDING
+        )
 
-    @patch("time.sleep", return_value=None)  # Don't actually sleep during tests
-    def test_get_job_status_with_spot_fleet(self, mock_sleep):
-        """Test getting job status for a SpotFleet job."""
-        # Create a job status parameter with SpotFleet information
+    def test_get_job_status_adopts_the_bastions_fleet_details(
+        self, detached_mode, workflow_id
+    ):
+        """Status is read from SSM and the fleet details are copied into tracking.
+
+        The bastion, not the provider, launches the fleet, so the fleet ID and its
+        instance list only reach the provider through the status parameter.
+        """
+        detached_mode.initialize()
         job_id = "test-job-2"
         status_data = {
             "status": STATUS_RUNNING,
@@ -214,17 +205,14 @@ class TestDetachedModeSpotFleetIntegration(unittest.TestCase):
             "resource_type": RESOURCE_TYPE_SPOT_FLEET,
             "all_instance_ids": ["i-spot1", "i-spot2"],
         }
-
-        # Put the status in SSM
-        self.ssm_client.put_parameter(
-            Name=f"/parsl/workflows/{self.workflow_id}/status/{job_id}",
+        detached_mode.session.client("ssm").put_parameter(
+            Name=f"/parsl/workflows/{workflow_id}/status/{job_id}",
             Value=json.dumps(status_data),
             Type="String",
         )
 
-        # Create resource tracking
         resource_id = f"spot-fleet-{job_id}"
-        self.detached_mode.resources = {
+        detached_mode.resources = {
             resource_id: {
                 "job_id": job_id,
                 "status": STATUS_PENDING,
@@ -232,54 +220,27 @@ class TestDetachedModeSpotFleetIntegration(unittest.TestCase):
             }
         }
 
-        # Get job status
-        status = self.detached_mode.get_job_status([resource_id])
+        status = detached_mode.get_job_status([resource_id])
 
-        # Verify status
-        self.assertEqual(status[resource_id], STATUS_RUNNING)
+        assert status[resource_id] == STATUS_RUNNING
+        resource = detached_mode.resources[resource_id]
+        assert resource["status"] == STATUS_RUNNING
+        assert resource["fleet_request_id"] == "sfr-12345"
+        assert resource["resource_type"] == RESOURCE_TYPE_SPOT_FLEET
+        assert resource["all_instance_ids"] == ["i-spot1", "i-spot2"]
 
-        # Verify resource was updated with SpotFleet information
-        self.assertEqual(
-            self.detached_mode.resources[resource_id]["status"], STATUS_RUNNING
-        )
-        self.assertEqual(
-            self.detached_mode.resources[resource_id]["fleet_request_id"], "sfr-12345"
-        )
-        self.assertEqual(
-            self.detached_mode.resources[resource_id]["resource_type"],
-            RESOURCE_TYPE_SPOT_FLEET,
-        )
-        self.assertEqual(
-            self.detached_mode.resources[resource_id]["all_instance_ids"],
-            ["i-spot1", "i-spot2"],
-        )
-
-    @patch("time.sleep", return_value=None)  # Don't actually sleep during tests
-    def test_cancel_job_with_spot_fleet(self, mock_sleep):
-        """Test canceling a SpotFleet job."""
-        # Create a job parameter for a SpotFleet job
+    def test_cancel_job_with_spot_fleet(self, detached_mode, workflow_id):
+        """Cancelling writes the fleet IDs the bastion needs to tear down."""
+        detached_mode.initialize()
         job_id = "test-job-3"
-        job_data = {
-            "command": 'echo "test"',
-            "image_id": self.ami_id,
-            "instance_type": "t2.micro",
-            "subnet_id": self.subnet_id,
-            "security_group_id": self.security_group_id,
-            "use_spot_fleet": True,
-            "instance_types": ["t2.micro", "t2.small"],
-            "nodes_per_block": 2,
-        }
-
-        # Put the job data in SSM
-        self.ssm_client.put_parameter(
-            Name=f"/parsl/workflows/{self.workflow_id}/jobs/{job_id}",
-            Value=json.dumps(job_data),
+        detached_mode.session.client("ssm").put_parameter(
+            Name=f"/parsl/workflows/{workflow_id}/jobs/{job_id}",
+            Value=json.dumps({"command": 'echo "test"', "use_spot_fleet": True}),
             Type="String",
         )
 
-        # Create resource tracking with SpotFleet information
         resource_id = f"spot-fleet-{job_id}"
-        self.detached_mode.resources = {
+        detached_mode.resources = {
             resource_id: {
                 "job_id": job_id,
                 "status": STATUS_RUNNING,
@@ -289,90 +250,93 @@ class TestDetachedModeSpotFleetIntegration(unittest.TestCase):
             }
         }
 
-        # Cancel the job
-        status = self.detached_mode.cancel_jobs([resource_id])
+        status = detached_mode.cancel_jobs([resource_id])
 
-        # Verify cancel status
-        self.assertEqual(status[resource_id], STATUS_CANCELED)
-        self.assertEqual(
-            self.detached_mode.resources[resource_id]["status"], STATUS_CANCELED
+        assert status[resource_id] == STATUS_CANCELED
+        assert detached_mode.resources[resource_id]["status"] == STATUS_CANCELED
+
+        cancel_param = detached_mode.session.client("ssm").get_parameter(
+            Name=f"/parsl/workflows/{workflow_id}/cancel"
         )
-
-        # Verify cancel parameter was created in SSM
-        cancel_param = self.ssm_client.get_parameter(
-            Name=f"/parsl/workflows/{self.workflow_id}/cancel"
-        )
-
-        # Verify cancel parameter contains SpotFleet information
         cancel_data = json.loads(cancel_param["Parameter"]["Value"])
-        self.assertIn(job_id, cancel_data["job_ids"])
-        self.assertIn("spot_fleet_jobs", cancel_data)
-        self.assertEqual(cancel_data["spot_fleet_jobs"][job_id], "sfr-12345")
+        assert job_id in cancel_data["job_ids"]
+        assert cancel_data["spot_fleet_jobs"][job_id] == "sfr-12345"
 
-    @patch("time.sleep", return_value=None)  # Don't actually sleep during tests
-    def test_cleanup_spot_fleet_resources(self, mock_sleep):
-        """Test cleaning up SpotFleet resources."""
-        # Create necessary params in SSM
+    def test_cleanup_deletes_the_fleet_and_its_ssm_records(
+        self, detached_mode, workflow_id, substrate_network
+    ):
+        """Cleanup deletes the real fleet, then drops its SSM parameters.
+
+        The fleet here is a genuine ``CreateFleet`` fleet, so the deletion is
+        observable. The moto version patched ``boto3.client`` and asserted a
+        ``MagicMock`` had received ``cancel_spot_fleet_requests`` -- the legacy API
+        #86 removed, which ``cleanup_resources`` no longer calls, so the assertion
+        held no matter what the code did. Deleting a fleet is also not optional
+        for an instant fleet: it is what terminates the instances.
+        """
+        detached_mode.initialize()
+        ec2 = detached_mode.session.client("ec2")
+
+        template = ec2.create_launch_template(
+            LaunchTemplateName=f"parsl-test-fleet-{uuid.uuid4().hex[:8]}",
+            LaunchTemplateData={
+                "ImageId": detached_mode.image_id,
+                "InstanceType": "t3.micro",
+            },
+        )["LaunchTemplate"]
+        fleet_id = ec2.create_fleet(
+            Type="instant",
+            LaunchTemplateConfigs=[
+                {
+                    "LaunchTemplateSpecification": {
+                        "LaunchTemplateId": template["LaunchTemplateId"],
+                        "Version": str(template["LatestVersionNumber"]),
+                    },
+                    "Overrides": [
+                        {
+                            "InstanceType": "t3.micro",
+                            "SubnetId": substrate_network["subnet_id"],
+                        }
+                    ],
+                }
+            ],
+            TargetCapacitySpecification={
+                "TotalTargetCapacity": 1,
+                "DefaultTargetCapacityType": "spot",
+            },
+        )["FleetId"]
+
         job_id = "test-job-4"
+        ssm = detached_mode.session.client("ssm")
+        for suffix, value in (
+            ("jobs", {"command": "echo test"}),
+            ("status", {"status": STATUS_RUNNING}),
+        ):
+            ssm.put_parameter(
+                Name=f"/parsl/workflows/{workflow_id}/{suffix}/{job_id}",
+                Value=json.dumps(value),
+                Type="String",
+            )
 
-        # Create job data parameter
-        self.ssm_client.put_parameter(
-            Name=f"/parsl/workflows/{self.workflow_id}/jobs/{job_id}",
-            Value=json.dumps({"command": "echo test"}),
-            Type="String",
-        )
-
-        # Create job status parameter
-        self.ssm_client.put_parameter(
-            Name=f"/parsl/workflows/{self.workflow_id}/status/{job_id}",
-            Value=json.dumps({"status": STATUS_RUNNING}),
-            Type="String",
-        )
-
-        # Mock a SpotFleet resource
         resource_id = f"spot-fleet-{job_id}"
-        self.detached_mode.resources = {
+        detached_mode.resources = {
             resource_id: {
                 "job_id": job_id,
                 "status": STATUS_RUNNING,
                 "resource_type": RESOURCE_TYPE_SPOT_FLEET,
-                "fleet_request_id": "sfr-12345",
-                "all_instance_ids": ["i-spot1", "i-spot2"],
+                "fleet_request_id": fleet_id,
             }
         }
 
-        # Clean up resources
-        with patch("boto3.client") as mock_boto_client:
-            # Mock the EC2 client's cancel_spot_fleet_requests method
-            mock_ec2_client = MagicMock()
-            mock_boto_client.return_value = mock_ec2_client
-            mock_ec2_client.cancel_spot_fleet_requests.return_value = {
-                "SuccessfulFleetRequests": [
-                    {
-                        "SpotFleetRequestId": "sfr-12345",
-                        "CurrentSpotFleetRequestState": "cancelled_terminating",
-                        "PreviousSpotFleetRequestState": "active",
-                    }
-                ]
-            }
+        detached_mode.cleanup_resources([resource_id])
 
-            # Call cleanup
-            self.detached_mode.cleanup_resources([resource_id])
+        assert resource_id not in detached_mode.resources
 
-        # Verify resource was removed from tracking
-        self.assertNotIn(resource_id, self.detached_mode.resources)
+        fleet = ec2.describe_fleets(FleetIds=[fleet_id])["Fleets"][0]
+        assert fleet["FleetState"].startswith("deleted")
 
-        # Verify SSM parameters were deleted
-        with self.assertRaises(self.ssm_client.exceptions.ParameterNotFound):
-            self.ssm_client.get_parameter(
-                Name=f"/parsl/workflows/{self.workflow_id}/jobs/{job_id}"
-            )
-
-        with self.assertRaises(self.ssm_client.exceptions.ParameterNotFound):
-            self.ssm_client.get_parameter(
-                Name=f"/parsl/workflows/{self.workflow_id}/status/{job_id}"
-            )
-
-
-if __name__ == "__main__":
-    unittest.main()
+        for suffix in ("jobs", "status"):
+            with pytest.raises(ssm.exceptions.ParameterNotFound):
+                ssm.get_parameter(
+                    Name=f"/parsl/workflows/{workflow_id}/{suffix}/{job_id}"
+                )

--- a/tests/integration/test_serverless_mode_spot_fleet_integration.py
+++ b/tests/integration/test_serverless_mode_spot_fleet_integration.py
@@ -1,17 +1,35 @@
 """Integration tests for ServerlessMode with SpotFleet functionality.
 
-These run the mode against moto, which intercepts the HTTP layer, so the real
-CloudFormation templates are deployed and the real ``describe_*`` response shapes
-are exercised. Nothing on the mode is stubbed.
+These run the mode against [substrate](https://github.com/scttfrdmn/substrate),
+the emulator this suite standardised on in #125, rather than moto (#183). Nothing
+on the mode is stubbed: the real CloudFormation templates are deployed and the real
+``describe_*`` response shapes are exercised.
 
-The template's spot fleet branch is one deliberate omission: moto's
-``AWS::EC2::SpotFleet`` handler reads
-``SpotFleetRequestConfigData["LaunchSpecifications"]`` unconditionally
-(``moto/ec2/models/spot_requests.py``), while ``ecs_worker.yml`` -- like current
-AWS guidance -- declares ``LaunchTemplateConfigs``. Deploying that branch dies
-inside moto with ``KeyError: 'LaunchSpecifications'``, a simulator gap rather
-than a package defect, so ``_get_spot_fleet_status()`` is exercised against a
-directly created fleet request instead.
+Moving here waited on four substrate fixes, all filed from this repository and all
+in ``0.88.0``: [#521](https://github.com/scttfrdmn/substrate/issues/521)
+(``Fn::Split`` yielded only its first element, which silently truncated
+``ecs_worker.yml``'s ``Command``),
+[#526](https://github.com/scttfrdmn/substrate/issues/526) (an intrinsic nested
+inside a structured property was never resolved),
+[#527](https://github.com/scttfrdmn/substrate/issues/527) (a deployed task
+definition kept CloudFormation's PascalCase keys, so ``describe_task_definition``
+returned ``[{}]``) and [#528](https://github.com/scttfrdmn/substrate/issues/528)
+(CloudWatch Logs read operations returned PascalCase members, so every field parsed
+to ``None``).
+
+Two things improved in the move rather than merely carrying over:
+
+* **The ``aws:ec2:fleet-id`` workaround is gone, not ported.** moto applies no such
+  tag, so the two fleet-status tests hand-applied it -- and a fleet whose tag the
+  test itself supplied cannot show that the lookup works. Substrate stamps it
+  (substrate#443) *and* now rejects manual ``aws:``-prefixed keys as reserved, the
+  way real EC2 does, so the tag being present is now an emulator behaviour the code
+  is genuinely tested against.
+* **The spot-fleet branch of ``ecs_worker.yml`` is no longer excluded.** moto's
+  ``AWS::EC2::SpotFleet`` handler reads
+  ``SpotFleetRequestConfigData["LaunchSpecifications"]`` unconditionally while the
+  template -- like current AWS guidance -- declares ``LaunchTemplateConfigs``, so
+  deploying that branch died with ``KeyError: 'LaunchSpecifications'``.
 
 SPDX-License-Identifier: Apache-2.0
 SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
@@ -23,17 +41,7 @@ import uuid
 import zipfile
 from unittest.mock import patch
 
-import boto3
 import pytest
-
-try:
-    # moto 5 replaced the per-service decorators (mock_ec2, mock_iam, ...) with a
-    # single mock_aws.
-    from moto import mock_aws
-
-    MOTO_AVAILABLE = True
-except ImportError:
-    MOTO_AVAILABLE = False
 
 from parsl_ephemeral_provider.modes.serverless import ServerlessMode
 from parsl_ephemeral_provider.constants import (
@@ -49,7 +57,7 @@ from parsl_ephemeral_provider.constants import (
 
 pytestmark = [
     pytest.mark.integration,
-    pytest.mark.skipif(not MOTO_AVAILABLE, reason="moto not installed"),
+    pytest.mark.substrate,
 ]
 
 
@@ -70,54 +78,57 @@ class MockStateStore:
         self.states.pop(state_key, None)
 
 
-@pytest.fixture(autouse=True)
-def moto():
-    """Activate moto around each test *and* around its fixtures.
-
-    ``@mock_aws`` as a class decorator wraps only the ``test_*`` methods, so a
-    fixture that provisions a VPC runs outside the mock and hits real AWS. An
-    autouse fixture is entered before the fixtures that depend on it, so the
-    whole graph is covered.
-    """
-    with mock_aws():
-        yield
-
-
 class TestServerlessModeSpotFleetIntegration:
-    """Integration tests for ServerlessMode against moto."""
+    """Integration tests for ServerlessMode against the emulator."""
 
     @pytest.fixture
-    def aws_session(self):
-        """A real boto3 session; moto intercepts its calls."""
-        return boto3.Session(region_name="us-east-1")
-
-    @pytest.fixture
-    def network(self, aws_session):
-        """Pre-provision the VPC, subnet, and security group.
+    def network(self, substrate_network):
+        """The caller-supplied network.
 
         Since #69 no mode creates network resources -- all three IDs are
-        caller-supplied and required for the ECS worker type.
+        caller-supplied and required for the ECS worker type -- and ``modes/base.py``
+        *verifies* each with a ``describe_*`` call, so they have to be real
+        emulator-side resources rather than ``vpc-12345`` placeholders.
         """
-        ec2 = aws_session.client("ec2")
-        vpc_id = ec2.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
-        subnet_id = ec2.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/24")["Subnet"][
-            "SubnetId"
-        ]
-        security_group_id = ec2.create_security_group(
-            GroupName=f"parsl-test-{uuid.uuid4().hex[:8]}",
-            Description="Test security group",
-            VpcId=vpc_id,
-        )["GroupId"]
-        return {
-            "vpc_id": vpc_id,
-            "subnet_id": subnet_id,
-            "security_group_id": security_group_id,
-        }
+        return substrate_network
+
+    @pytest.fixture
+    def aws_session(self, substrate_session):
+        """A session whose clients reach the emulator.
+
+        ``substrate_session`` wraps ``.client`` rather than expecting each call site
+        to pass ``endpoint_url``, so the mode's own clients -- built internally from
+        this session -- reach the emulator too.
+        """
+        return substrate_session
+
+    @staticmethod
+    def _job_id(label):
+        """A job ID unique in its **first eight characters**.
+
+        Not merely unique: the ECS and Lambda stack names are
+        ``parsl-{ecs,lambda}-{job_id[:8]}`` (``modes/serverless.py:564,717``), so
+        ``test-job-1`` and ``test-job-2`` are the same stack. moto never showed this
+        -- each test got a fresh mock -- while emulator state lives for the server
+        process's lifetime, so the second submit met ``AlreadyExists``.
+
+        The truncation is a real provider constraint rather than a test artefact:
+        two jobs whose IDs share eight characters collide on one stack. Same shape
+        as the bastion stack's ``workflow_id[:8]``. Worth knowing before it is met
+        in an account instead of an emulator.
+        """
+        return f"{uuid.uuid4().hex[:8]}-{label}"
 
     def _mode(self, aws_session, **overrides):
-        """Build a ServerlessMode with a unique provider ID."""
+        """Build a ServerlessMode with a unique provider ID.
+
+        The random part leads for the same reason as in ``_job_id``: the staging
+        bucket is ``parsl-lambda-code-{provider_id[:8]}``
+        (``modes/serverless.py:645``), so a ``test-``-prefixed ID gives every
+        provider in the file near-identical bucket names.
+        """
         kwargs = {
-            "provider_id": f"test-{uuid.uuid4()}",
+            "provider_id": f"{uuid.uuid4().hex[:8]}-test",
             "session": aws_session,
             "state_store": MockStateStore(),
             "worker_type": WORKER_TYPE_ECS,
@@ -158,10 +169,11 @@ class TestServerlessModeSpotFleetIntegration:
         """
         serverless_mode.initialize()
 
-        resource_id = serverless_mode.submit_job("test-job-1", "echo hello", 2)
+        job_id = self._job_id("job-1")
+        resource_id = serverless_mode.submit_job(job_id, "echo hello", 2)
 
         resource = serverless_mode.resources[resource_id]
-        assert resource["job_id"] == "test-job-1"
+        assert resource["job_id"] == job_id
         assert resource["command"] == "echo hello"
         assert resource["status"] == STATUS_PENDING
         assert resource["resource_type"] == RESOURCE_TYPE_ECS_TASK
@@ -174,18 +186,58 @@ class TestServerlessModeSpotFleetIntegration:
         outputs = {out["OutputKey"] for out in stack["Outputs"]}
         assert {"ClusterName", "ServiceName"} <= outputs
 
-    def test_submit_lambda_job_stages_a_real_zip_in_s3(self, aws_session):
+    def test_submit_ecs_job_deploys_a_readable_task_definition(self, serverless_mode):
+        """The deployed task definition reads back with its command intact.
+
+        This is the assertion moto could not support and substrate could not until
+        ``0.88.0``: three separate defects each returned a *successful* but empty or
+        truncated container list, so a stack that deployed a broken task definition
+        looked identical to one that worked. ``Command`` is the interesting field
+        because the template routes it through ``!Split`` inside
+        ``ContainerDefinitions`` -- the exact shape of substrate#521 and #526.
+        """
+        serverless_mode.initialize()
+        resource_id = serverless_mode.submit_job(
+            self._job_id("job-td"), "echo hello", 1
+        )
+        stack_name = serverless_mode.resources[resource_id]["stack_name"]
+
+        outputs = {
+            out["OutputKey"]: out["OutputValue"]
+            for out in serverless_mode.cf_client.describe_stacks(StackName=stack_name)[
+                "Stacks"
+            ][0]["Outputs"]
+        }
+
+        task_def = serverless_mode.session.client("ecs").describe_task_definition(
+            taskDefinition=outputs["TaskDefinitionArn"]
+        )["taskDefinition"]
+
+        containers = task_def["containerDefinitions"]
+        assert containers, "task definition deployed with no containers"
+        assert containers[0]["command"], "the command was lost between CFN and ECS"
+
+    def test_submit_lambda_job_stages_a_real_zip_in_s3(self, aws_session, network):
         """A Lambda submit stages an intact archive and deploys the function.
 
         The deployment package used to be latin1-decoded into the
         `CodeZipContent` CloudFormation parameter. That is neither the base64 the
-        template documents nor legal XML, so CloudFormation's own DescribeStacks
-        echo came back unparseable and the job reported UNKNOWN forever (#116).
+        template documents nor legal XML -- 117 of its codepoints are control
+        characters XML 1.0 forbids in character data -- so CloudFormation's own
+        DescribeStacks echo came back unparseable and the job reported UNKNOWN
+        forever (#116).
+
+        The parameter echo is therefore what this asserts on, since an unparseable
+        echo is precisely how that defect presented. A ``CodeSize`` comparison would
+        be the more obvious check and is the wrong one here: a CFN-deployed function
+        reports ``CodeSize: 0`` on substrate ``0.88.0`` where a direct
+        ``create_function`` reports the true size, so the assertion would fail for an
+        emulator reason while saying nothing about #116.
         """
-        mode = self._mode(aws_session, worker_type=WORKER_TYPE_LAMBDA)
+        mode = self._mode(aws_session, worker_type=WORKER_TYPE_LAMBDA, **network)
         mode.initialize()
 
-        resource_id = mode.submit_job("test-job-lambda", "echo hi", 1)
+        resource_id = mode.submit_job(self._job_id("job-lambda"), "echo hi", 1)
         resource = mode.resources[resource_id]
 
         assert resource["resource_type"] == RESOURCE_TYPE_LAMBDA_FUNCTION
@@ -200,21 +252,34 @@ class TestServerlessModeSpotFleetIntegration:
         )
         assert zipfile.ZipFile(io.BytesIO(body)).namelist() == ["handler.py"]
 
+        # The archive travels by S3 reference, and the string parameters round-trip
+        # through DescribeStacks -- the echo that used to come back unparseable.
+        stack = mode.cf_client.describe_stacks(StackName=resource["stack_name"])[
+            "Stacks"
+        ][0]
+        params = {p["ParameterKey"]: p["ParameterValue"] for p in stack["Parameters"]}
+        assert params["CodeS3Bucket"] == resource["code_bucket"]
+        assert params["CodeS3Key"] == resource["code_key"]
+        assert params["CodeZipContent"] == "", "the archive must not travel inline"
+
+        # And the function was really deployed from that reference.
+        resource_types = {
+            r["ResourceType"]
+            for r in mode.cf_client.describe_stack_resources(
+                StackName=resource["stack_name"]
+            )["StackResources"]
+        }
+        assert "AWS::Lambda::Function" in resource_types
+
         # The status query parses -- it could not while the parameter carried
         # XML-illegal control characters.
         assert mode.get_job_status([resource_id])[resource_id] == STATUS_PENDING
 
-        # And the function was really deployed from that archive.
-        function = aws_session.client("lambda").get_function(
-            FunctionName="parsl-lambda-test-job-lambda"
-        )
-        assert function["Configuration"]["CodeSize"] == len(body)
-
-    def test_cleanup_removes_the_staged_lambda_code(self, aws_session):
+    def test_cleanup_removes_the_staged_lambda_code(self, aws_session, network):
         """Cleaning up a Lambda job deletes its staged package and bucket."""
-        mode = self._mode(aws_session, worker_type=WORKER_TYPE_LAMBDA)
+        mode = self._mode(aws_session, worker_type=WORKER_TYPE_LAMBDA, **network)
         mode.initialize()
-        resource_id = mode.submit_job("test-job-lambda-2", "echo hi", 1)
+        resource_id = mode.submit_job(self._job_id("job-lambda-2"), "echo hi", 1)
         bucket = mode.resources[resource_id]["code_bucket"]
         key = mode.resources[resource_id]["code_key"]
 
@@ -228,7 +293,7 @@ class TestServerlessModeSpotFleetIntegration:
         mode.cleanup_infrastructure()
         assert bucket not in [b["Name"] for b in s3.list_buckets()["Buckets"]]
 
-    def test_a_caller_supplied_bucket_is_reused_and_kept(self, aws_session):
+    def test_a_caller_supplied_bucket_is_reused_and_kept(self, aws_session, network):
         """A configured lambda_code_bucket is staged into, never deleted.
 
         The parameter used to be ``checkpoint_bucket``, whose checkpointing half
@@ -236,25 +301,25 @@ class TestServerlessModeSpotFleetIntegration:
         behaviour under a name that describes it.
         """
         s3 = aws_session.client("s3")
-        s3.create_bucket(Bucket="parsl-test-caller-bucket")
+        caller_bucket = f"parsl-test-caller-{uuid.uuid4().hex[:8]}"
+        s3.create_bucket(Bucket=caller_bucket)
 
         mode = self._mode(
             aws_session,
             worker_type=WORKER_TYPE_LAMBDA,
-            lambda_code_bucket="parsl-test-caller-bucket",
+            lambda_code_bucket=caller_bucket,
+            **network,
         )
         mode.initialize()
-        resource_id = mode.submit_job("test-job-lambda-3", "echo hi", 1)
+        resource_id = mode.submit_job(self._job_id("job-lambda-3"), "echo hi", 1)
 
-        assert mode.resources[resource_id]["code_bucket"] == "parsl-test-caller-bucket"
+        assert mode.resources[resource_id]["code_bucket"] == caller_bucket
 
         mode.cleanup_resources([resource_id])
         mode.cleanup_infrastructure()
 
         # The caller's bucket survives: only a bucket the mode created is deleted.
-        assert "parsl-test-caller-bucket" in [
-            b["Name"] for b in s3.list_buckets()["Buckets"]
-        ]
+        assert caller_bucket in [b["Name"] for b in s3.list_buckets()["Buckets"]]
 
     def test_a_failed_submit_leaves_nothing_behind(self, serverless_mode):
         """A submit that fails mid-flight does not leak a stack or a record."""
@@ -266,7 +331,7 @@ class TestServerlessModeSpotFleetIntegration:
             side_effect=RuntimeError("boom"),
         ):
             with pytest.raises(Exception, match="Failed to submit job"):
-                serverless_mode.submit_job("test-job-fail", "echo hello", 1)
+                serverless_mode.submit_job(self._job_id("job-fail"), "echo hello", 1)
 
         # Tracking is created before dispatch now, so the failure path has to
         # remove it again -- otherwise a phantom job would be polled forever.
@@ -295,11 +360,19 @@ class TestServerlessModeSpotFleetIntegration:
         ``describe_fleets``, which knows nothing about an ``sfr-`` request, so it
         took the "EC2 has forgotten this fleet" branch and returned COMPLETED --
         the assertion was against an API the code no longer calls.
+
+        Nothing tags the instances here. ``aws:ec2:fleet-id`` is the only supported
+        way to enumerate an instant fleet's instances -- ``DescribeFleetInstances``
+        rejects this fleet type outright, and ``DescribeFleets`` reports the original
+        launch without dropping instances that have since terminated -- and the
+        emulator stamps it, as real EC2 does (substrate#443). The moto version had to
+        hand-apply the tag, which meant the lookup was passing on a tag the test
+        itself had supplied.
         """
         serverless_mode.initialize()
         ec2 = serverless_mode.session.client("ec2")
         template = ec2.create_launch_template(
-            LaunchTemplateName="parsl-test-fleet-template",
+            LaunchTemplateName=f"parsl-test-fleet-{uuid.uuid4().hex[:8]}",
             LaunchTemplateData={
                 "ImageId": "ami-12345678",
                 "InstanceType": "t3.small",
@@ -328,28 +401,8 @@ class TestServerlessModeSpotFleetIntegration:
         )
         fleet_id = fleet["FleetId"]
 
-        # Real EC2 tags every fleet-launched instance with `aws:ec2:fleet-id`,
-        # and that tag is the only supported way to enumerate an instant fleet's
-        # instances: DescribeFleetInstances rejects this fleet type outright, and
-        # DescribeFleets reports the original launch without dropping instances
-        # that have since terminated. **moto** does not apply it, so it is set
-        # here -- otherwise the lookup comes back empty and a running fleet
-        # reports COMPLETED for want of a tag rather than for any behaviour of
-        # the code under test.
-        #
-        # This file stays on moto even though substrate now applies the tag
-        # itself (substrate#443, 0.85.0): six tests here drive `cf_client`, and
-        # substrate does not emulate CloudFormation. Note the workaround is only
-        # viable *because* it is moto -- substrate now enforces the real rule
-        # that `aws:` keys are reserved and rejects create_tags outright, which
-        # is why the substrate-backed copy of this pattern in
-        # test_spot_interruption_substrate.py had to drop it.
         instance_ids = [i for g in fleet["Instances"] for i in g["InstanceIds"]]
         assert instance_ids, "fleet launched nothing; nothing to assert about"
-        ec2.create_tags(
-            Resources=instance_ids,
-            Tags=[{"Key": "aws:ec2:fleet-id", "Value": fleet_id}],
-        )
 
         assert serverless_mode._get_spot_fleet_status(fleet_id) == STATUS_RUNNING
 
@@ -365,7 +418,7 @@ class TestServerlessModeSpotFleetIntegration:
         serverless_mode.initialize()
         ec2 = serverless_mode.session.client("ec2")
         template = ec2.create_launch_template(
-            LaunchTemplateName="parsl-test-fleet-template-2",
+            LaunchTemplateName=f"parsl-test-fleet-{uuid.uuid4().hex[:8]}",
             LaunchTemplateData={
                 "ImageId": "ami-12345678",
                 "InstanceType": "t3.small",
@@ -394,10 +447,6 @@ class TestServerlessModeSpotFleetIntegration:
         )
         fleet_id = fleet["FleetId"]
         instance_ids = [i for g in fleet["Instances"] for i in g["InstanceIds"]]
-        ec2.create_tags(  # moto does not apply it; see above
-            Resources=instance_ids,
-            Tags=[{"Key": "aws:ec2:fleet-id", "Value": fleet_id}],
-        )
 
         ec2.terminate_instances(InstanceIds=instance_ids)
 
@@ -410,7 +459,7 @@ class TestServerlessModeSpotFleetIntegration:
     def test_cancel_job_deletes_the_stack(self, serverless_mode):
         """Cancelling a job marks it CANCELLED and deletes its stack."""
         serverless_mode.initialize()
-        resource_id = serverless_mode.submit_job("test-job-2", "echo hello", 2)
+        resource_id = serverless_mode.submit_job(self._job_id("job-2"), "echo hello", 2)
         stack_name = serverless_mode.resources[resource_id]["stack_name"]
 
         cancel_results = serverless_mode.cancel_jobs([resource_id])
@@ -426,18 +475,19 @@ class TestServerlessModeSpotFleetIntegration:
     def test_list_resources_groups_by_worker_type(self, serverless_mode):
         """Submitted jobs are listed under their worker type."""
         serverless_mode.initialize()
-        resource_id = serverless_mode.submit_job("test-job-3", "echo hello", 2)
+        job_id = self._job_id("job-3")
+        resource_id = serverless_mode.submit_job(job_id, "echo hello", 2)
 
         resources = serverless_mode.list_resources()
 
         assert len(resources["ecs_tasks"]) == 1
         assert resources["ecs_tasks"][0]["id"] == resource_id
-        assert resources["ecs_tasks"][0]["job_id"] == "test-job-3"
+        assert resources["ecs_tasks"][0]["job_id"] == job_id
 
     def test_cleanup_resources_drops_tracking(self, serverless_mode):
         """Cleaning up a resource deletes its stack and drops the tracking."""
         serverless_mode.initialize()
-        resource_id = serverless_mode.submit_job("test-job-4", "echo hello", 2)
+        resource_id = serverless_mode.submit_job(self._job_id("job-4"), "echo hello", 2)
         stack_name = serverless_mode.resources[resource_id]["stack_name"]
 
         serverless_mode.cleanup_resources([resource_id])
@@ -514,8 +564,9 @@ class TestServerlessModeSpotFleetIntegration:
             "NodesPerBlock": "2",
             "SpotMaxPricePercentage": "80",
         }
+        stack_name = f"parsl-ecs-parameter-check-{uuid.uuid4().hex[:8]}"
         cf.create_stack(
-            StackName="parsl-ecs-parameter-check",
+            StackName=stack_name,
             TemplateBody=get_cf_template("ecs_worker.yml"),
             Parameters=[
                 {"ParameterKey": key, "ParameterValue": value}
@@ -524,5 +575,5 @@ class TestServerlessModeSpotFleetIntegration:
             Capabilities=["CAPABILITY_IAM"],
         )
 
-        stack = cf.describe_stacks(StackName="parsl-ecs-parameter-check")["Stacks"][0]
+        stack = cf.describe_stacks(StackName=stack_name)["Stacks"][0]
         assert stack["StackStatus"] == "CREATE_COMPLETE"

--- a/tests/integration/test_substrate_modes.py
+++ b/tests/integration/test_substrate_modes.py
@@ -12,6 +12,13 @@ leaves them alone -- deleting a caller's network would be the same class of bug 
 the serverless security-group deletion fixed in #100. The old
 ``assert mode.vpc_id is None`` after cleanup asserted the opposite.
 
+Job IDs here lead with their random part rather than a ``test-job-`` prefix. The
+stack names derive from ``job_id[:8]`` (``modes/serverless.py:564,717``), so
+``f"test-job-{uuid…}"`` truncated to the same ``test-job`` for all three tests and
+the suite passed only against a freshly reset emulator -- a second run met
+``AlreadyExists``. #183 found this while moving the spot-fleet files off moto, where
+a fresh mock per test hid it.
+
 SPDX-License-Identifier: Apache-2.0
 SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
 """
@@ -115,7 +122,7 @@ class TestStandardModeSubstrate:
         try:
             mode.initialize()
 
-            job_id = f"test-job-{uuid.uuid4().hex[:8]}"
+            job_id = f"{uuid.uuid4().hex[:8]}-test-job"
             resource_id = mode.submit_job(job_id, "echo hello", 1)
 
             assert resource_id in mode.resources
@@ -136,9 +143,11 @@ class TestStandardModeSubstrate:
 class TestDetachedModeSubstrate:
     """Integration tests for DetachedMode using substrate.
 
-    ``bastion_host_type="direct"`` throughout: the CloudFormation bastion is not
-    reachable here, since substrate serves no ``cloudformation`` endpoint. That
-    path is covered against real AWS in ``tests/aws/``.
+    ``bastion_host_type="direct"`` throughout, which is now a choice rather than a
+    constraint: substrate has served CloudFormation since ``0.87.0`` and deploys
+    ``bastion.yml`` end to end since ``0.87.1``. The default stack path is covered by
+    ``test_detached_mode_spot_fleet_integration.py``, so keeping ``direct`` here means
+    both bastion paths get exercised instead of only one.
     """
 
     def _mode(self, session, network, store, provider_id, **overrides):
@@ -202,7 +211,7 @@ class TestDetachedModeSubstrate:
         try:
             mode.initialize()
 
-            job_id = f"test-job-{uuid.uuid4().hex[:8]}"
+            job_id = f"{uuid.uuid4().hex[:8]}-test-job"
             resource_id = mode.submit_job(job_id, "echo hello", 1)
 
             assert resource_id in mode.resources
@@ -318,7 +327,7 @@ class TestServerlessModeSubstrate:
         try:
             mode.initialize()
 
-            job_id = f"test-job-{uuid.uuid4().hex[:8]}"
+            job_id = f"{uuid.uuid4().hex[:8]}-test-job"
             resource_id = mode.submit_job(job_id, "echo hello", 1)
 
             assert resource_id in mode.resources


### PR DESCRIPTION
Closes #183. moto is gone from `tests/integration/` — zero `mock_aws` under that
directory, only prose explaining what changed.

## The switch adds coverage rather than trading it

substrate has overtaken moto on CloudFormation, so this is not a like-for-like port.

| | Before (moto) | After (substrate) |
|---|---|---|
| Detached bastion | `bastion_host_type="direct"` — the **fallback** | The default `cloudformation` path, deploying real `bastion.yml` |
| `aws:ec2:fleet-id` | Hand-applied by the test, then asserted | Stamped by the emulator, as real EC2 does |
| Fleet cleanup | `MagicMock` asserted to receive `cancel_spot_fleet_requests` | A real `CreateFleet` fleet, asserted `deleted*` |
| ECS task definition | Not read back | `describe_task_definition` parses, `command` non-empty |

Two of those old assertions could not have failed:

- **The fleet-id tag.** moto does not stamp it, so the test applied it and then
  looked it up — passing on a value it supplied itself. Substrate stamps it
  ([substrate#443](https://github.com/scttfrdmn/substrate/issues/443)) *and* now
  rejects manual `aws:`-prefixed keys as reserved, so the workaround is deleted, not
  ported.
- **The fleet cleanup.** It asserted a `MagicMock` had received
  `cancel_spot_fleet_requests` — the legacy API #86 removed and the provider no
  longer calls. An assertion against an API the code does not call cannot fail.

And one case moto could not run at all: since #86 `bastion.yml` puts `ImageId` in a
launch template and has the `AWS::EC2::Instance` reference it. moto's CFN handler
reads `properties["ImageId"]` directly (`moto/ec2/models/instances.py:400`) and
resolves no launch template, so it raises `KeyError` on a stack real CloudFormation
accepts. Substrate deploys it end to end since `0.87.1`
([#516](https://github.com/scttfrdmn/substrate/issues/516),
[#517](https://github.com/scttfrdmn/substrate/issues/517)).
`test_substrate_modes.py` keeps `direct`, so both bastion paths are now covered
instead of one.

## A latent bug the move surfaced

Four tests derived resource names from IDs that collide **after truncation**. The
provider truncates every ID it embeds — `parsl-bastion-{workflow_id[:8]}`
(`modes/detached.py:458`), `parsl-{ecs,lambda}-{job_id[:8]}`
(`modes/serverless.py:564,717`), `parsl-lambda-code-{provider_id[:8]}` (`:645`) — so
`f"test-job-{uuid…}"` is the single name `test-job` for every test. A second run
without `make substrate-reset` met `AlreadyExists`. The random component now leads.

Three of the four are **pre-existing** in `test_substrate_modes.py` and unrelated to
this migration. moto hid the whole class structurally: a fresh mock per test means a
same-named resource never meets its predecessor.

Worth knowing beyond the tests — this is a real provider constraint. Two live
workflows whose IDs share eight characters collide on one bastion stack.

## Two new substrate defects, found by probing

Neither blocks this PR; both are recorded in `docs/substrate_testing.md`'s gaps table
and neither is filed upstream yet.

- **Neither `DeleteStack` nor `DescribeStacks` resolves a stack ARN, only a name.**
  `delete_stack(StackName=<arn>)` returns **HTTP 200 and leaves the stack standing**;
  `describe_stacks(StackName=<arn>)` raises `ValidationError … does not exist`. Real
  CloudFormation accepts either. This hits teardown directly:
  `cleanup_infrastructure()` deletes by `self.bastion_id`, which *is* an ARN, so
  bastion teardown silently no-ops.
- **A CFN-deployed `AWS::Lambda::Function` reports `CodeSize: 0`** where a direct
  `create_function` reports the true size; `invoke` still returns 200. So `CodeSize`
  cannot prove a stack staged real code, which is why
  `test_submit_lambda_job_stages_a_real_zip_in_s3` asserts on the `DescribeStacks`
  parameter echo instead. That is the better assertion regardless: #116's symptom was
  an unparseable parameter echo (latin1-decoded zip bytes → 117 XML-illegal control
  codepoints), not a wrong size, so the guard should sit on the echo round-tripping.

## Verification

Every substrate behaviour this depends on was probed on the wire against the `0.88.0`
image rather than read from a changelog — `register_image`, `create_role`, the SSM
round-trip with a symbolic `ParameterNotFound`, the full CFN bastion lifecycle,
`delete_ec2_fleet`, the ECS stack outputs, Lambda staging, caller-bucket survival,
fleet state transitions without a hand-applied tag, and the whole `ecs_worker.yml`
parameter set. Two probes contradicted expectations and changed the design (the two
defects above).

- `tests/integration` — **131 → 133 passed**
- Run **twice with no `make substrate-reset`** on an already-dirty emulator: 133 both
  times. That is the property the old suite lacked.
- Conformance (`tests/test_substrate_emulation.py`) — 5 passed
- Unit + security — 1202 passed, 3 skipped
- `ruff check .` clean; `ruff format --check .` — 153 files formatted

The gate set in the #183 body was: *the migration is only real if the count holds
**and** the #443 tag workaround is gone — a test that still hand-applies the tag
would pass either way.* Both hold.

moto remains a dependency for `tests/unit/`, which must stay container-free. #183's
plan also called for tightening the #392 comment in
`tests/test_substrate_emulation.py`; that was already done — it asserts the symbolic
code alongside the HTTP status.