### PR TITLE
test: real-AWS coverage for three unverified options (closes #166)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The two `time.sleep` calls in `modes/detached.py` are inside the generated
   bastion script's string literal, not module code, and are out of scope.
 
+- **Real-AWS coverage for three options that had none** (#166).
+  `tests/aws/test_unverified_options_e2e.py`, 8 cases marked
+  `@pytest.mark.aws @pytest.mark.slow`. Each covers a path whose failure mode is
+  "AWS accepted the request and did not honour it" — which every mock and the
+  emulator both report as success, so no amount of `tests/unit` or
+  `tests/integration` work could reach them.
+
+  - **`ecs_container_image` on Fargate.** #136 made the option forwardable and
+    moved the default off `public.ecr.aws/lambda/python:3.9`, but nothing had
+    watched a container start from a caller-chosen image. The tests read the
+    container's own stdout out of the CloudWatch log group `ecs_worker.yml`
+    already provisions, and assert the *Python version* it reports — a
+    non-default `python:3.11-slim` is used precisely so the assertion fails if
+    the default silently wins, which is the regression #136 fixed. A second case
+    reads `stoppedReason` and the container exit codes, because a task that
+    cannot pull its image still reaches `STOPPED`; "reached STOPPED" is evidence
+    of nothing.
+  - **`preserve_bastion` and `idle_timeout`.** Both halves of the flag, not just
+    the removing one: a `preserve_bastion=True` bastion that gets torn down is a
+    detached workflow the client can never reconnect to, and a test covering only
+    `False` would pass against an implementation that always deleted. These call
+    `cleanup_infrastructure()` directly, because `shutdown()` forces
+    `preserve_bastion = False` before calling it and so cannot distinguish the
+    two settings. The self-termination case calls nothing at all and waits for the
+    bastion to reach a terminal state on its own.
+  - **`S3State(create_bucket_if_not_exists=True)` against real S3.** The
+    `CreateBucket` → `PutPublicAccessBlock` → `PutBucketTagging` sequence, plus
+    the `LocationConstraint` asymmetry (`us-east-1` rejects the parameter every
+    other region requires) that an emulator cannot expose because it accepts
+    either form. substrate#446 had left `PUT ?publicAccessBlock` unrouted on
+    exactly this path.
+
+  Writing these surfaced two facts about the API worth recording:
+
+  - **`create_bucket_if_not_exists` is not reachable through
+    `EphemeralProvider`.** The constructor takes `s3_bucket` and `s3_key`, but
+    `_initialize_state_store` builds the store with only `provider`,
+    `bucket_name`, and `key_prefix` — so a provider *always* takes the
+    already-exists branch, and a caller who wants the bucket created must
+    construct `S3State` themselves. The tests do that, and say why. The gap is
+    wider than #166 described and is not closed here.
+  - **`ecs_worker.yml` splits `Command` on commas**, via
+    `!Split [',', !Ref Command]`, so a shell string passed to `submit()` arrives
+    as a single argv[0] and the container exits before running anything. The
+    tests join their argv through a helper that documents this.
+
 ## [0.9.0] - 2026-08-03
 
 ### Changed

--- a/docs/operating_modes.md
+++ b/docs/operating_modes.md
@@ -294,9 +294,18 @@ provider = EphemeralProvider(
 `ecs_task_cpu` and `ecs_task_memory` must be a combination Fargate accepts; see
 [Fargate task
 sizes](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html).
+An invalid pair fails the *task definition*, so the CloudFormation stack rolls
+back before any container starts — which looks nothing like an image problem.
 `lambda_runtime` must be one of the `Runtime` values allowed by
 `templates/cloudformation/lambda_worker.yml`, or CloudFormation rejects the
 stack.
+
+**On ECS, the command is split on commas, not spaces.** `ecs_worker.yml` builds
+the container's argv with `!Split [',', !Ref Command]`, so pass
+`"python,-c,print(1)"` rather than `"python -c print(1)"` — a space-separated
+string arrives as a single argv[0], and the container exits without running
+anything. This applies only to `compute_type="ecs"`; Lambda and the EC2 modes take
+an ordinary shell string.
 
 These are accepted only on `mode="serverless"`; setting one on another mode
 raises `ProviderConfigurationError`. `memory_size` and `timeout` joined that

--- a/tests/aws/test_unverified_options_e2e.py
+++ b/tests/aws/test_unverified_options_e2e.py
@@ -1,0 +1,779 @@
+"""Real-AWS end-to-end tests for three paths no other suite can settle (#166).
+
+Each of these is a claim only a live run can check, because the failure mode is
+"AWS accepted the request and did not honour it" -- which every mock and every
+emulator reports as success:
+
+1. ``ecs_container_image`` actually reaches the Fargate container. #136 made the
+   option forwardable and moved the default off a Lambda base image, but nothing
+   has ever watched a container start from a caller-chosen image. A mock cannot
+   tell "the task definition accepted the image string" from "that image ran", so
+   these tests read the container's own stdout out of CloudWatch Logs.
+
+2. ``preserve_bastion`` and ``idle_timeout`` actually govern the bastion's
+   lifetime. Both were unreachable through the provider before #136. The idle
+   timer is shell that ``DetachedMode._prepare_bastion_init_script`` writes into
+   UserData and registers as a cron job on the bastion; nothing in this repo
+   executes it. It is also a cost path -- a bastion that never reclaims itself
+   bills indefinitely, the same failure class as #132 and #163.
+
+3. ``S3State(create_bucket_if_not_exists=True)`` against real S3. Covered under
+   moto and under substrate, but never against the service: ``tests/aws``'s
+   ``s3_state_bucket`` fixture pre-creates the bucket, so the provider always
+   takes the already-exists branch there.
+
+Run with::
+
+    AWS_PROFILE=aws pytest tests/aws/test_unverified_options_e2e.py -m aws --no-cov -v
+
+These cost real money and real time. The Fargate cases pull an image and run a
+task; the idle-timeout case waits out a window that cannot be shortened below
+one cron tick. See the per-class docstrings for the bounds.
+
+SPDX-License-Identifier: Apache-2.0
+SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+"""
+
+import logging
+import time
+import uuid
+
+import pytest
+from botocore.exceptions import ClientError
+
+from parsl_ephemeral_provider.exceptions import StateError
+from parsl_ephemeral_provider.provider import EphemeralProvider
+from parsl_ephemeral_provider.state.s3 import S3State
+
+logger = logging.getLogger(__name__)
+
+AWS_TEST_PROFILE = "aws"
+
+POLL_INTERVAL_S = 15
+
+# A Fargate task pulls its image before it runs, so this covers the pull as well
+# as the task. Public Docker Hub images of this size settle well inside it.
+FARGATE_MAX_WAIT_S = 900
+
+# Fargate accepts only certain CPU/memory pairs, and an invalid combination fails
+# the *task definition* -- a different error, at a different stage, that would
+# read as an image problem. 512/1024 is the smallest valid pair, so also the
+# cheapest.
+FARGATE_CPU = 512
+FARGATE_MEMORY = 1024
+
+# Deliberately NOT DEFAULT_ECS_CONTAINER_IMAGE, which is python:3.12-slim. An
+# image equal to the default cannot distinguish "the option was forwarded" from
+# "the default was used" -- precisely the bug #136 fixed. 3.11 is one minor
+# version off, so the assertion below fails if the default wins.
+ECS_TEST_IMAGE = "python:3.11-slim"
+ECS_EXPECTED_VERSION = "3.11"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _wait_for_stack(cf_client, stack_name: str, timeout: int) -> str:
+    """Poll until *stack_name* leaves IN_PROGRESS; return its final status.
+
+    The status is returned rather than asserted on: ``ecs_worker.yml`` also
+    creates two IAM roles, a cluster, and a log group, so a rollback here is
+    often not about the image at all, and the caller can say so.
+    """
+    deadline = time.time() + timeout
+    last_status = "UNKNOWN"
+    while time.time() < deadline:
+        try:
+            stacks = cf_client.describe_stacks(StackName=stack_name)["Stacks"]
+        except ClientError as exc:
+            if "does not exist" in str(exc):
+                return "DELETED"
+            raise
+        last_status = str(stacks[0]["StackStatus"])
+        if not last_status.endswith("_IN_PROGRESS"):
+            return last_status
+        time.sleep(POLL_INTERVAL_S)
+    return last_status
+
+
+def _stack_output(cf_client, stack_name: str, key: str) -> str:
+    """Return one stack output by key, or fail naming what was available.
+
+    Read from the stack rather than reconstructed from the naming convention:
+    ``LogGroupName`` is an actual Output of ``ecs_worker.yml``, and asserting
+    against a locally rebuilt ``/aws/ecs/parsl-${WorkflowId}-${JobId}`` would
+    pass even if the template stopped using that name.
+    """
+    outputs = cf_client.describe_stacks(StackName=stack_name)["Stacks"][0].get(
+        "Outputs", []
+    )
+    for output in outputs:
+        if output["OutputKey"] == key:
+            return str(output["OutputValue"])
+    pytest.fail(
+        f"Stack {stack_name} has no output {key!r}; got "
+        f"{[o['OutputKey'] for o in outputs]}"
+    )
+
+
+def _container_output(logs_client, log_group: str, timeout: int) -> str:
+    """Return everything the container wrote, as one string.
+
+    CloudWatch ingestion lags the container by a few seconds, so this polls
+    rather than reading once. An empty result is returned rather than raised:
+    "the container produced no output" is a meaningful assertion failure in the
+    caller, and a more useful message than a timeout here.
+    """
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            streams = logs_client.describe_log_streams(logGroupName=log_group).get(
+                "logStreams", []
+            )
+        except ClientError as exc:
+            if exc.response["Error"]["Code"] == "ResourceNotFoundException":
+                time.sleep(POLL_INTERVAL_S)
+                continue
+            raise
+
+        lines = []
+        for stream in streams:
+            events = logs_client.get_log_events(
+                logGroupName=log_group,
+                logStreamName=stream["logStreamName"],
+                startFromHead=True,
+            ).get("events", [])
+            lines.extend(e["message"] for e in events)
+        if lines:
+            return "\n".join(lines)
+        time.sleep(POLL_INTERVAL_S)
+    return ""
+
+
+def _bastion_instance_id(cf_client, bastion_id: str) -> str:
+    """Resolve ``bastion_id`` to an EC2 instance ID.
+
+    ``bastion_host_type`` defaults to ``"cloudformation"``, so ``bastion_id`` is
+    usually a *stack name*, not an instance ID -- ``describe_instances`` on it
+    raises. ``bastion.yml`` publishes the instance as its ``BastionHostId``
+    output.
+    """
+    if bastion_id.startswith("i-"):
+        return bastion_id
+    return _stack_output(cf_client, bastion_id, "BastionHostId")
+
+
+def _instance_state(ec2_client, instance_id: str) -> str:
+    """Return an instance's state name, or ``"gone"`` if the record is absent.
+
+    A terminated instance ages out of ``describe_instances`` entirely, so
+    ``NotFound`` and an empty reservation list both mean "terminated, and then
+    some" -- not an error.
+    """
+    try:
+        described = ec2_client.describe_instances(InstanceIds=[instance_id])
+    except ClientError as exc:
+        if "NotFound" in exc.response["Error"]["Code"]:
+            return "gone"
+        raise
+    reservations = described.get("Reservations", [])
+    if not reservations or not reservations[0].get("Instances"):
+        return "gone"
+    return str(reservations[0]["Instances"][0]["State"]["Name"])
+
+
+# ---------------------------------------------------------------------------
+# TestEcsContainerImageIsHonoured
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.aws
+@pytest.mark.slow
+class TestEcsContainerImageIsHonoured:
+    """``ecs_container_image`` runs the caller's image, not the default (#166).
+
+    This is the whole reason to choose Fargate over Lambda: an image that already
+    carries the workload's dependencies. Every assertion here reads the
+    container's *own output*, because that is the only signal separating "the
+    task definition accepted the image string" from "that image ran".
+
+    Each test deploys one CloudFormation stack and runs one Fargate task at the
+    smallest legal CPU/memory pair.
+    """
+
+    @pytest.fixture
+    def ecs_provider(self, tmp_path, aws_session, test_run_id, aws_region, network_ids):
+        """A serverless provider pinned to ECS with a non-default image.
+
+        ``compute_type="ecs"`` rather than the default: ``auto`` routes short
+        single-task commands to Lambda (``_select_worker_type``), which would
+        silently not exercise Fargate at all -- the failure this class exists to
+        catch.
+        """
+        provider = EphemeralProvider(
+            region=aws_region,
+            mode="serverless",
+            compute_type="ecs",
+            ecs_container_image=ECS_TEST_IMAGE,
+            ecs_task_cpu=FARGATE_CPU,
+            ecs_task_memory=FARGATE_MEMORY,
+            state_store_type="file",
+            state_file_path=str(tmp_path / f"state-{test_run_id}.json"),
+            auto_shutdown=True,
+            auto_create_instance_profile=True,
+            profile_name=AWS_TEST_PROFILE,
+            additional_tags={"E2ETestRunId": test_run_id, "AutoCleanup": "true"},
+            waiter_delay=15,
+            waiter_max_attempts=40,
+            debug=True,
+            **network_ids,
+        )
+
+        yield provider
+
+        try:
+            provider.shutdown()
+        except Exception as exc:
+            logger.warning("ecs_provider shutdown raised (best-effort): %s", exc)
+
+    @staticmethod
+    def _argv(*parts: str) -> str:
+        """Join *parts* the way ``ecs_worker.yml`` expects to receive them.
+
+        The template passes ``Command`` through ``!Split [',', ...]`` to build the
+        container's argv, so a plain shell string arrives as a single argv[0] and
+        the container exits before running anything. Commas -- not spaces -- are
+        the separator, which is not obvious from the provider's
+        ``submit(command)`` signature and is worth stating once here rather than
+        at each call.
+        """
+        return ",".join(parts)
+
+    def test_the_configured_image_is_what_runs(
+        self, ecs_provider, aws_session, aws_region
+    ):
+        """The container reports the Python version of the image we asked for.
+
+        The version is the assertion because it is what distinguishes the
+        configured image from the default. Asserting merely that *something* ran
+        would pass against ``python:3.12-slim`` too, and that is the exact
+        regression -- the option silently not being forwarded.
+        """
+        job_id = ecs_provider.submit(
+            self._argv(
+                "python",
+                "-c",
+                "import sys; print('PARSL_E2E_PYTHON=%d.%d' % sys.version_info[:2])",
+            ),
+            tasks_per_node=1,
+        )
+
+        cf = aws_session.client("cloudformation", region_name=aws_region)
+        logs = aws_session.client("logs", region_name=aws_region)
+        stack_name = f"parsl-ecs-{job_id[:8]}"
+
+        status = _wait_for_stack(cf, stack_name, FARGATE_MAX_WAIT_S)
+        assert status in ("CREATE_COMPLETE", "UPDATE_COMPLETE"), (
+            f"Stack {stack_name} ended at {status}. A rollback here is usually not "
+            f"about the image: check whether Fargate rejected cpu={FARGATE_CPU}/"
+            f"memory={FARGATE_MEMORY} at the task-definition stage, or an IAM "
+            "role in the template failed, before reading this as a failure of "
+            "ecs_container_image."
+        )
+
+        log_group = _stack_output(cf, stack_name, "LogGroupName")
+        output = _container_output(logs, log_group, FARGATE_MAX_WAIT_S)
+
+        assert output, (
+            f"The container wrote nothing to {log_group}. This is how a wrong "
+            "image fails quietly -- the old Lambda-base-image default started its "
+            "runtime interface emulator, waited for an invocation event that "
+            "never came, and exited with no error attributable to the image."
+        )
+        assert f"PARSL_E2E_PYTHON={ECS_EXPECTED_VERSION}" in output, (
+            f"Expected the configured {ECS_TEST_IMAGE}; container said: {output[:500]}"
+        )
+
+    def test_the_task_did_not_stop_for_a_container_level_reason(
+        self, ecs_provider, aws_session, aws_region
+    ):
+        """``stoppedReason`` must not name a pull or start failure.
+
+        A task that cannot pull its image still reaches STOPPED, so "reached
+        STOPPED" is evidence of nothing. #166 asks for ``stoppedReason``
+        specifically because that is where ``CannotPullContainerError`` and
+        entrypoint failures are reported.
+
+        ``ecs_worker.yml`` runs the task under an ECS *Service* with a
+        ``DesiredCount``, so a container that exits is replaced -- the assertion
+        is about the first task observed to stop, not about the service settling.
+        """
+        job_id = ecs_provider.submit(
+            self._argv("python", "-c", "print('PARSL_E2E_RAN')"), tasks_per_node=1
+        )
+
+        cf = aws_session.client("cloudformation", region_name=aws_region)
+        ecs = aws_session.client("ecs", region_name=aws_region)
+        stack_name = f"parsl-ecs-{job_id[:8]}"
+
+        assert _wait_for_stack(cf, stack_name, FARGATE_MAX_WAIT_S) in (
+            "CREATE_COMPLETE",
+            "UPDATE_COMPLETE",
+        ), f"Stack {stack_name} did not deploy; nothing to inspect"
+
+        cluster = _stack_output(cf, stack_name, "ClusterName")
+        # Tasks are matched by task-definition family, not by tag: the service
+        # sets no PropagateTags, so a task carries none of the stack's tags.
+        family = f"parsl-ecs-task-{job_id[:8]}"
+
+        deadline = time.time() + FARGATE_MAX_WAIT_S
+        stopped = None
+        while time.time() < deadline and stopped is None:
+            for desired in ("STOPPED", "RUNNING"):
+                arns = ecs.list_tasks(
+                    cluster=cluster, family=family, desiredStatus=desired
+                ).get("taskArns", [])
+                if not arns:
+                    continue
+                for task in ecs.describe_tasks(cluster=cluster, tasks=arns).get(
+                    "tasks", []
+                ):
+                    if task.get("lastStatus") == "STOPPED":
+                        stopped = task
+                        break
+                if stopped is not None:
+                    break
+            if stopped is None:
+                time.sleep(POLL_INTERVAL_S)
+
+        assert stopped is not None, (
+            f"No task in family {family} reached STOPPED within "
+            f"{FARGATE_MAX_WAIT_S}s. A task stuck in PROVISIONING usually means "
+            "the subnet cannot reach the registry -- Fargate pulls before it runs."
+        )
+
+        reason = stopped.get("stoppedReason", "")
+        for marker in ("CannotPullContainerError", "ImagePull", "OutOfMemoryError"):
+            assert marker not in reason, (
+                f"Task stopped for a container-level reason: {reason}"
+            )
+
+        exit_codes = [c.get("exitCode") for c in stopped.get("containers", [])]
+        assert exit_codes and all(code == 0 for code in exit_codes), (
+            f"Container exit codes {exit_codes}, stoppedReason={reason!r}. A "
+            "non-zero exit with no pull error is the signature of a command the "
+            "image cannot execute -- see _argv() on how ecs_worker.yml splits it."
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestBastionLifetimeOptions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.aws
+@pytest.mark.slow
+class TestBastionLifetimeOptions:
+    """``preserve_bastion`` and ``idle_timeout`` govern the bastion's lifetime.
+
+    Neither reached ``DetachedMode`` before #136, so the mode's defaults always
+    won and no live run has ever depended on them.
+
+    ``shutdown()`` is not the seam to test either through: it forces
+    ``preserve_bastion = False`` before calling ``cleanup_infrastructure()``
+    (``modes/detached.py:2044``), so it removes the bastion whatever the caller
+    asked for -- which ``test_shutdown_removes_bastion`` in
+    ``test_detached_mode_e2e.py`` already covers. These tests call
+    ``cleanup_infrastructure()`` directly, which is where the flag is read.
+    """
+
+    # One cron tick (*/5) + the idle window + boot + shutdown, with room to
+    # spare. The bound cannot go much below this: the script compares
+    # IDLE_MINUTES -gt IDLE_TIMEOUT -- strictly greater -- so idle_timeout=1
+    # needs more than a minute of idleness *and* the next five-minute tick.
+    SELF_TERMINATE_MAX_WAIT_S = 1500
+
+    @pytest.fixture
+    def idle_bastion_provider(
+        self, tmp_path, aws_session, test_run_id, aws_region, network_ids
+    ):
+        """A detached provider whose bastion should reclaim itself.
+
+        ``idle_timeout`` is in *minutes*; 1 is the smallest value the script's
+        strictly-greater comparison can ever act on. Constructing the provider is
+        what launches the bastion -- ``__init__`` calls
+        ``operating_mode.initialize()`` (``provider.py:791``), and there is no
+        ``provider.initialize()`` to call.
+        """
+        provider = EphemeralProvider(
+            region=aws_region,
+            instance_type="t3.micro",
+            mode="detached",
+            bastion_instance_type="t3.micro",
+            idle_timeout=1,
+            preserve_bastion=False,
+            state_store_type="file",
+            state_file_path=str(tmp_path / f"state-{test_run_id}.json"),
+            auto_shutdown=True,
+            auto_create_instance_profile=True,
+            profile_name=AWS_TEST_PROFILE,
+            additional_tags={"E2ETestRunId": test_run_id, "AutoCleanup": "true"},
+            waiter_delay=15,
+            waiter_max_attempts=40,
+            debug=True,
+            **network_ids,
+        )
+
+        yield provider
+
+        # Unconditional: if self-termination did not work, this is what stops the
+        # bastion billing. A failing test must not also leak an instance.
+        try:
+            provider.shutdown()
+        except Exception as exc:
+            logger.warning(
+                "idle_bastion_provider shutdown raised (best-effort): %s", exc
+            )
+
+    @pytest.fixture
+    def preserved_bastion_provider(
+        self, tmp_path, aws_session, test_run_id, aws_region, network_ids
+    ):
+        """A detached provider that keeps its bastion across cleanup.
+
+        ``preserve_bastion=True`` is the shipped default, and the reason it
+        exists: a preserved bastion is what a later session reconnects to. It is
+        passed explicitly so the test states what it asserts rather than relying
+        on a default it happens to share.
+        """
+        provider = EphemeralProvider(
+            region=aws_region,
+            instance_type="t3.micro",
+            mode="detached",
+            bastion_instance_type="t3.micro",
+            preserve_bastion=True,
+            state_store_type="file",
+            state_file_path=str(tmp_path / f"state-{test_run_id}.json"),
+            auto_shutdown=True,
+            auto_create_instance_profile=True,
+            profile_name=AWS_TEST_PROFILE,
+            additional_tags={"E2ETestRunId": test_run_id, "AutoCleanup": "true"},
+            waiter_delay=15,
+            waiter_max_attempts=40,
+            debug=True,
+            **network_ids,
+        )
+
+        yield provider
+
+        # shutdown() overrides preserve_bastion, which is what reclaims the
+        # instance this test deliberately left running.
+        try:
+            provider.shutdown()
+        except Exception as exc:
+            logger.warning(
+                "preserved_bastion_provider shutdown raised (best-effort): %s", exc
+            )
+
+    def test_the_bastion_terminates_itself_with_no_shutdown_call(
+        self, idle_bastion_provider, aws_session, aws_region
+    ):
+        """The bastion reaches a terminal state without the client asking.
+
+        Nothing in this body calls ``shutdown()`` or ``terminate_instances`` --
+        that is the point. The fixture's teardown runs afterwards and is a safety
+        net, not the mechanism under test.
+
+        ``InstanceInitiatedShutdownBehavior: terminate`` (``bastion.yml:146``,
+        and the same on the direct path) is what turns the script's
+        ``shutdown -h now`` into a termination rather than a stop. A bastion found
+        ``stopped`` means that setting regressed: it ends the compute charge but
+        keeps the EBS volume billing, so it is a partial failure of the same cost
+        path, not a pass.
+        """
+        mode = idle_bastion_provider.operating_mode
+        assert mode.bastion_id, "No bastion was created; nothing to reclaim"
+
+        cf = aws_session.client("cloudformation", region_name=aws_region)
+        ec2 = aws_session.client("ec2", region_name=aws_region)
+        instance_id = _bastion_instance_id(cf, mode.bastion_id)
+
+        deadline = time.time() + self.SELF_TERMINATE_MAX_WAIT_S
+        state = "unknown"
+        while time.time() < deadline:
+            state = _instance_state(ec2, instance_id)
+            if state in ("terminated", "shutting-down", "gone"):
+                return
+            assert state != "stopped", (
+                "The bastion stopped rather than terminated, so its EBS volume "
+                "keeps billing. Check that "
+                "InstanceInitiatedShutdownBehavior: terminate still reaches the "
+                "launch template."
+            )
+            time.sleep(POLL_INTERVAL_S * 2)
+
+        pytest.fail(
+            f"Bastion {instance_id} was still {state} after "
+            f"{self.SELF_TERMINATE_MAX_WAIT_S}s with idle_timeout=1 minute. The "
+            "idle script is written into UserData by "
+            "DetachedMode._prepare_bastion_init_script and registered as a */5 "
+            "cron job. Note that script begins with 'set -e' and then runs "
+            "'yum install -y python3 python3-pip jq awscli' -- awscli is not an "
+            "installable package on Amazon Linux 2023, so if that line fails the "
+            "whole UserData aborts before the cron job is ever registered. Check "
+            "/var/log/cloud-init-output.log and whether "
+            "/usr/local/bin/parsl-idle-shutdown.sh exists on the instance."
+        )
+
+    def test_cleanup_removes_the_bastion_when_not_preserving(
+        self, idle_bastion_provider, aws_session, aws_region
+    ):
+        """``preserve_bastion=False`` makes ``cleanup_infrastructure()`` reclaim it.
+
+        Called directly rather than through ``shutdown()``, which forces the flag
+        to ``False`` and so cannot distinguish the two settings. This is the
+        faster of this class's two lifetime tests: it does not wait out the idle
+        window.
+        """
+        mode = idle_bastion_provider.operating_mode
+        assert mode.bastion_id, "No bastion was created; nothing to reclaim"
+
+        cf = aws_session.client("cloudformation", region_name=aws_region)
+        ec2 = aws_session.client("ec2", region_name=aws_region)
+        instance_id = _bastion_instance_id(cf, mode.bastion_id)
+
+        mode.cleanup_infrastructure()
+
+        deadline = time.time() + 600
+        state = "unknown"
+        while time.time() < deadline:
+            state = _instance_state(ec2, instance_id)
+            if state in ("terminated", "shutting-down", "gone"):
+                return
+            time.sleep(POLL_INTERVAL_S)
+
+        pytest.fail(
+            f"Bastion {instance_id} was still {state} 600s after "
+            "cleanup_infrastructure() with preserve_bastion=False. It is billing."
+        )
+
+    def test_cleanup_keeps_the_bastion_when_preserving(
+        self, preserved_bastion_provider, aws_session, aws_region
+    ):
+        """``preserve_bastion=True`` survives ``cleanup_infrastructure()``.
+
+        The other half of the flag, and the half that is load-bearing for
+        detached mode: a bastion torn down here is a workflow the client can
+        never reconnect to. Asserting only the ``False`` case would pass against
+        an implementation that always deleted.
+        """
+        mode = preserved_bastion_provider.operating_mode
+        assert mode.bastion_id, "No bastion was created; nothing to preserve"
+
+        cf = aws_session.client("cloudformation", region_name=aws_region)
+        ec2 = aws_session.client("ec2", region_name=aws_region)
+        instance_id = _bastion_instance_id(cf, mode.bastion_id)
+
+        mode.cleanup_infrastructure()
+
+        # Give a deletion time to become visible: asserting immediately would
+        # pass even if cleanup had just issued a terminate.
+        time.sleep(POLL_INTERVAL_S * 2)
+
+        state = _instance_state(ec2, instance_id)
+        assert state in ("pending", "running"), (
+            f"Bastion {instance_id} is {state} after cleanup_infrastructure() "
+            "with preserve_bastion=True. Detached mode's whole premise is that "
+            "the client can disconnect and reconnect to this instance."
+        )
+        assert mode.bastion_id is not None, (
+            "cleanup_infrastructure() cleared bastion_id while preserving the "
+            "instance, so the next session cannot find it -- an orphan that bills"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestS3BucketCreation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.aws
+@pytest.mark.slow
+class TestS3BucketCreation:
+    """``create_bucket_if_not_exists=True`` against real S3 (#166).
+
+    Covered under moto and under substrate, but never against the service. The
+    emulator gaps this path has already hit -- substrate#446 left
+    ``PUT ?publicAccessBlock`` unrouted, so it answered ``BucketAlreadyExists``
+    for a bucket just created -- are why a live check is worth having: the
+    sequence ``CreateBucket`` → ``PutPublicAccessBlock`` → ``PutBucketTagging``
+    is where real S3 differs most from an emulator.
+
+    ``S3State`` is constructed directly, and not for convenience: **the flag is
+    not reachable from ``EphemeralProvider``**. The constructor takes
+    ``s3_bucket`` and ``s3_key``, but ``_initialize_state_store``
+    (``provider.py:1054``) builds the store with only ``provider``,
+    ``bucket_name``, and ``key_prefix`` -- so a provider always takes the
+    already-exists branch, and a caller who wants the bucket created has to build
+    the store themselves. That is arguably a wider gap than #166 describes.
+    """
+
+    @pytest.fixture
+    def bucket_name(self, aws_session, aws_region, test_run_id):
+        """A bucket name that does not exist yet, removed afterwards.
+
+        Deliberately not created here -- creating it is what is under test.
+        Teardown covers both outcomes, since an assertion that fails partway
+        through can still have left the bucket behind.
+        """
+        name = f"parsl-e2e-autocreate-{uuid.uuid4().hex[:8]}-{test_run_id}"
+        s3 = aws_session.client("s3", region_name=aws_region)
+
+        yield name
+
+        try:
+            for page in s3.get_paginator("list_objects_v2").paginate(Bucket=name):
+                objects = page.get("Contents", [])
+                if objects:
+                    s3.delete_objects(
+                        Bucket=name,
+                        Delete={"Objects": [{"Key": o["Key"]} for o in objects]},
+                    )
+            s3.delete_bucket(Bucket=name)
+            logger.info("bucket_name teardown: deleted %s", name)
+        except ClientError as exc:
+            if exc.response["Error"]["Code"] not in ("NoSuchBucket", "404"):
+                logger.warning("bucket_name teardown: %s", exc)
+
+    @pytest.fixture
+    def state_provider(self, aws_session, aws_region, test_run_id):
+        """The minimum object ``S3State`` needs.
+
+        ``resolve_session()`` returns ``provider.session`` when it is a
+        ``boto3.Session``, so the attribute must be named ``session`` -- anything
+        else falls through to assembling a fresh session from credential
+        attributes this object does not have.
+
+        A real ``EphemeralProvider`` is not used, and not merely because it is
+        heavier: constructing one reaches AWS and creates a launch template and
+        an IAM role, none of which this class is about.
+        """
+
+        class _StateProvider:
+            def __init__(self):
+                self.provider_id = f"e2e-{test_run_id}"
+                self.workflow_id = f"wf-{test_run_id}"
+                self.region = aws_region
+                self.session = aws_session
+
+        return _StateProvider()
+
+    def test_a_missing_bucket_is_created_and_locked_down(
+        self, state_provider, bucket_name, aws_session, aws_region
+    ):
+        """Creation, public-access block, and tagging.
+
+        The public-access block is the part worth asserting, more than the
+        creation: this bucket holds provider state -- instance IDs, network IDs,
+        whatever the workflow put in its tags -- and the code replaced a
+        deprecated ``ACL="private"`` with this. A bucket created without it is
+        world-readable the moment any later policy allows it.
+        """
+        s3 = aws_session.client("s3", region_name=aws_region)
+
+        with pytest.raises(ClientError) as excinfo:
+            s3.head_bucket(Bucket=bucket_name)
+        assert excinfo.value.response["Error"]["Code"] in ("404", "NoSuchBucket")
+
+        state = S3State(
+            provider=state_provider,
+            bucket_name=bucket_name,
+            create_bucket_if_not_exists=True,
+        )
+
+        s3.head_bucket(Bucket=bucket_name)
+
+        blocked = s3.get_public_access_block(Bucket=bucket_name)[
+            "PublicAccessBlockConfiguration"
+        ]
+        assert blocked["BlockPublicAcls"] is True
+        assert blocked["IgnorePublicAcls"] is True
+        assert blocked["BlockPublicPolicy"] is True
+        assert blocked["RestrictPublicBuckets"] is True
+
+        tags = {
+            t["Key"]: t["Value"]
+            for t in s3.get_bucket_tagging(Bucket=bucket_name)["TagSet"]
+        }
+        assert tags["ParslManagedBucket"] == "true"
+        assert tags["ParslWorkflowId"] == state_provider.workflow_id
+
+        # Usable, not merely present: a bucket in the wrong region answers
+        # head_bucket through a redirect but fails PutObject.
+        state.save_state("e2e-key", {"created": "auto", "live": True})
+        loaded = state.load_state("e2e-key")
+        assert loaded is not None and loaded["created"] == "auto"
+        state.delete_state("e2e-key")
+
+    def test_the_bucket_lands_in_the_configured_region(
+        self, state_provider, bucket_name, aws_session, aws_region
+    ):
+        """A ``LocationConstraint`` mistake only shows up against real S3.
+
+        ``us-east-1`` rejects a ``LocationConstraint`` while every other region
+        requires one, and ``_ensure_bucket_exists`` branches on exactly that.
+        Emulators accept either form, so the asymmetry is invisible everywhere
+        except here -- and getting it wrong puts state in a region the workflow
+        cannot reach.
+        """
+        S3State(
+            provider=state_provider,
+            bucket_name=bucket_name,
+            create_bucket_if_not_exists=True,
+        )
+
+        s3 = aws_session.client("s3", region_name=aws_region)
+        location = s3.get_bucket_location(Bucket=bucket_name)["LocationConstraint"]
+        # us-east-1 is reported as None: the API's own quirk, not a defect.
+        actual = location or "us-east-1"
+        assert actual == aws_region, (
+            f"Bucket was created in {actual}, not the configured {aws_region}"
+        )
+
+    def test_an_existing_bucket_is_adopted_not_recreated(
+        self, state_provider, bucket_name
+    ):
+        """The flag must be idempotent against the service, not just the mock.
+
+        A provider resumed from a state file constructs its store again, so every
+        restart runs this against a bucket that already exists. Here
+        ``head_bucket`` succeeds and ``CreateBucket`` is never reached -- which is
+        the behaviour worth pinning, because the alternative (re-issuing
+        ``CreateBucket``) answers differently by region and would make the resume
+        path region-dependent.
+        """
+        first = S3State(
+            provider=state_provider,
+            bucket_name=bucket_name,
+            create_bucket_if_not_exists=True,
+        )
+        first.save_state("adopted", {"ok": True})
+
+        try:
+            second = S3State(
+                provider=state_provider,
+                bucket_name=bucket_name,
+                create_bucket_if_not_exists=True,
+            )
+        except StateError as exc:
+            pytest.fail(
+                f"Reconstructing the store against its own bucket raised: {exc}. "
+                "This is the resume path -- every restart hits it."
+            )
+
+        # State the first store wrote is still readable through the second, so
+        # the bucket was adopted rather than replaced.
+        assert second.load_state("adopted") == {"ok": True}
+        second.delete_state("adopted")


### PR DESCRIPTION
Closes #166.

Adds `tests/aws/test_unverified_options_e2e.py` — 8 cases, all
`@pytest.mark.aws @pytest.mark.slow`. Every one covers a path whose failure mode
is *"AWS accepted the request and did not honour it"*, which every mock and the
substrate emulator both report as success. That is why these could not be closed
under `tests/unit` or `tests/integration`.

## What each case establishes

### `ecs_container_image` on Fargate — 2 cases

#136 made the option forwardable and moved the default off
`public.ecr.aws/lambda/python:3.9`, but nothing had ever watched a container
start from a caller-chosen image.

- `test_the_configured_image_is_what_runs` asserts the **Python version the
  container itself reports**, read out of the CloudWatch log group
  `ecs_worker.yml` already provisions (`LogGroupName` is a stack Output, so the
  test reads it rather than rebuilding the name locally). `python:3.11-slim` is
  used deliberately — one minor version off the `python:3.12-slim` default — so
  the assertion fails if the default silently wins. That is precisely the
  regression #136 fixed, and an assertion using the default image could not
  detect it.
- `test_the_task_did_not_stop_for_a_container_level_reason` reads `stoppedReason`
  and the container exit codes. A task that cannot pull its image still reaches
  `STOPPED`, so "reached STOPPED" is evidence of nothing — this is what #166 asked
  for `stoppedReason` specifically about.

The fixture pins `compute_type="ecs"`; the default `auto` routes short
single-task commands to Lambda (`_select_worker_type`), so it would not exercise
Fargate at all.

### `preserve_bastion` and `idle_timeout` — 3 cases

Both were unreachable through the provider before #136, so the mode's defaults
always won.

**`shutdown()` is not the seam these can be tested through.** It sets
`preserve_bastion = False` before calling `cleanup_infrastructure()`
(`modes/detached.py:2044`), so it reclaims the bastion whatever the caller asked
for — and `test_shutdown_removes_bastion` in `test_detached_mode_e2e.py` already
covers that. These tests call `cleanup_infrastructure()` directly, which is where
the flag is actually read.

- `test_the_bastion_terminates_itself_with_no_shutdown_call` calls nothing and
  polls for a terminal state. `InstanceInitiatedShutdownBehavior: terminate`
  (`bastion.yml:146`) is what turns the generated script's `shutdown -h now` into
  a termination; a bastion found `stopped` fails with a message saying why that
  is a partial failure of the same cost path, not a pass — it ends the compute
  charge but keeps the EBS volume billing.
- `test_cleanup_removes_the_bastion_when_not_preserving`
- `test_cleanup_keeps_the_bastion_when_preserving` — the half that would
  otherwise go untested. A `preserve_bastion=True` bastion torn down here is a
  detached workflow the client can never reconnect to, and a suite covering only
  the `False` case passes against an implementation that always deletes.

### `S3State(create_bucket_if_not_exists=True)` against real S3 — 3 cases

Covered under moto and under substrate, never against the service:
`tests/aws`'s `s3_state_bucket` fixture pre-creates the bucket, so the provider
takes the already-exists branch there.

- The `CreateBucket` → `PutPublicAccessBlock` → `PutBucketTagging` sequence.
  substrate#446 had left `PUT ?publicAccessBlock` unrouted on exactly this path,
  which is the concrete precedent for wanting a live check.
- The `LocationConstraint` asymmetry — `us-east-1` rejects the parameter every
  other region requires, and `_ensure_bucket_exists` branches on it. Emulators
  accept either form, so this is invisible anywhere else.
- Idempotence on the resume path, which every provider restart hits.

## Two API facts this surfaced

Both are recorded in the tests' own docstrings and in the CHANGELOG, since
neither is derivable from a quick read:

1. **`create_bucket_if_not_exists` is not reachable through
   `EphemeralProvider` at all.** The constructor accepts `s3_bucket` and
   `s3_key`, but `_initialize_state_store` (`provider.py:1054`) builds the store
   with only `provider`, `bucket_name`, and `key_prefix`. So a provider *always*
   takes the already-exists branch, and a caller who wants the bucket created has
   to construct `S3State` themselves — which is what these tests do. This is a
   wider gap than #166 describes and is **not closed here**; it is an API change,
   not test coverage.
2. **`ecs_worker.yml` splits `Command` on commas**, via
   `!Split [',', !Ref Command]`. A shell string passed to `submit()` therefore
   reaches the container as a single argv[0] and it exits before running
   anything. The tests join argv through an `_argv()` helper whose docstring
   states this, rather than each call site rediscovering it.

## Verification

These tests are **not run in CI** — `aws-e2e-tests` skips when
`vars.AWS_TEST_REGION` is unset (#161), and running them bills real resources.
What was verified locally on this branch:

| check | result |
|---|---|
| `pytest tests/unit tests/security --no-cov` | **1241 passed, 2 skipped** (baseline) |
| `ruff check .` / `ruff format --check .` | clean, 147 files |
| `mypy parsl_ephemeral_provider` | **59** (baseline, unchanged) |
| `pytest tests/aws/test_unverified_options_e2e.py --collect-only` | 8 collected |
| bandit, license headers, commitlint | pass |

The correctness of these tests against live AWS has **not** been demonstrated by
a run — they need `AWS_PROFILE=aws` plus `AWS_TEST_REGION`/`AWS_TEST_VPC_ID`/
`AWS_TEST_SUBNET_ID`/`AWS_TEST_SG_ID`, and the bastion case alone waits up to 25
minutes for a `*/5` cron tick plus the idle window. Every assumption they encode
was instead read out of the code and templates and cited in-place, and each
`pytest.fail` message names the specific thing to inspect if it trips. Notably,
the self-termination failure message flags that
`_prepare_bastion_init_script` runs `set -e` and then
`yum install -y python3 python3-pip jq awscli` — `awscli` is not an installable
package on AL2023, and if that line fails the UserData aborts before the cron
job is ever registered. If that test fails on first live run, that is the first
place to look.