### PR TITLE
test: fix the S3 E2E client-cache assumption, record live-run findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     as a single argv[0] and the container exits before running anything. The
     tests join their argv through a helper that documents this.
 
+  Running that suite live for the first time then found three more, filed rather
+  than fixed here: detached mode cannot create a bastion at all, because the
+  generated init script is 32 KB against a 4 KB CloudFormation parameter limit and
+  a 16 KB EC2 UserData limit (#227, `severity: critical`); the same script would
+  abort at its `awscli` install under `set -e` on Amazon Linux 2023 if it ever
+  reached an instance (#225); and the two API facts above are now #224 and #226.
+  The ECS and S3 coverage passed against live AWS.
+
+### Fixed
+- **The S3 bucket-creation E2E test asserted absence and presence through one
+  client.** A boto3 S3 client that has received a 404 for a bucket name keeps
+  answering 404 for that name after a *different* client creates the bucket —
+  verified live, still failing 15 s later, while `list_buckets` showed the bucket
+  and every other assertion in the test passed against it. `S3State` builds its own
+  client, so the create is always cross-client from the test's perspective. The
+  pre-check now uses a throwaway client. No product change: `_ensure_bucket_exists`
+  heads and creates on the same client, which is the order that works.
+
 ## [0.9.0] - 2026-08-03
 
 ### Changed

--- a/tests/aws/test_unverified_options_e2e.py
+++ b/tests/aws/test_unverified_options_e2e.py
@@ -681,10 +681,17 @@ class TestS3BucketCreation:
         deprecated ``ACL="private"`` with this. A bucket created without it is
         world-readable the moment any later policy allows it.
         """
-        s3 = aws_session.client("s3", region_name=aws_region)
-
+        # A *throwaway* client for the pre-check, never reused below. A boto3 S3
+        # client that has seen a 404 for a name goes on answering 404 for that
+        # name for at least 15s after a *different* client creates it -- verified
+        # live: same-client create-then-head succeeds, cross-client does not.
+        # Asserting absence through the same client that later asserts presence
+        # therefore fails on a bucket that demonstrably exists (list_buckets
+        # shows it, and the state round-trip at the end of this test works).
         with pytest.raises(ClientError) as excinfo:
-            s3.head_bucket(Bucket=bucket_name)
+            aws_session.client("s3", region_name=aws_region).head_bucket(
+                Bucket=bucket_name
+            )
         assert excinfo.value.response["Error"]["Code"] in ("404", "NoSuchBucket")
 
         state = S3State(
@@ -693,6 +700,7 @@ class TestS3BucketCreation:
             create_bucket_if_not_exists=True,
         )
 
+        s3 = aws_session.client("s3", region_name=aws_region)
         s3.head_bucket(Bucket=bucket_name)
 
         blocked = s3.get_public_access_block(Bucket=bucket_name)[


### PR DESCRIPTION
## What

The #166 suite ran against live AWS for the first time (`AWS_PROFILE=aws`, us-east-1,
account 942542972736). One test was wrong; three product defects surfaced and are
filed rather than fixed here.

## Results

| Phase | Tests | Result |
|---|---|---|
| S3 bucket creation | 3 | **3 pass** (after the fix in this PR) |
| Fargate `ecs_container_image` | 2 | **2 pass**, 182 s |
| Bastion lifetime | 3 | **3 error at construction** — #227 |

`ecs_container_image` is genuinely honoured on live Fargate: the container reported
`PARSL_E2E_PYTHON=3.11` from the configured `python:3.11-slim`, not the
`python:3.12-slim` default. That is the assertion #136 shipped without and #166 asked
for, and it holds.

Zero leaked resources after every phase — no stacks, instances, task definitions, log
groups, buckets, or IAM role/profile pairs. The ECS log group goes with its stack, and
detached mode's error path deletes its own half-created stack.

## The fix

`test_a_missing_bucket_is_created_and_locked_down` failed on a bucket that
demonstrably existed — `list_buckets` showed it, the public-access-block and tagging
assertions passed against it, and the state round-trip at the end of the same test
worked.

A boto3 S3 client that has received a 404 for a bucket name keeps answering 404 for
that name after a **different** client creates the bucket. Isolated live:

```
create on SAME client as precheck : head on precheck-client -> OK
create on OTHER client            : head on precheck-client -> FAIL 404
```

Still failing 15 s later, so it is not propagation lag. `S3State` builds its own
client, so from the test's perspective the create is always cross-client. Asserting
absence and presence through one client is unsound here; the pre-check now uses a
throwaway client.

**No product change.** `_ensure_bucket_exists` heads and creates on the same client,
which is the working order.

## Filed, not fixed

- **#227 (`severity: critical`) — detached mode cannot create a bastion at all.** The
  generated init script is 32,055 B. The default CloudFormation path base64-encodes it
  to 42,740 B and sends it as a stack *parameter*, against a 4,096 B limit — boundary
  probed exactly: 4,096 accepted, 4,097 rejected. The `"direct"` path passes it raw to
  `RunInstances`, against a 16,384 B limit — confirmed by `DryRun`. Both paths blocked,
  so `EphemeralProvider.__init__` raises for `mode="detached"`.
- **#225 — the bastion script would abort at its `awscli` install under `set -e`** on
  AL2023, taking the orchestrator service, the idle-shutdown script and its cron entry
  with it. Real in the script text, but unreachable until #227 lands. Cross-linked.
- **#224** — `create_bucket_if_not_exists` unreachable through `EphemeralProvider`.
- **#226** — `ecs_worker.yml` splits `Command` on commas.

The three bastion tests need no change; they become the regression check for #227.

## Verification

- `ruff check` + `ruff format --check` clean
- The 3 S3 tests pass live, 3/3, after the fix; they failed 3/3 before it
- CHANGELOG updated under `[Unreleased]` (`### Fixed`, plus a note on the live-run
  outcome in the existing #166 entry)