### PR TITLE
feat: add poll_until and adopt it in StandardMode (closes #91)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   exists for — and a new companion test asserts the complement, that no
   constructor parameter has fallen out of the sample set altogether.
 
+### Added
+- **`error_handling.poll_until()`, and `StandardMode`'s waits now use it** (#91).
+  Three hand-rolled `while time.time() < deadline` loops in `modes/standard.py` —
+  the EC2 Fleet block wait in `_create_spot_fleet_instance`, `_wait_for_ssm_online`,
+  and `_wait_for_worker_ready` — polled AWS on flat `time.sleep(10)` / `sleep(15)`
+  intervals while `error_handling.py` sat unused by the modes. They now share the
+  framework's backoff-and-jitter schedule, so a set of providers launched together
+  no longer polls SSM and EC2 in lockstep for the whole boot.
+
+  The framework needed a new entry point rather than the existing decorator, and
+  #91's body was wrong about this: it claimed the fleet poll "benefits from
+  `retry_with_backoff` as-is". It does not. `retry_with_backoff` fires on an
+  exception, and `SpotFleetManager.get_block_status` swallows every exception and
+  returns the last known status string — so the decorator would have fired zero
+  times at the site the issue nominated as its best fit. All three are
+  **success-polls**: the call succeeds and returns a *not-yet* answer. That shape
+  had no home in the framework, which is what `poll_until` adds; it takes a
+  predicate, a wall-clock timeout, and a `RetryConfig` used purely for its
+  delay math (`max_attempts` is deliberately ignored — a boot legitimately takes
+  forty polls).
+
+  `utils/aws.py:wait_for_resource` was considered first and cannot serve these:
+  it dispatches to *named* boto3 waiters, and no boto3 waiter exists for "fleet
+  block reached RUNNING", which `SpotFleetManager` derives from instance states.
+
+  Two details are load-bearing rather than incidental:
+
+  - **The polls narrow which errors they tolerate.** `poll_until` reads any
+    exception as "not yet", which is right for the `ClientError` these polls
+    expect and wrong for everything else — a missing credential would otherwise
+    be retried in silence until the timeout expired, turning an instant failure
+    into a five-minute one. An `on_error` hook re-raises anything that is not a
+    `ClientError`.
+  - **The fleet predicate returns a status rather than a bool**, so a terminal
+    FAILED/CANCELED/COMPLETED block fails immediately instead of being polled for
+    the full ten minutes. Raising from inside a predicate would have been read as
+    "not yet" and swallowed.
+
+  `OperatingModeError` and `ResourceCreationError` are still what these methods
+  raise on timeout; the primitive's `TimeoutError` is converted at each site.
+  The two `time.sleep` calls in `modes/detached.py` are inside the generated
+  bastion script's string literal, not module code, and are out of scope.
+
 ## [0.9.0] - 2026-08-03
 
 ### Changed

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,7 +22,7 @@ parsl_ephemeral_provider/
 ├── globus_compute.py           # EphemeralComputeProvider subclass
 ├── constants.py                # AWS constants and defaults
 ├── exceptions.py               # Exception hierarchy
-├── error_handling.py           # Retry/backoff framework (used by compute/)
+├── error_handling.py           # Retry/backoff and polling framework
 ├── modes/
 │   ├── base.py                 # OperatingMode interface
 │   ├── standard.py             # Direct client-to-worker
@@ -148,9 +148,30 @@ CloudFormation is the only IaC surface: the unused Terraform modules under
 - Exponential backoff with jitter for transient AWS API errors, via
   `error_handling.py`
 
-`error_handling.py` is used by the `compute/` managers. The `modes/` hand-roll
-their own polling loops instead; keeping both is tracked as
-[#91](https://github.com/scttfrdmn/parsl-ephemeral-provider/issues/91).
+`error_handling.py` offers two shapes, and which one applies depends on how the
+failure presents:
+
+- **`retry_with_backoff`** wraps a call that *raises*. Used throughout the
+  `compute/` managers.
+- **`poll_until`** waits on a call that *succeeds* and returns a not-yet answer —
+  an instance absent from SSM, a fleet block short of `running`. Used by
+  `StandardMode`'s three readiness waits. A retry decorator cannot express this:
+  nothing is thrown, so it would fire zero times and return the not-yet answer as
+  the result. Added in v0.10.0
+  ([#91](https://github.com/scttfrdmn/parsl-ephemeral-provider/issues/91)), which
+  replaced the modes' hand-rolled flat-interval polling loops.
+
+Both take a `RetryConfig` for the delay schedule, so a poll and a retry back off
+and jitter identically. `poll_until` ignores its `max_attempts` — a poll is bounded
+by wall clock, since a slow boot legitimately takes dozens of attempts.
+
+`utils/aws.py:wait_for_resource` occupies adjacent ground but is not
+interchangeable: it dispatches to *named* boto3 waiters, so it covers only states
+AWS itself publishes a waiter for. Derived states — "this fleet block is running",
+which `SpotFleetManager` computes from instance states — need `poll_until`.
+
+The two `time.sleep` calls in `modes/detached.py` are inside the generated bastion
+script's string literal, which runs on the bastion with no access to this package.
 
 ## Security considerations
 

--- a/parsl_ephemeral_provider/error_handling.py
+++ b/parsl_ephemeral_provider/error_handling.py
@@ -10,7 +10,7 @@ SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
 import logging
 import time
 import random
-from typing import Dict, List, Optional, Any, Type
+from typing import Callable, Dict, List, Optional, Any, Type, TypeVar
 from dataclasses import dataclass, field
 from enum import Enum
 import functools
@@ -22,6 +22,9 @@ from botocore.exceptions import (
 )
 
 logger = logging.getLogger(__name__)
+
+# The value a poll predicate yields once it is satisfied; see poll_until().
+T = TypeVar("T")
 
 
 class ErrorSeverity(Enum):
@@ -634,3 +637,95 @@ def retry_with_backoff(
         return wrapper
 
     return decorator
+
+
+def poll_until(
+    predicate: Callable[[], Optional[T]],
+    *,
+    timeout: float,
+    description: str,
+    retry_config: Optional[RetryConfig] = None,
+    on_error: Optional[Callable[[Exception], None]] = None,
+) -> T:
+    """Poll *predicate* until it returns a truthy value, with backoff and jitter.
+
+    This is the framework's entry point for a **success-poll**, which is a
+    different shape from :func:`retry_with_backoff` and cannot be expressed with
+    it (#91). The decorator retries a call that *raised*; here the call
+    **succeeds** and returns a not-yet answer -- an instance that has not
+    appeared in ``describe_instance_information``, a fleet block that has not
+    reached ``running``. Nothing is thrown, so the decorator would never fire
+    and the loop would run exactly once.
+
+    Before this existed, ``modes/`` hand-rolled three of these with flat
+    ``time.sleep(10)``/``sleep(15)`` intervals, which is the concrete debt #91
+    tracked: no jitter, so N providers started together poll AWS in lockstep,
+    and no shared notion of a bounded wait.
+
+    Parameters
+    ----------
+    predicate : Callable[[], Optional[T]]
+        Called once per attempt. Return a truthy value to stop and have it
+        returned; return ``None`` or any falsey value to keep waiting. Raising
+        is treated as "not yet" -- see *on_error*.
+    timeout : float
+        Total seconds to keep polling before giving up. This bounds wall-clock
+        time, not attempt count: unlike ``RetryConfig.max_attempts``, a caller
+        waiting for a 10-minute boot wants a deadline rather than a number of
+        tries.
+    description : str
+        What is being waited for, used in the timeout message and debug logs.
+        Phrase it as a noun so the message reads "timed out waiting for {…}".
+    retry_config : Optional[RetryConfig]
+        Supplies the delay schedule via :meth:`RetryConfig.get_delay`, so a poll
+        gets the same exponential backoff and jitter as a retry. Defaults to
+        ``RetryConfig()``. ``max_attempts`` is deliberately **not** consulted --
+        *timeout* is the bound here.
+    on_error : Optional[Callable[[Exception], None]]
+        Called with any exception the predicate raises, then polling continues.
+        Use it to log at the level the caller wants. When omitted, exceptions
+        are logged at debug: a poll's early attempts are *expected* to fail
+        (the resource does not exist yet), so warning on each one turns normal
+        operation into a wall of noise.
+
+    Returns
+    -------
+    T
+        The first truthy value *predicate* returned.
+
+    Raises
+    ------
+    TimeoutError
+        If *timeout* elapses with no truthy result. Callers that owe their own
+        exception type should catch this and re-raise; ``modes/standard.py``
+        converts it to ``OperatingModeError``.
+    """
+    config = retry_config or RetryConfig()
+    deadline = time.time() + timeout
+    attempt = 0
+
+    while True:
+        attempt += 1
+        try:
+            result = predicate()
+            if result:
+                logger.debug(f"{description}: satisfied on attempt {attempt}")
+                return result
+        except Exception as e:  # noqa: BLE001 -- a raise means "not yet"
+            if on_error is not None:
+                on_error(e)
+            else:
+                logger.debug(f"{description}: attempt {attempt} raised {e}")
+
+        delay = config.get_delay(attempt)
+        remaining = deadline - time.time()
+        if remaining <= 0:
+            break
+        # Never sleep past the deadline: a capped delay of 60s against 5s of
+        # remaining budget would otherwise overshoot the timeout by 55s and
+        # skip a final attempt the caller had time for.
+        time.sleep(min(delay, remaining))
+        if time.time() >= deadline:
+            break
+
+    raise TimeoutError(f"Timed out after {timeout}s waiting for {description}")

--- a/parsl_ephemeral_provider/modes/standard.py
+++ b/parsl_ephemeral_provider/modes/standard.py
@@ -33,6 +33,7 @@ from parsl_ephemeral_provider.constants import (
     STATUS_UNKNOWN,
     STATUS_WARM,
 )
+from parsl_ephemeral_provider.error_handling import RetryConfig, poll_until
 from parsl_ephemeral_provider.exceptions import (
     OperatingModeError,
     ResourceCreationError,
@@ -56,6 +57,26 @@ from parsl_ephemeral_provider.utils.aws import (
 
 logger = logging.getLogger(__name__)
 
+# SendCommand is asynchronous: get_command_invocation returns InvocationDoesNotExist
+# for a moment after it returns. Not a retry interval -- see _wait_for_worker_ready.
+SSM_INVOCATION_SETTLE_SECONDS = 5
+
+
+def _swallow_client_errors(exc: Exception) -> None:
+    """Log an AWS error a poll should tolerate, and re-raise anything else.
+
+    ``poll_until`` treats any exception as "not satisfied yet", which is right
+    for the ``ClientError`` these polls expect -- an instance absent from SSM,
+    an invocation that has not landed. It is wrong for everything else: a
+    missing credential or a typo in a parameter name would otherwise be retried
+    silently until the timeout expired, turning an immediate failure into a
+    five-minute one. This narrows the tolerance back to what the hand-rolled
+    loops had before #91.
+    """
+    if not isinstance(exc, ClientError):
+        raise exc
+    logger.debug(f"SSM poll tolerated: {exc}")
+
 
 class StandardMode(OperatingMode):
     """Standard operating mode implementation.
@@ -66,6 +87,17 @@ class StandardMode(OperatingMode):
     This mode supports regular EC2 instances, spot instances, and spot fleet
     requests for more reliable and cost-effective computation.
     """
+
+    # Delay schedule for the SSM readiness polls (#91). These replaced flat
+    # 10s/15s intervals: starting tighter finds an instance that registers
+    # quickly sooner, the cap keeps a slow boot from being polled hundreds of
+    # times, and the jitter stops N providers launched together from hitting
+    # SSM in lockstep -- which was the concrete cost of hand-rolling these.
+    _ssm_poll_config = RetryConfig(base_delay=5.0, max_delay=30.0)
+
+    # The fleet-block poll is coarser: EC2 Fleet capacity is fulfilled on the
+    # order of a minute, so polling it every few seconds only burns API quota.
+    _fleet_poll_config = RetryConfig(base_delay=10.0, max_delay=60.0)
 
     def __init__(
         self,
@@ -1215,21 +1247,27 @@ class StandardMode(OperatingMode):
             If the instance does not appear in SSM within *timeout* seconds.
         """
         ssm = self.session.client("ssm")
-        deadline = time.time() + timeout
-        while time.time() < deadline:
-            try:
-                resp = ssm.describe_instance_information(
-                    Filters=[{"Key": "InstanceIds", "Values": [instance_id]}]
-                )
-                if resp.get("InstanceInformationList"):
-                    logger.debug(f"Instance {instance_id} is online in SSM")
-                    return
-            except ClientError as e:
-                logger.debug(f"SSM describe_instance_information: {e}")
-            time.sleep(10)
-        raise OperatingModeError(
-            f"Instance {instance_id} did not become available in SSM within {timeout}s"
-        )
+
+        def registered() -> bool:
+            resp = ssm.describe_instance_information(
+                Filters=[{"Key": "InstanceIds", "Values": [instance_id]}]
+            )
+            return bool(resp.get("InstanceInformationList"))
+
+        try:
+            poll_until(
+                registered,
+                timeout=timeout,
+                description=f"instance {instance_id} to register with SSM",
+                retry_config=self._ssm_poll_config,
+                on_error=_swallow_client_errors,
+            )
+        except TimeoutError as e:
+            raise OperatingModeError(
+                f"Instance {instance_id} did not become available in SSM "
+                f"within {timeout}s"
+            ) from e
+        logger.debug(f"Instance {instance_id} is online in SSM")
 
     def _wait_for_worker_ready(self, instance_id: str, timeout: int = 600) -> None:
         """Wait for the worker ready marker on an instance via SSM RunCommand.
@@ -1250,31 +1288,40 @@ class StandardMode(OperatingMode):
             If the ready marker is not found within *timeout* seconds.
         """
         ssm = self.session.client("ssm")
-        deadline = time.time() + timeout
-        while time.time() < deadline:
-            try:
-                resp = ssm.send_command(
-                    InstanceIds=[instance_id],
-                    DocumentName="AWS-RunShellScript",
-                    Parameters={"commands": ["test -f /var/run/parsl_worker_ready"]},
-                    Comment="Parsl worker ready check",
-                )
-                command_id = resp["Command"]["CommandId"]
-                # Brief wait then check the result
-                time.sleep(5)
-                invocation = ssm.get_command_invocation(
-                    CommandId=command_id,
-                    InstanceId=instance_id,
-                )
-                if invocation.get("StatusDetails") == "Success":
-                    logger.debug(f"Worker ready on {instance_id}")
-                    return
-            except ClientError as e:
-                logger.debug(f"SSM ready check: {e}")
-            time.sleep(15)
-        raise OperatingModeError(
-            f"Worker ready marker not found on {instance_id} within {timeout}s"
-        )
+
+        def marker_present() -> bool:
+            resp = ssm.send_command(
+                InstanceIds=[instance_id],
+                DocumentName="AWS-RunShellScript",
+                Parameters={"commands": ["test -f /var/run/parsl_worker_ready"]},
+                Comment="Parsl worker ready check",
+            )
+            command_id = resp["Command"]["CommandId"]
+            # Not a retry interval: SendCommand is asynchronous, so the
+            # invocation does not exist to be read for a moment after it
+            # returns. This pause stays inside the predicate and deliberately
+            # stays flat -- backing it off would only delay the first read of a
+            # command that always takes about the same time to land.
+            time.sleep(SSM_INVOCATION_SETTLE_SECONDS)
+            invocation = ssm.get_command_invocation(
+                CommandId=command_id,
+                InstanceId=instance_id,
+            )
+            return bool(invocation.get("StatusDetails") == "Success")
+
+        try:
+            poll_until(
+                marker_present,
+                timeout=timeout,
+                description=f"worker ready marker on {instance_id}",
+                retry_config=self._ssm_poll_config,
+                on_error=_swallow_client_errors,
+            )
+        except TimeoutError as e:
+            raise OperatingModeError(
+                f"Worker ready marker not found on {instance_id} within {timeout}s"
+            ) from e
+        logger.debug(f"Worker ready on {instance_id}")
 
     def _dispatch_ssm_command(self, instance_id: str, command: str, job_id: str) -> str:
         """Dispatch a shell command to an EC2 instance via SSM SendCommand.
@@ -1698,22 +1745,38 @@ class StandardMode(OperatingMode):
             # above -- so a timeout here no longer conflates "no spot capacity"
             # with "slow to boot".
             max_wait = DEFAULT_RESOURCE_CREATION_TIMEOUT
-            start_time = time.time()
+            # Bind the manager locally: the guard above narrowed it away from
+            # None, but that narrowing does not reach inside a closure.
+            fleet_manager = self.spot_fleet_manager
 
-            while time.time() - start_time < max_wait:
-                status = self.spot_fleet_manager.get_block_status(block_id)
+            def settled_status() -> Optional[str]:
+                """Return the block status once it stops being provisional.
+
+                Only RUNNING and the three terminal states are answers; anything
+                else (PENDING, UNKNOWN) means keep waiting. Returning the status
+                rather than a bool lets the terminal case be handled below --
+                raising from inside a predicate would be read as "not yet"
+                and swallowed by ``poll_until``.
+                """
+                status = fleet_manager.get_block_status(block_id)
                 logger.debug(f"EC2 Fleet block {block_id} status: {status}")
+                if status in (
+                    STATUS_RUNNING,
+                    STATUS_FAILED,
+                    STATUS_CANCELED,
+                    STATUS_COMPLETED,
+                ):
+                    return str(status)
+                return None
 
-                if status == STATUS_RUNNING:
-                    break
-                elif status in [STATUS_FAILED, STATUS_CANCELED, STATUS_COMPLETED]:
-                    self._discard_failed_fleet_block(block_id)
-                    raise ResourceCreationError(
-                        f"EC2 Fleet block failed with status {status}"
-                    )
-
-                time.sleep(10)
-            else:
+            try:
+                final_status = poll_until(
+                    settled_status,
+                    timeout=max_wait,
+                    description=f"EC2 Fleet block {block_id} to reach RUNNING",
+                    retry_config=self._fleet_poll_config,
+                )
+            except TimeoutError as e:
                 logger.error(
                     f"Timeout waiting for EC2 Fleet block {block_id} to reach RUNNING"
                 )
@@ -1721,6 +1784,12 @@ class StandardMode(OperatingMode):
                 raise ResourceCreationError(
                     f"EC2 Fleet block {block_id} did not reach RUNNING "
                     f"state within {max_wait}s"
+                ) from e
+
+            if final_status != STATUS_RUNNING:
+                self._discard_failed_fleet_block(block_id)
+                raise ResourceCreationError(
+                    f"EC2 Fleet block failed with status {final_status}"
                 )
 
             # Register the fleet with the spot interruption monitor if enabled.

--- a/tests/unit/test_provider_edge_cases.py
+++ b/tests/unit/test_provider_edge_cases.py
@@ -15,9 +15,11 @@ import warnings
 from unittest.mock import MagicMock, patch
 
 import pytest
+from botocore.exceptions import ClientError, NoCredentialsError
 
 from parsl.jobs.states import JobState
 
+from parsl_ephemeral_provider.error_handling import RetryConfig
 from parsl_ephemeral_provider.constants import (
     DEFAULT_BASTION_HOST_TYPE,
     DEFAULT_BASTION_IDLE_TIMEOUT,
@@ -32,11 +34,17 @@ from parsl_ephemeral_provider.constants import (
     DEFAULT_PRESERVE_BASTION,
     DEFAULT_WARM_POOL_SIZE,
     DEFAULT_WARM_POOL_TTL,
+    STATUS_FAILED,
     STATUS_INTERRUPTED,
+    STATUS_PENDING,
+    STATUS_RUNNING,
+    STATUS_UNKNOWN,
 )
 from parsl_ephemeral_provider.exceptions import (
+    OperatingModeError,
     ProviderConfigurationError,
     ProviderError,
+    ResourceCreationError,
 )
 from parsl_ephemeral_provider.provider import EphemeralProvider
 from parsl_ephemeral_provider.state.base import STATE_KEY_MODE, STATE_KEY_PROVIDER
@@ -1830,3 +1838,251 @@ class TestRunningResourcesSurviveCleanup:
             provider, _ = _make_provider(tmp_dir)
 
         assert provider.max_idle_time == DEFAULT_MAX_IDLE_TIME
+
+
+# ---------------------------------------------------------------------------
+# TestModePollsUseTheFramework
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestModePollsUseTheFramework:
+    """StandardMode's SSM waits go through ``poll_until`` (#91).
+
+    These sites used to be hand-rolled ``while time.time() < deadline`` loops
+    with flat ``time.sleep(10)``/``sleep(15)`` intervals: no jitter, so providers
+    started together polled AWS in lockstep, and no shared notion of a bounded
+    wait. These tests pin the behaviour that changed, not the fact that a
+    particular function is called.
+    """
+
+    @pytest.fixture
+    def tmp_dir(self):
+        with tempfile.TemporaryDirectory() as d:
+            yield d
+
+    @staticmethod
+    def _mode(tmp_dir, **overrides):
+        """Build a StandardMode with a mocked session and a fast poll schedule."""
+        from parsl_ephemeral_provider.modes.standard import StandardMode
+
+        provider_id = f"test-{uuid.uuid4().hex[:8]}"
+        state_file = os.path.join(tmp_dir, f"{provider_id}.json")
+        params = dict(
+            provider_id=provider_id,
+            session=MagicMock(),
+            state_store=FileStateStore(file_path=state_file, provider_id=provider_id),
+            image_id="ami-12345678",
+            vpc_id="vpc-test00001",
+            subnet_id="subnet-test001",
+            security_group_id="sg-test00001",
+        )
+        params.update(overrides)
+        mode = StandardMode(**params)
+        # Per-instance override of the class-level schedule, so the tests do not
+        # wait out the real 5s-to-30s backoff.
+        mode._ssm_poll_config = RetryConfig(base_delay=0.001, max_delay=0.01)
+        return mode
+
+    def test_ssm_online_poll_retries_until_the_instance_appears(self, tmp_dir):
+        """An instance absent from SSM is a not-yet answer, not a failure."""
+        mode = self._mode(tmp_dir)
+        ssm = mode.session.client.return_value
+        ssm.describe_instance_information.side_effect = [
+            {"InstanceInformationList": []},
+            {"InstanceInformationList": []},
+            {"InstanceInformationList": [{"InstanceId": "i-123"}]},
+        ]
+
+        mode._wait_for_ssm_online("i-123", timeout=5)
+
+        assert ssm.describe_instance_information.call_count == 3
+
+    def test_ssm_online_timeout_still_raises_operating_mode_error(self, tmp_dir):
+        """The exception type is public API; ``poll_until`` raises TimeoutError.
+
+        Callers catch ``OperatingModeError``, so the conversion must happen
+        inside the mode rather than leaking the primitive's own type.
+        """
+        mode = self._mode(tmp_dir)
+        ssm = mode.session.client.return_value
+        ssm.describe_instance_information.return_value = {"InstanceInformationList": []}
+
+        with pytest.raises(OperatingModeError, match="did not become available in SSM"):
+            mode._wait_for_ssm_online("i-123", timeout=0.05)
+
+    def test_ssm_online_poll_tolerates_client_error(self, tmp_dir):
+        """A ClientError mid-boot is expected and must not abort the wait."""
+        mode = self._mode(tmp_dir)
+        ssm = mode.session.client.return_value
+        ssm.describe_instance_information.side_effect = [
+            ClientError(
+                error_response={"Error": {"Code": "InvalidInstanceId"}},
+                operation_name="DescribeInstanceInformation",
+            ),
+            {"InstanceInformationList": [{"InstanceId": "i-123"}]},
+        ]
+
+        mode._wait_for_ssm_online("i-123", timeout=5)
+
+        assert ssm.describe_instance_information.call_count == 2
+
+    def test_ssm_online_poll_fails_fast_on_a_non_client_error(self, tmp_dir):
+        """A credentials failure must not be retried for the full timeout.
+
+        ``poll_until`` treats any exception as "not yet", which is right for the
+        ClientError above and wrong here: no amount of waiting fixes a missing
+        credential, and swallowing it would turn an instant failure into a
+        five-minute one. The mode narrows the tolerance with ``on_error``.
+        """
+        mode = self._mode(tmp_dir)
+        ssm = mode.session.client.return_value
+        ssm.describe_instance_information.side_effect = NoCredentialsError()
+
+        with pytest.raises(NoCredentialsError):
+            mode._wait_for_ssm_online("i-123", timeout=300)
+
+        assert ssm.describe_instance_information.call_count == 1
+
+    def test_worker_ready_poll_retries_until_the_marker_lands(self, tmp_dir):
+        """The ready check re-sends its command until the marker exists."""
+        mode = self._mode(tmp_dir)
+        ssm = mode.session.client.return_value
+        ssm.send_command.return_value = {"Command": {"CommandId": "cmd-1"}}
+        ssm.get_command_invocation.side_effect = [
+            {"StatusDetails": "Failed"},
+            {"StatusDetails": "Success"},
+        ]
+
+        with patch(
+            "parsl_ephemeral_provider.modes.standard.SSM_INVOCATION_SETTLE_SECONDS", 0
+        ):
+            mode._wait_for_worker_ready("i-123", timeout=5)
+
+        assert ssm.send_command.call_count == 2
+
+    def test_worker_ready_timeout_raises_operating_mode_error(self, tmp_dir):
+        """Same public exception type as before #91."""
+        mode = self._mode(tmp_dir)
+        ssm = mode.session.client.return_value
+        ssm.send_command.return_value = {"Command": {"CommandId": "cmd-1"}}
+        ssm.get_command_invocation.return_value = {"StatusDetails": "Failed"}
+
+        with patch(
+            "parsl_ephemeral_provider.modes.standard.SSM_INVOCATION_SETTLE_SECONDS", 0
+        ):
+            with pytest.raises(OperatingModeError, match="ready marker not found"):
+                mode._wait_for_worker_ready("i-123", timeout=0.05)
+
+    def test_poll_schedules_have_jitter(self):
+        """Jitter is the concrete gain over the flat sleeps #91 replaced.
+
+        Without it, N providers launched together poll SSM and EC2 in lockstep
+        for the whole boot, which is what makes a fleet of them throttle.
+        """
+        from parsl_ephemeral_provider.modes.standard import StandardMode
+
+        for config in (StandardMode._ssm_poll_config, StandardMode._fleet_poll_config):
+            assert config.jitter is True
+            assert config.exponential_backoff is True
+            # Bounded, so a slow boot is not polled hundreds of times.
+            assert config.max_delay <= 60.0
+
+
+# ---------------------------------------------------------------------------
+# TestFleetBlockPoll
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestFleetBlockPoll:
+    """The fleet-block wait distinguishes terminal from provisional (#91).
+
+    ``get_block_status`` never raises -- its ``except`` returns the last known
+    status string -- so a retry decorator could never fire here, contrary to what
+    #91's body claimed. It is a success-poll, and the states it returns split
+    three ways: RUNNING is the answer, FAILED/CANCELED/COMPLETED must fail
+    immediately rather than wait out the timeout, and anything else means keep
+    polling.
+    """
+
+    @pytest.fixture
+    def tmp_dir(self):
+        with tempfile.TemporaryDirectory() as d:
+            yield d
+
+    @pytest.fixture
+    def mode(self, tmp_dir):
+        from parsl_ephemeral_provider.modes.standard import StandardMode
+
+        provider_id = f"test-{uuid.uuid4().hex[:8]}"
+        state_file = os.path.join(tmp_dir, f"{provider_id}.json")
+        m = StandardMode(
+            provider_id=provider_id,
+            session=MagicMock(),
+            state_store=FileStateStore(file_path=state_file, provider_id=provider_id),
+            image_id="ami-12345678",
+            vpc_id="vpc-test00001",
+            subnet_id="subnet-test001",
+            security_group_id="sg-test00001",
+        )
+        m._fleet_poll_config = RetryConfig(base_delay=0.001, max_delay=0.01)
+        # Injected rather than requested via use_spot_fleet=True: constructing a
+        # real SpotFleetManager against a MagicMock session fails in audit
+        # logging, and the manager is stubbed here regardless.
+        m.spot_fleet_manager = MagicMock()
+        m.spot_fleet_manager.create_blocks.return_value = {
+            "block-1": {"instance_ids": ["i-123"], "fleet_request_id": "fleet-1"}
+        }
+        return m
+
+    @staticmethod
+    def _run_args():
+        return {
+            "UserData": "#!/bin/bash\n",
+            "TagSpecifications": [{"Tags": [{"Key": "JobId", "Value": "job-1"}]}],
+        }
+
+    def test_pending_is_polled_until_running(self, mode):
+        """PENDING is provisional: keep asking."""
+        mode.spot_fleet_manager.get_block_status.side_effect = [
+            STATUS_PENDING,
+            STATUS_PENDING,
+            STATUS_RUNNING,
+        ]
+
+        assert mode._create_spot_fleet_instance(self._run_args()) == "block-1"
+        assert mode.spot_fleet_manager.get_block_status.call_count == 3
+
+    def test_a_terminal_status_fails_without_waiting_out_the_timeout(self, mode):
+        """FAILED is an answer, so it must not be polled for ten minutes.
+
+        Returning the status out of the predicate rather than raising inside it
+        is what makes this possible: an exception raised in a predicate is read
+        as "not yet" and swallowed.
+        """
+        mode.spot_fleet_manager.get_block_status.return_value = STATUS_FAILED
+
+        start = time.time()
+        with pytest.raises(ResourceCreationError, match="failed with status FAILED"):
+            mode._create_spot_fleet_instance(self._run_args())
+
+        assert time.time() - start < 5.0
+        assert mode.spot_fleet_manager.get_block_status.call_count == 1
+
+    def test_a_block_that_never_settles_times_out_and_is_discarded(self, mode):
+        """A timed-out block must be cleaned up, not left billing."""
+        mode.spot_fleet_manager.get_block_status.return_value = STATUS_UNKNOWN
+
+        with patch.object(mode, "_discard_failed_fleet_block") as discard:
+            with patch(
+                "parsl_ephemeral_provider.modes.standard."
+                "DEFAULT_RESOURCE_CREATION_TIMEOUT",
+                0.05,
+            ):
+                with pytest.raises(
+                    ResourceCreationError, match="did not reach RUNNING"
+                ):
+                    mode._create_spot_fleet_instance(self._run_args())
+
+        discard.assert_called_once_with("block-1")

--- a/tests/unit/test_robust_error_handling.py
+++ b/tests/unit/test_robust_error_handling.py
@@ -17,6 +17,7 @@ from parsl_ephemeral_provider.error_handling import (
     ErrorAnalyzer,
     ErrorRecoveryHandler,
     RobustErrorHandler,
+    poll_until,
     retry_with_backoff,
 )
 
@@ -463,3 +464,189 @@ class TestRetryDecorator:
 
         # Error should be recorded in handler
         assert len(error_handler.error_history) > 0
+
+
+class TestPollUntil:
+    """Tests for the success-poll primitive (#91).
+
+    ``poll_until`` exists because ``retry_with_backoff`` cannot express these
+    waits: the predicate *succeeds* and returns a not-yet answer rather than
+    raising, so the decorator would fire zero times. Several tests below pin
+    exactly that distinction.
+    """
+
+    # A schedule short enough that the whole class runs in well under a second.
+    FAST = RetryConfig(base_delay=0.01, max_delay=0.05)
+
+    def test_returns_the_first_truthy_value(self):
+        """The predicate's value is what comes back, not just True."""
+        result = poll_until(
+            lambda: "i-abc123",
+            timeout=1.0,
+            description="an instance ID",
+            retry_config=self.FAST,
+        )
+        assert result == "i-abc123"
+
+    def test_polls_until_the_predicate_flips(self):
+        """A falsey answer means keep waiting, and is not an error."""
+        calls = 0
+
+        def ready():
+            nonlocal calls
+            calls += 1
+            return calls >= 3
+
+        assert (
+            poll_until(
+                ready,
+                timeout=1.0,
+                description="readiness",
+                retry_config=self.FAST,
+            )
+            is True
+        )
+        assert calls == 3
+
+    def test_a_falsey_predicate_is_not_an_exception(self):
+        """The case ``retry_with_backoff`` cannot serve.
+
+        The predicate never raises, so a retry decorator would call it once and
+        return the not-yet answer as if it were the result. ``poll_until`` must
+        keep going instead -- this is the whole reason #91 needed a second
+        primitive rather than the existing one.
+        """
+        answers = iter([None, False, 0, "", "i-final"])
+        result = poll_until(
+            lambda: next(answers),
+            timeout=1.0,
+            description="a value after four falsey answers",
+            retry_config=self.FAST,
+        )
+        assert result == "i-final"
+
+    def test_timeout_raises_with_the_description(self):
+        """The message must name what was being waited for, not just time out."""
+        with pytest.raises(TimeoutError, match="SSM registration"):
+            poll_until(
+                lambda: False,
+                timeout=0.05,
+                description="SSM registration",
+                retry_config=self.FAST,
+            )
+
+    def test_timeout_is_respected_despite_a_long_delay_schedule(self):
+        """A delay larger than the remaining budget must not overshoot.
+
+        With ``base_delay=10`` the first sleep would be ten seconds, so a 0.1s
+        timeout has to clamp it. Without the clamp the call would block for the
+        full delay and report a 0.1s timeout ten seconds late.
+        """
+        start = time.time()
+        with pytest.raises(TimeoutError):
+            poll_until(
+                lambda: False,
+                timeout=0.1,
+                description="something that never happens",
+                retry_config=RetryConfig(base_delay=10.0, max_delay=60.0),
+            )
+        assert time.time() - start < 2.0
+
+    def test_a_raising_predicate_is_treated_as_not_yet(self):
+        """Early attempts are expected to fail; the poll absorbs that."""
+        calls = 0
+
+        def flaky():
+            nonlocal calls
+            calls += 1
+            if calls < 3:
+                raise ClientError(
+                    error_response={
+                        "Error": {"Code": "InvalidInstanceId", "Message": "nope"}
+                    },
+                    operation_name="DescribeInstanceInformation",
+                )
+            return "online"
+
+        assert (
+            poll_until(
+                flaky,
+                timeout=1.0,
+                description="an instance that 404s twice",
+                retry_config=self.FAST,
+            )
+            == "online"
+        )
+        assert calls == 3
+
+    def test_on_error_sees_every_exception(self):
+        """The hook is how a caller narrows which errors are tolerable."""
+        seen = []
+        calls = 0
+
+        def flaky():
+            nonlocal calls
+            calls += 1
+            if calls < 3:
+                raise ConnectionError(f"attempt {calls}")
+            return True
+
+        poll_until(
+            flaky,
+            timeout=1.0,
+            description="a flaky check",
+            retry_config=self.FAST,
+            on_error=seen.append,
+        )
+        assert [str(e) for e in seen] == ["attempt 1", "attempt 2"]
+
+    def test_on_error_can_reraise_to_fail_fast(self):
+        """An ``on_error`` that raises must abort the poll immediately.
+
+        This is how ``modes/standard.py`` keeps a credentials failure from being
+        retried silently for five minutes: tolerate ``ClientError``, re-raise
+        anything else. If the raise were swallowed, the poll would burn the
+        whole timeout on an error that could never resolve.
+        """
+
+        def fatal(exc):
+            raise exc
+
+        def always_raises():
+            raise NoCredentialsError()
+
+        with pytest.raises(NoCredentialsError):
+            poll_until(
+                always_raises,
+                timeout=5.0,
+                description="a poll that should fail fast",
+                retry_config=self.FAST,
+                on_error=fatal,
+            )
+
+    def test_max_attempts_does_not_bound_the_poll(self):
+        """Only *timeout* bounds a poll -- ``RetryConfig.max_attempts`` is unused.
+
+        ``RetryConfig`` is shared with the retry decorator, where
+        ``max_attempts`` is the bound. Reusing the dataclass for its delay math
+        must not import that bound: a boot that takes 40 polls is normal, and a
+        default ``max_attempts=3`` would abort it after three.
+        """
+        calls = 0
+
+        def ready_on_tenth():
+            nonlocal calls
+            calls += 1
+            return calls >= 10
+
+        assert poll_until(
+            ready_on_tenth,
+            timeout=5.0,
+            description="the tenth attempt",
+            retry_config=RetryConfig(max_attempts=3, base_delay=0.001, max_delay=0.01),
+        )
+        assert calls == 10
+
+    def test_default_retry_config_is_usable(self):
+        """Omitting *retry_config* must not require the caller to build one."""
+        assert poll_until(lambda: True, timeout=1.0, description="an immediate answer")


### PR DESCRIPTION
Closes #91.

## What changed

`error_handling.py` gains **`poll_until()`**, and the three hand-rolled polling loops in `modes/standard.py` adopt it:

| Site | Was | Now |
|---|---|---|
| `_create_spot_fleet_instance` fleet-block wait | `while` + `time.sleep(10)` | `poll_until`, 10s→60s backoff + jitter |
| `_wait_for_ssm_online` | `while` + `time.sleep(10)` | `poll_until`, 5s→30s backoff + jitter |
| `_wait_for_worker_ready` | `while` + `time.sleep(15)` | `poll_until`, 5s→30s backoff + jitter |

The concrete gain is jitter: N providers launched together used to poll SSM and EC2 in lockstep for the whole boot.

## The issue body is wrong on its central claim

#91 says the fleet poll "benefits from `retry_with_backoff`" and is "the one site where the framework fits as-is." **It is not.** `retry_with_backoff` fires on an exception, and `SpotFleetManager.get_block_status` ends:

```python
except Exception as e:
    logger.error(...)
    return self.blocks[block_id].get("status", STATUS_UNKNOWN)
```

It never raises, so the decorator would have fired **zero times** at the site the issue nominated as its best fit — the same reasoning the issue correctly applies to the two warm-pool waiters.

All three sites are **success-polls**: the call succeeds and returns a *not-yet* answer. That shape had no home in the framework. `RetryConfig` already had the delay/jitter math (`get_delay`) but only an exception-typed entry point (`should_retry`), so `poll_until` supplies the missing predicate-shaped one and reuses the math rather than duplicating it.

Per the issue's own instruction — *"Either add one (and note `utils/aws.py:1237 wait_for_resource` already occupies adjacent ground), or leave these alone. Do not force the decorator onto them."* — `wait_for_resource` was considered first and cannot serve these: it dispatches to **named boto3 waiters**, and no waiter exists for "fleet block reached RUNNING", which `SpotFleetManager` derives from instance states. `docs/architecture.md` now records when each of the three applies, so this does not become a fourth polling idiom.

## Two load-bearing details

**The polls narrow which errors they tolerate.** `poll_until` reads any exception as "not yet" — right for the `ClientError` these polls expect (an instance absent from SSM, an invocation that has not landed), wrong for everything else. A missing credential would otherwise be retried in silence until the timeout expired, turning an instant failure into a five-minute one. An `on_error` hook re-raises anything that is not a `ClientError`, restoring what the hand-rolled `except ClientError` loops had. Tested in both directions.

**The fleet predicate returns a status, not a bool.** A terminal `FAILED`/`CANCELED`/`COMPLETED` block must fail immediately rather than be polled for the full ten minutes, and raising from inside a predicate would be read as "not yet" and swallowed. So the predicate returns the status once it stops being provisional and the terminal case is handled by the caller.

`OperatingModeError` and `ResourceCreationError` are still what these methods raise on timeout — the primitive's `TimeoutError` is converted at each site, since the exception types are public API.

## Out of scope

The two `time.sleep` calls in `modes/detached.py` (`:1431`, `:1435`) are inside the **generated bastion script's string literal**, not module code. That script runs on the bastion with no access to this package, so it cannot import `poll_until`.

`time.sleep(5)` inside `_wait_for_worker_ready`'s predicate is a third thing and stays flat: `SendCommand` is asynchronous, so the invocation does not exist to be read for a moment after it returns. That is an inherent pause, not a retry policy — backing it off would only delay the first read of a command that always takes about the same time to land. It is now the named constant `SSM_INVOCATION_SETTLE_SECONDS` with that rationale attached.

## Verification

- Unit + security: **1241 passed / 2 skipped** (was 1231 on main) — 10 new `TestPollUntil`, 7 `TestModePollsUseTheFramework`, 3 `TestFleetBlockPoll`
- Integration: **134 passed** against substrate 0.88.0
- `ruff check` / `format --check`: clean over 146 files
- `mypy`: **59 errors**, baseline held (the closure needed a local bind — narrowing does not reach inside one)
- `bandit`: clean; `sphinx-build -W`: succeeded

Tests pin behaviour rather than call sites: that a falsey predicate keeps polling where a retry decorator would not, that a long delay schedule cannot overshoot a short timeout, that `max_attempts` does **not** bound a poll, that `on_error` can re-raise to fail fast, and that a terminal fleet status fails in one call instead of waiting out the timeout.