### PR TITLE
docs: the package is on PyPI, and record why substrate stays on 0.88.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,11 @@ Fleet, Lambda, or Fargate, scaled from zero and torn down when you are done.**
 
 ## Install
 
-Not yet on PyPI ([#180](https://github.com/scttfrdmn/parsl-ephemeral-provider/issues/180)),
-so install from the repository:
+```bash
+uv add parsl-ephemeral-provider
+```
+
+Or, for unreleased changes, from the repository:
 
 ```bash
 uv add git+https://github.com/scttfrdmn/parsl-ephemeral-provider

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,9 +10,10 @@ The following versions of Parsl Ephemeral Provider are currently being supported
 | < 0.9   | :x:                |
 
 The project is pre-1.0 and alpha: only the latest minor line receives security
-fixes, and there are no backports. Nothing has been published to PyPI yet
-([#180](https://github.com/scttfrdmn/parsl-ephemeral-provider/issues/180)), so every
-existing install is from source.
+fixes, and there are no backports. v0.9.0 is the first release published to PyPI
+([#180](https://github.com/scttfrdmn/parsl-ephemeral-provider/issues/180)); anything
+earlier exists only as a git tag, so a security fix reaches you by upgrading
+rather than by a patch to an older line.
 
 ## Reporting a Vulnerability
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -2,7 +2,11 @@
 
 ## Installation
 
-**Not yet on PyPI**, so install from the repository:
+```bash
+uv add parsl-ephemeral-provider
+```
+
+For unreleased changes, install from the repository instead:
 
 ```bash
 uv add git+https://github.com/scttfrdmn/parsl-ephemeral-provider
@@ -14,10 +18,9 @@ Or, working from a clone:
 uv sync --extra dev --extra test
 ```
 
-`uv add parsl-ephemeral-provider` will start working once
-[#180](https://github.com/scttfrdmn/parsl-ephemeral-provider/issues/180) is resolved —
-the package name is unregistered, so that command currently fails with "no
-matching distribution found" rather than installing an older version.
+Published since v0.9.0
+([#180](https://github.com/scttfrdmn/parsl-ephemeral-provider/issues/180)); v0.9.0 is
+the first release on PyPI, so there are no earlier versions to pin to.
 
 Python 3.10 or newer is required (Parsl 2026.x dropped 3.9).
 

--- a/docs/substrate_testing.md
+++ b/docs/substrate_testing.md
@@ -200,6 +200,29 @@ blocker: each is a hazard to what a *teardown or assertion* can be trusted to pr
 The EventBridge row is a gap this project turns to its advantage rather than one it
 works around.
 
+> [!IMPORTANT]
+> **The pin stays on `0.88.0`, and bumping it is blocked on
+> [substrate#560](https://github.com/scttfrdmn/substrate/issues/560).** `0.89.0` and
+> `0.90.0` between them fix all three rows below — including both defects this
+> repository filed, #544 and #545 — so the bump is wanted. It cannot land yet:
+> substrate gives a resource with no explicit physical name **the logical ID
+> verbatim**, and a logical ID is only unique within a stack while an IAM role name
+> is account-global. So a second stack from the same template collides with
+> `EntityAlreadyExists`, and 6 integration tests fail. `bastion.yml`
+> (`BastionHostRole`) and `ecs_worker.yml` (`TaskRole`, `TaskExecutionRole`) all
+> deliberately omit the name, which is the practice that makes a template
+> deployable more than once.
+>
+> The create was *already* failing on `0.88.0` — `0.89.0`'s rollback is only what
+> made it visible, since the stack previously still reported `CREATE_COMPLETE`. So
+> these six tests pass on the current pin for the wrong reason, which is worth
+> knowing before trusting them.
+>
+> Diagnosing it needed `DisableRollback=True` plus `DescribeStackResources`:
+> `DescribeStackEvents` answers `UnsupportedOperation` ("substrate models stack
+> status, not per-resource stack events"), so the failing resource is not reachable
+> that way.
+
 | Gap | Effect | Upstream |
 |---|---|---|
 | `DeleteStack` does not delete the stack's resources | The stack record goes and `describe_stacks` then raises `ValidationError` correctly, but an S3 bucket and an IAM role both outlive their stack. A teardown assertion that only checks the stack passes for the wrong reason. Re-probed against `0.88.0`: a CFN-created bucket is still listed after `DeleteStack` | [substrate#518](https://github.com/scttfrdmn/substrate/issues/518) |


### PR DESCRIPTION
Two unrelated-but-adjacent things, both documentation.

## 1. The install instructions were stale the moment v0.9.0 published

Three places told the reader the package was not on PyPI and to install from git:

- `README.md` — which is also the **PyPI landing page**, so this was the first
  thing a new user read after arriving from PyPI.
- `docs/getting_started.md` — including a paragraph explaining that
  `uv add parsl-ephemeral-provider` would fail with "no matching distribution
  found".
- `SECURITY.md` — "Nothing has been published to PyPI yet, so every existing
  install is from source."

`uv add parsl-ephemeral-provider` is now the first-choice instruction, with the
git form kept for unreleased changes. `SECURITY.md` now states that v0.9.0 is the
first PyPI release and that a fix reaches you by upgrading, since nothing pre-1.0
is backported.

## 2. A wanted emulator bump is blocked upstream

substrate 0.89.0 and 0.90.0 between them fix **all three** CloudFormation rows in
`docs/substrate_testing.md`, including both defects this repository filed —
[#544](https://github.com/scttfrdmn/substrate/issues/544) (stack ARNs) and
[#545](https://github.com/scttfrdmn/substrate/issues/545) (Lambda `CodeSize`). So
the bump is wanted.

**It cannot land yet.** Substrate gives a resource with no explicit physical name
the **logical ID verbatim**. A logical ID is unique only within a stack, while an
IAM role name is account-global — so a second stack from the same template
collides with `EntityAlreadyExists`. On 0.90.0 that takes 6 integration tests from
passing to failing: `bastion.yml` (`BastionHostRole`) and `ecs_worker.yml`
(`TaskRole`, `TaskExecutionRole`) all omit the name, which is precisely the
practice that makes a template deployable more than once.

Filed as [substrate#560](https://github.com/scttfrdmn/substrate/issues/560) with a
12-line reproducer that needs none of this project.

### The part worth knowing about the current pin

The create was **already failing on 0.88.0**. The stack just reported
`CREATE_COMPLETE` anyway, so nothing surfaced. 0.89.0's rollback did not break
these six tests — it revealed that they pass on our current pin *for the wrong
reason*. That is the same answers-200-while-wrong shape substrate's last three
releases have been closing, one layer down in the physical-name allocator.

Diagnosing it needed `DisableRollback=True` plus `DescribeStackResources`:
`DescribeStackEvents` answers `UnsupportedOperation` ("substrate models stack
status, not per-resource stack events"), so the failing resource is unreachable
that way. Noted in the docs for whoever hits this next.

## Verification

The pin is reverted to `0.88.0` in **both** places (`docker-compose.substrate.yml`
and `ci.yml` — they have drifted before, so they move together), leaving no
functional change in this PR.

- integration: **134 passed** against 0.88.0 after `make substrate-reset`
- `ruff check .`: clean
- The 0.90.0 image was confirmed present on ghcr before testing (`HTTP 200` on the
  manifest) — a released tag is not the same as a published image. Note the git
  tags carry a leading `v` (`v0.90.0`) while the image tags do not (`0.90.0`).