### PR TITLE
chore: release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-08-03
+
 ### Changed
 - **moto is retired from the integration suite** (#183). The two remaining
   moto-backed files —
@@ -2563,7 +2565,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ECS task definitions now create their CloudWatch log group before registration;
   log groups are tracked and deleted on cleanup (closes #22)
 
-[Unreleased]: https://github.com/scttfrdmn/parsl-ephemeral-provider/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/scttfrdmn/parsl-ephemeral-provider/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/scttfrdmn/parsl-ephemeral-provider/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/scttfrdmn/parsl-ephemeral-provider/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/scttfrdmn/parsl-ephemeral-provider/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/scttfrdmn/parsl-ephemeral-provider/compare/v0.5.0...v0.6.0

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ The following versions of Parsl Ephemeral Provider are currently being supported
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.8.x   | :white_check_mark: |
-| < 0.8   | :x:                |
+| 0.9.x   | :white_check_mark: |
+| < 0.9   | :x:                |
 
 The project is pre-1.0 and alpha: only the latest minor line receives security
 fixes, and there are no backports. Nothing has been published to PyPI yet

--- a/parsl_ephemeral_provider/__init__.py
+++ b/parsl_ephemeral_provider/__init__.py
@@ -13,7 +13,7 @@ SPDX-License-Identifier: Apache-2.0
 SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
 """
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"
 
 from .globus_compute import EphemeralComputeProvider
 from .provider import EphemeralProvider

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ parsl_ephemeral_provider = [
 
 [project]
 name = "parsl-ephemeral-provider"
-version = "0.8.0"
+version = "0.9.0"
 # "for AWS" relationally, never "AWS provider". AWS Trademark Guidelines s7 (rev.
 # 2026-07-17): "You will not combine, abbreviate, telescope, or hyphenate AWS Marks
 # with any other words" and "will not incorporate AWS Marks into the names of your
@@ -284,7 +284,7 @@ skip_covered = false
 directory = "htmlcov"
 
 [tool.bumpversion]
-current_version = "0.8.0"
+current_version = "0.9.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 search = "{current_version}"

--- a/uv.lock
+++ b/uv.lock
@@ -1473,7 +1473,7 @@ wheels = [
 
 [[package]]
 name = "parsl-ephemeral-provider"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Cuts v0.9.0. No functional change — version metadata and changelog only.

## What ships

The v0.9.0 milestone carried **12 closed and 8 open** issues. The 12 ship here.
Highlights of the 745-line `[Unreleased]` section now folded into `[0.9.0]`:

- **#183** — moto retired from `tests/integration/`, which was the deliberate
  gate on the first PyPI upload. The move *added* coverage rather than swapping
  like for like: the default CloudFormation bastion path, a real `aws:ec2:fleet-id`
  tag instead of one the test supplied itself, an observable fleet deletion, and a
  deployed ECS task definition read back.
- **#90** — 2,746 LOC removed that no package module imported, plus the whole
  `network/` package.
- **#213** — the complete identifier rename to `parsl-ephemeral-provider`.
- **#199** — two published doc pages deleted that contradicted the accurate ones.
- Dependency floors raised past three advisories, one HIGH (`cryptography`
  runtime floor → `>=48.0.1`).

## Milestone rescoping

7 of the 8 open issues moved to a new **v0.10.0** milestone: #62, #91, #130,
#133, #134, #155, #166.

**#180 stays on v0.9.0 deliberately.** It asks for a fresh version and tag built
from the renamed tree — which is this PR — and its one substantive blocker (#183)
merged in #216. After this lands, what remains on it is purely account-side:
registering trusted publishing via the pending-publisher flow.

## Two things bump-my-version doesn't do

- **Footer comparison links.** It has never written them, so `[Unreleased]` still
  compared from v0.8.0 and no `[0.9.0]` line existed. Both fixed by hand.
- **`SECURITY.md`'s supported-version table**, which named `0.8.x`. Nothing is
  backported pre-1.0, so a stale table advertises support for a line that no
  longer receives fixes.

It *did* update `__init__.py` correctly (it has missed that before), and
`make version-verify` confirms `pyproject.toml` and `__init__.py` agree at 0.9.0.

The `v0.8.0` references left in `docs/` are deliberate — each is a historical
statement about when a behaviour changed, not a claim about the current version.

## Verification

- unit + security: **1,173 passed / 3 skipped**
- `make version-verify`: *Versions agree: 0.9.0*
- pre-commit: all hooks pass, including commitlint

> [!WARNING]
> Do **not** re-run `release.yml` on the `v0.8.0` tag. It operates on the tagged
> commit, which predates the rename, and would publish `parsl_ephemeral_aws/` —
> an abandoned identity PyPI's immutable filenames make uncorrectable.