### PR TITLE
fix: stage the bastion init script in S3 instead of UserData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,83 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The ECS and S3 coverage passed against live AWS.
 
 ### Fixed
+- **Detached mode could not create a bastion at all** (#227). The init script the
+  bastion boots from is ~32 KB — 42,740 B base64-encoded — against a **4,096 B**
+  CloudFormation parameter limit and a **16,384 B** `RunInstances` UserData limit.
+  Both bastion paths therefore failed: `create_stack` rejected the parameter
+  outright, and the direct path was refused by EC2. gzip does not rescue it (34 KB
+  compresses to 8,333 B — inside EC2's limit, still double CloudFormation's).
+
+  The script is now uploaded to S3 and UserData carries only a shim that fetches
+  it. The URL is **presigned**, not an `aws s3 cp` against the instance's own
+  role, because the direct path attaches no instance profile (#229), so a
+  credentialed fetch would have rescued only the CloudFormation bastion. One
+  mechanism now fixes both.
+
+  The bucket is provider-scoped, created on first use, and deleted on cleanup
+  **only if this mode created it** — the ownership gate #100 established for the
+  serverless security group. Staged-script cleanup is gated on `preserve_bastion`
+  alone rather than on the bastion having been created, so a script staged for a
+  bastion whose creation then failed is still collected.
+
+  Verified against real AWS: a bastion stack reached `CREATE_COMPLETE` and a
+  direct-path bastion launched, both from a UserData shim under 4,096 B, and the
+  two live cleanup E2E tests that previously errored during construction now pass.
+  Verified against substrate that the presigned URL in UserData really serves the
+  script over HTTP — which caught a defect no mock could: botocore's *presigner*
+  emits SigV2 even when `client.meta.config.signature_version` reports `s3v4`, and
+  SigV2 is rejected by every region created after 2014 (substrate answers 501).
+  `Config(signature_version="s3v4")` is now passed explicitly.
+
+  The size assertions assume the **worst-case** URL. A presigned URL is 175 B with
+  static keys but **1,064 B** under session-token credentials, where the token
+  alone is ~664 B — measured, after an assertion written against the short form
+  would have passed in development and failed for anyone using a role.
+- **The bastion init script aborted on its first `dnf` line, so no bastion ever
+  orchestrated anything** (#225). It ran under `set -e` and then
+  `apt-get install -y python3 python3-pip jq awscli || yum install ...`. On Amazon
+  Linux 2023 — the default AMI family — `apt-get` does not exist, and `awscli` is
+  not an installable package there (CLI v2 ships preinstalled; the v1 package was
+  dropped). Both sides failed, `set -e` aborted, and the manager script, its
+  systemd service and the idle-shutdown timer were never installed. The instance
+  still reached `running` and the stack still reported `CREATE_COMPLETE`.
+
+  The install now dispatches on the available package manager, and the package
+  list is three corrections deep — each found by booting a bastion, not by reading
+  the shell:
+
+  - **`python3-boto3`, not `pip install boto3`.** The manager imports boto3 at
+    module scope and no AMI ships it, so the original line could not have produced
+    a working bastion even had every package in it resolved. But `dnf install
+    python3-pip` pulls in **python3.11** and repoints `/usr/bin/python3` at it,
+    breaking `dnf` itself and AWS CLI v2 — both python3.9 scripts — with
+    `ModuleNotFoundError: No module named 'dnf'`. AL2023 packages boto3 for the
+    system 3.9.
+  - **`cronie`.** AL2023 installs no cron daemon, so the idle-shutdown timer — the
+    only thing that reads `idle_timeout` — was registered against a `crontab` that
+    did not exist.
+  - **no `python3` in the list.** It is already present, and naming it invites the
+    same 3.11 substitution.
+
+  The script now also verifies its prerequisites by outcome rather than by
+  installer exit status (the pip failure was an installer that *succeeded* and left
+  the system unable to run its own tools), and ends by touching
+  `/var/run/parsl_bastion_ready`. That sentinel is the only positive evidence
+  UserData ran to the end: instance state, status checks and stack status are all
+  indifferent to it, which is how this stayed invisible.
+- **The idle-shutdown timer was registered on no schedule** (#225). Even with a
+  cron daemon installed, `(crontab -l 2>/dev/null; echo '...') | crontab -` left
+  `/var/spool/cron/root` at **0 bytes** on a fresh bastion: `crontab -l` has
+  nothing to list there and exits non-zero, so the subshell contributed nothing
+  and the append landed nowhere — while every command in the pipeline exited 0.
+  `idle_timeout` could not work, and with the default `preserve_bastion=True`
+  nothing else reclaims a bastion.
+
+  The timer is now a `/etc/cron.d/parsl-idle-shutdown` drop-in, which has no
+  read-modify-write step and so no empty-input case. The prerequisite check now
+  requires a *running* daemon (`systemctl is-active crond`) rather than the
+  `crontab` client being on `PATH`; the client's presence said nothing about
+  whether the drop-in would ever be read.
 - **The S3 bucket-creation E2E test asserted absence and presence through one
   client.** A boto3 S3 client that has received a 404 for a bucket name keeps
   answering 404 for that name after a *different* client creates the bucket —

--- a/parsl_ephemeral_provider/constants.py
+++ b/parsl_ephemeral_provider/constants.py
@@ -445,6 +445,26 @@ DEFAULT_BASTION_HOST_TYPE = "cloudformation"  # or "direct" (RunInstances)
 # against this constant rather than a copied-out "t3.micro".
 DEFAULT_BASTION_INSTANCE_TYPE = "t3.micro"
 
+# Delivery limits for the bastion's UserData, and the margin the shim must fit.
+#
+# The bastion init script is a whole program -- ~32 KB of shell wrapping an
+# ~850-line embedded Python orchestrator -- and #227 found it exceeded every
+# mechanism that was being used to deliver it: 10.4x the CloudFormation
+# parameter limit and 2.0x EC2's raw UserData limit. It is now staged in S3 and
+# fetched by a shim small enough that neither limit is a constraint again.
+#
+# Both limits are asserted at render time (`_prepare_bastion_user_data`) so a
+# future edit to the script cannot silently reintroduce #227: the failure would
+# otherwise appear only against live AWS, since substrate enforces neither.
+MAX_CFN_PARAMETER_BYTES = 4096  # CloudFormation parameter value, probed exactly
+MAX_EC2_USER_DATA_BYTES = 16384  # RunInstances UserData, before base64
+MAX_EC2_USER_DATA_B64_BYTES = 25600  # RunInstances UserData, after base64
+# How long the presigned GET on the staged script stays valid. The shim runs
+# once, seconds into first boot, so this only has to outlast instance
+# provisioning -- but a spot bastion can sit in `pending` for minutes, so the
+# window is generous rather than tight.
+BASTION_SCRIPT_URL_TTL = 3600  # seconds
+
 # Lambda defaults (minimal for imports)
 DEFAULT_LAMBDA_TIMEOUT = 300
 # python3.9 reached end of support, and this package requires Python >= 3.10

--- a/parsl_ephemeral_provider/modes/detached.py
+++ b/parsl_ephemeral_provider/modes/detached.py
@@ -17,13 +17,18 @@ import uuid
 from typing import Any, Dict, List, Optional
 
 import boto3
+from botocore.config import Config
 from botocore.exceptions import ClientError
 
 from parsl_ephemeral_provider.constants import (
+    BASTION_SCRIPT_URL_TTL,
     DEFAULT_BASTION_HOST_TYPE,
     DEFAULT_BASTION_IDLE_TIMEOUT,
     DEFAULT_PRESERVE_BASTION,
     IMDSV2_METADATA_OPTIONS,
+    MAX_CFN_PARAMETER_BYTES,
+    MAX_EC2_USER_DATA_B64_BYTES,
+    MAX_EC2_USER_DATA_BYTES,
     RESOURCE_TYPE_EC2,
     RESOURCE_TYPE_BASTION,
     RESOURCE_TYPE_CLOUDFORMATION,
@@ -140,6 +145,15 @@ class DetachedMode(OperatingMode):
         self.idle_timeout = idle_timeout
         self.preserve_bastion = preserve_bastion
         self.stack_name = None
+
+        # Where the bastion init script is staged for the instance to fetch
+        # (#227). The script is far too large to pass as UserData directly, so
+        # UserData is a shim that downloads this object. The ownership flag is
+        # the same guard as serverless mode's Lambda code bucket: a bucket this
+        # mode created is deleted at cleanup, one it merely found is not.
+        self._script_bucket: Optional[str] = None
+        self._script_key: Optional[str] = None
+        self._owns_script_bucket = False
 
         # Spot Fleet specific attributes
         self.use_spot_fleet = use_spot_fleet
@@ -337,8 +351,10 @@ class DetachedMode(OperatingMode):
             )
 
         try:
-            # Prepare bastion init script
-            init_script = self._prepare_bastion_init_script()
+            # UserData is the bootstrap shim, not the init script itself: the
+            # script is ~32 KB against EC2's 16 KB limit, so passing it here
+            # failed outright (#227). It is staged in S3 and fetched on boot.
+            init_script = self._prepare_bastion_user_data()
 
             # Prepare instance tags
             tags = [
@@ -457,8 +473,10 @@ class DetachedMode(OperatingMode):
             # Prepare stack name
             self.stack_name = f"parsl-bastion-{self.workflow_id[:8]}"
 
-            # Prepare bastion init script
-            init_script = self._prepare_bastion_init_script()
+            # The stack parameter carries the bootstrap shim, not the init
+            # script: base64 of the script was 42,740 B against a 4,096 B
+            # parameter limit, so create_stack rejected every bastion (#227).
+            init_script = self._prepare_bastion_user_data()
             init_script_b64 = base64.b64encode(init_script.encode()).decode()
 
             # Prepare tags
@@ -600,10 +618,69 @@ class DetachedMode(OperatingMode):
         if self.worker_init:
             init_script += f"# Custom initialization\n{self.worker_init}\n\n"
 
-        # Install required packages
+        # Install required packages.
+        #
+        # This block used to be a single `apt-get ... || yum ...` line including
+        # `awscli`, under `set -e` (#225). On Amazon Linux 2023 -- the default
+        # AMI family -- `apt-get` is absent so the left side failed, and
+        # `awscli` is not an installable package there (CLI v2 ships
+        # preinstalled, and the v1 package was dropped), so the right side
+        # failed too. Under `set -e` UserData aborted here, and everything
+        # below -- the manager script, its service, the idle-shutdown cron --
+        # never happened. The instance still reached `running` and the stack
+        # still reported CREATE_COMPLETE, which is why it went unnoticed.
+        #
+        # The package list is what a live AL2023 bastion actually needs, three
+        # corrections deep (each found by booting one, not by reading):
+        #
+        # - `python3-boto3`, not `pip install boto3`. The manager script imports
+        #   boto3 at module scope and no AMI ships it, so the original line could
+        #   not have produced a working bastion even had every package in it
+        #   resolved. But installing it via pip means first installing pip, and
+        #   `dnf install python3-pip` pulls in **python3.11** and repoints
+        #   /usr/bin/python3 at it -- which breaks `dnf` itself and AWS CLI v2,
+        #   both of which are python3.9 scripts (`ModuleNotFoundError: No module
+        #   named 'dnf'`). AL2023 packages boto3 for the system 3.9; use that.
+        # - `cronie`. AL2023 has no cron daemon installed, so `crontab -` below
+        #   failed with "command not found" and the idle-shutdown timer -- the
+        #   only thing that reads `idle_timeout` -- silently never ran.
+        # - no `python3` in the list. It is already present, and naming it
+        #   invites the same 3.11 substitution.
         init_script += "# Install required packages\n"
-        init_script += "apt-get update -y || yum update -y\n"
-        init_script += "apt-get install -y python3 python3-pip jq awscli || yum install -y python3 python3-pip jq awscli\n\n"
+        init_script += "if command -v dnf >/dev/null 2>&1; then\n"
+        init_script += "    dnf install -y python3-boto3 jq cronie\n"
+        init_script += "elif command -v yum >/dev/null 2>&1; then\n"
+        init_script += "    yum install -y python3-boto3 jq cronie\n"
+        init_script += "elif command -v apt-get >/dev/null 2>&1; then\n"
+        init_script += "    apt-get update -y\n"
+        init_script += "    apt-get install -y python3-boto3 jq cron\n"
+        init_script += "else\n"
+        init_script += '    echo "No supported package manager found" >&2\n'
+        init_script += "    exit 1\n"
+        init_script += "fi\n\n"
+
+        # crond is enabled on install but not started in the same boot.
+        init_script += "systemctl enable --now crond 2>/dev/null || "
+        init_script += "systemctl enable --now cron 2>/dev/null || true\n\n"
+
+        # Fail loudly on a missing prerequisite rather than pressing on and
+        # leaving a bastion that looks healthy but orchestrates nothing. Checking
+        # the outcome rather than the installer's exit status is deliberate: the
+        # `python3-pip` failure above was an installer that *succeeded* and left
+        # the system unable to run its own tools.
+        init_script += "# Verify prerequisites\n"
+        init_script += "for cmd in python3 jq; do\n"
+        init_script += '    command -v "$cmd" >/dev/null 2>&1 || '
+        init_script += '{ echo "Required command $cmd not found" >&2; exit 1; }\n'
+        init_script += "done\n"
+        init_script += 'python3 -c "import boto3" || '
+        init_script += '{ echo "boto3 not importable" >&2; exit 1; }\n'
+        # A *running* daemon, not merely an installed `crontab` client. The
+        # /etc/cron.d drop-in below is read by the daemon alone, so `crontab`
+        # being on PATH proves nothing about whether the timer will ever fire.
+        init_script += "systemctl is-active crond >/dev/null 2>&1 || "
+        init_script += "systemctl is-active cron >/dev/null 2>&1 || "
+        init_script += '{ echo "No cron daemon is running" >&2; exit 1; }\n\n'
 
         # Set up environment variables
         init_script += "# Set up environment variables\n"
@@ -684,11 +761,275 @@ class DetachedMode(OperatingMode):
         # Make idle shutdown script executable
         init_script += "chmod +x /usr/local/bin/parsl-idle-shutdown.sh\n\n"
 
-        # Create cron job for idle shutdown
-        init_script += "# Create cron job for idle shutdown\n"
-        init_script += "(crontab -l 2>/dev/null; echo '*/5 * * * * /usr/local/bin/parsl-idle-shutdown.sh') | crontab -\n\n"
+        # Register the idle-shutdown timer.
+        #
+        # This was `(crontab -l 2>/dev/null; echo '...') | crontab -`, which on a
+        # fresh bastion wrote a **0-byte** /var/spool/cron/root: `crontab -l` has
+        # nothing to list on an instance with no prior crontab, and on AL2023 it
+        # exits non-zero and prints its "no crontab for root" notice to stderr,
+        # so the subshell contributed nothing and -- because the `echo` and the
+        # pipe are evaluated together -- the append landed nowhere. The timer was
+        # registered on no schedule at all, which is the second reason
+        # `idle_timeout` could not work even after #225 installed cronie. Only
+        # reading /var/spool/cron/root on a live bastion showed it; every command
+        # in the pipeline exits 0.
+        #
+        # A file in /etc/cron.d needs no read-modify-write of existing state, so
+        # it has no empty-input case. It takes a user field (crontab(5) system
+        # format), must be mode 0644 and owned by root, and its name must contain
+        # no dot -- cron silently ignores files that violate any of those.
+        init_script += "# Register the idle-shutdown timer\n"
+        init_script += "cat > /etc/cron.d/parsl-idle-shutdown << 'EOL'\n"
+        init_script += "SHELL=/bin/bash\n"
+        init_script += "PATH=/sbin:/bin:/usr/sbin:/usr/bin\n"
+        init_script += "*/5 * * * * root /usr/local/bin/parsl-idle-shutdown.sh\n"
+        init_script += "EOL\n"
+        init_script += "chown root:root /etc/cron.d/parsl-idle-shutdown\n"
+        init_script += "chmod 0644 /etc/cron.d/parsl-idle-shutdown\n\n"
+
+        # Signal completion. The sentinel is the only positive evidence that the
+        # script ran to the end: instance state, status checks, and CloudFormation
+        # stack status are all indifferent to UserData, so #225's silent
+        # truncation looked identical to success from every side. Anything that
+        # wants to know whether a bastion is really orchestrating can check for
+        # this file over SSM.
+        init_script += "# Signal successful completion\n"
+        init_script += "touch /var/run/parsl_bastion_ready\n"
 
         return init_script
+
+    def _ensure_script_bucket(self) -> str:
+        """Return the S3 bucket used to stage the bastion init script.
+
+        A provider-scoped bucket is created on first use and removed by
+        ``cleanup_infrastructure()``. Mirrors serverless mode's
+        ``_ensure_lambda_code_bucket``, including the guard that matters:
+        ``_owns_script_bucket`` stays False for a bucket this mode merely found,
+        which is what stops cleanup from deleting someone else's.
+
+        Returns
+        -------
+        str
+            Name of the bucket to stage the init script in.
+        """
+        if self._script_bucket:
+            return self._script_bucket
+
+        s3 = self.session.client("s3")
+        region = self.session.region_name
+        # provider_id first, as it is the random part: the provider truncates
+        # every ID it embeds to eight characters, and a shared prefix would give
+        # every provider in an account the same bucket name.
+        bucket = f"parsl-bastion-script-{self.provider_id[:8]}"
+
+        try:
+            # us-east-1 is the one region CreateBucket rejects a
+            # LocationConstraint for.
+            if region and region != "us-east-1":
+                s3.create_bucket(
+                    Bucket=bucket,
+                    CreateBucketConfiguration={"LocationConstraint": region},
+                )
+            else:
+                s3.create_bucket(Bucket=bucket)
+            self._owns_script_bucket = True
+            logger.debug(f"Created bastion script bucket {bucket}")
+        except ClientError as e:
+            code = e.response.get("Error", {}).get("Code")
+            # Already ours (a restart, or a rebuilt bastion in the same run).
+            if code not in ("BucketAlreadyOwnedByYou", "BucketAlreadyExists"):
+                raise
+            logger.debug(f"Reusing existing bastion script bucket {bucket}")
+
+        self._script_bucket = bucket
+        return bucket
+
+    def _stage_bastion_init_script(self, init_script: str) -> str:
+        """Upload the init script to S3 and return a presigned URL for it.
+
+        Parameters
+        ----------
+        init_script : str
+            The rendered init script.
+
+        Returns
+        -------
+        str
+            A presigned GET URL valid for ``BASTION_SCRIPT_URL_TTL`` seconds.
+
+        Notes
+        -----
+        A **presigned** URL rather than an ``aws s3 cp`` against the instance's
+        own role, because the direct (``RunInstances``) path attaches no
+        instance profile at all -- ``IamInstanceProfile`` appears nowhere on
+        that path -- so a credentialed fetch would rescue only the
+        CloudFormation bastion. A presigned URL needs no credentials on the
+        instance and so fixes both paths with one mechanism.
+
+        The object is private: the URL carries the authorization, and the
+        bucket keeps its account defaults.
+        """
+        bucket = self._ensure_script_bucket()
+        key = f"bastion-init-{self.workflow_id[:8]}.sh"
+        # SigV4 must be requested explicitly. botocore's *presigner* still
+        # defaults to SigV2 even though `client.meta.config.signature_version`
+        # reports "s3v4" -- verified both ways: the default presign emits
+        # `?AWSAccessKeyId=...&Signature=...`, which every region created after
+        # 2014 rejects, and which the substrate emulator answers with 501.
+        s3 = self.session.client("s3", config=Config(signature_version="s3v4"))
+
+        s3.put_object(
+            Bucket=bucket,
+            Key=key,
+            Body=init_script.encode(),
+            ServerSideEncryption="AES256",
+        )
+        self._script_key = key
+        logger.debug(
+            f"Staged bastion init script ({len(init_script)} B) at s3://{bucket}/{key}"
+        )
+
+        url: str = s3.generate_presigned_url(
+            "get_object",
+            Params={"Bucket": bucket, "Key": key},
+            ExpiresIn=BASTION_SCRIPT_URL_TTL,
+        )
+        return url
+
+    def _render_bastion_shim(self, script_url: str) -> str:
+        """Build the small UserData script that fetches and runs the init script.
+
+        Parameters
+        ----------
+        script_url : str
+            Presigned URL of the staged init script.
+
+        Returns
+        -------
+        str
+            A few hundred bytes of shell -- the actual UserData.
+
+        Notes
+        -----
+        ``curl`` rather than the AWS CLI: it is present on every supported AMI,
+        and unlike ``aws s3 cp`` it needs no credentials for a presigned URL.
+        Deliberately **not** under ``set -e``; instead each step is checked and
+        failure is written to a sentinel file, because a UserData that aborts
+        silently is exactly how #225 went unnoticed -- CloudFormation reports
+        CREATE_COMPLETE either way, since stack health says nothing about
+        UserData.
+        """
+        return f"""#!/bin/bash
+# Parsl bastion bootstrap shim. The real init script is staged in S3 (#227):
+# at ~32 KB it exceeds both the 4 KB CloudFormation parameter limit and the
+# 16 KB EC2 UserData limit, so only this fetch travels as UserData.
+SCRIPT=/var/lib/parsl-bastion-init.sh
+STATUS=/var/log/parsl-bastion-bootstrap.status
+
+if ! curl -fsSL --retry 5 --retry-delay 5 -o "$SCRIPT" '{script_url}'; then
+    echo "FAILED: could not download bastion init script" > "$STATUS"
+    exit 1
+fi
+
+chmod 700 "$SCRIPT"
+if bash "$SCRIPT" >> /var/log/parsl-bastion-init.log 2>&1; then
+    echo "OK" > "$STATUS"
+else
+    echo "FAILED: bastion init script exited $?" > "$STATUS"
+    exit 1
+fi
+"""
+
+    def _prepare_bastion_user_data(self) -> str:
+        """Render the init script, stage it, and return the UserData to send.
+
+        Returns
+        -------
+        str
+            The bootstrap shim -- small enough for every delivery mechanism.
+
+        Raises
+        ------
+        ResourceCreationError
+            If the shim does not fit the limits it is meant to respect.
+
+        Notes
+        -----
+        The size assertion is the point of this seam, not a formality. #227 was
+        undetectable in-tree: nothing rendered the script and measured it, and
+        substrate enforces neither limit, so a 10x overrun reached live AWS and
+        made detached mode unusable. Checking here means a future edit that
+        inflates the payload fails in the unit suite instead.
+        """
+        init_script = self._prepare_bastion_init_script()
+        script_url = self._stage_bastion_init_script(init_script)
+        shim = self._render_bastion_shim(script_url)
+
+        raw = len(shim.encode())
+        encoded = len(base64.b64encode(shim.encode()))
+        # The CloudFormation path sends the base64 form as a stack parameter, so
+        # it is the tightest of the three limits by a wide margin. Checking all
+        # three regardless of bastion_host_type keeps the guarantee independent
+        # of which path a given provider happens to take.
+        for size, limit, what in (
+            (encoded, MAX_CFN_PARAMETER_BYTES, "CloudFormation parameter"),
+            (raw, MAX_EC2_USER_DATA_BYTES, "EC2 UserData"),
+            (encoded, MAX_EC2_USER_DATA_B64_BYTES, "EC2 encoded UserData"),
+        ):
+            if size > limit:
+                raise ResourceCreationError(
+                    f"Bastion UserData shim is {size} B, over the {limit} B "
+                    f"{what} limit. The init script is staged in S3 precisely so "
+                    f"this cannot happen (#227); something has been added to the "
+                    f"shim itself, which must stay small."
+                )
+
+        return shim
+
+    def _delete_staged_bastion_script(self) -> None:
+        """Delete the staged init script object and, if owned, its bucket.
+
+        Failures are logged rather than raised: this runs from cleanup, where
+        masking the caller's real error would be worse than leaving an object
+        behind.
+        """
+        if not self._script_bucket:
+            return
+
+        bucket = self._script_bucket
+        s3 = self.session.client("s3")
+
+        if self._script_key:
+            try:
+                s3.delete_object(Bucket=bucket, Key=self._script_key)
+                logger.debug(
+                    f"Deleted staged bastion script s3://{bucket}/{self._script_key}"
+                )
+            except Exception as e:
+                logger.warning(f"Failed to delete staged bastion script: {e}")
+            finally:
+                self._script_key = None
+
+        # Ownership gate: a bucket supplied or pre-existing is left alone.
+        if not self._owns_script_bucket:
+            return
+
+        try:
+            # A bucket must be empty before it can be deleted; anything left
+            # here is a script whose bastion never reached cleanup.
+            paginator = s3.get_paginator("list_objects_v2")
+            for page in paginator.paginate(Bucket=bucket):
+                objects = [{"Key": obj["Key"]} for obj in page.get("Contents", [])]
+                if objects:
+                    s3.delete_objects(Bucket=bucket, Delete={"Objects": objects})
+
+            s3.delete_bucket(Bucket=bucket)
+            logger.debug(f"Deleted bastion script bucket {bucket}")
+        except Exception as e:
+            logger.warning(f"Failed to delete bastion script bucket {bucket}: {e}")
+        finally:
+            self._script_bucket = None
+            self._owns_script_bucket = False
 
     def _get_bastion_manager_script(self) -> str:
         """Get the Python script for the bastion manager.
@@ -1903,6 +2244,16 @@ if __name__ == '__main__':
 
             self.bastion_id = None
 
+        # The staged init script outlives its bastion otherwise: the object is
+        # only needed during first boot, so once the bastion is gone it is a
+        # leaked object in a leaked bucket (#227). Deliberately *outside* the
+        # branch above, which is gated on `self.bastion_id`: a script staged for
+        # a bastion whose creation then failed would otherwise never be
+        # collected, and that is exactly the path #227 made common. Still
+        # skipped for a preserved bastion, which may be rebuilt from it.
+        if not self.preserve_bastion:
+            self._delete_staged_bastion_script()
+
         # Tear down the monitoring thread only when the bastion is going too --
         # a preserved bastion is still running workers worth watching. (There is
         # no networking to delete here; the comment that used to say so predated
@@ -2061,6 +2412,13 @@ if __name__ == '__main__':
             "bastion_host_type": self.bastion_host_type,
             "stack_name": self.stack_name,
             "spot_interruption_handling": self.spot_interruption_handling,
+            # Without these, a provider reconstructed from state cannot clean up
+            # the script bucket it created -- the same reasoning as #132's
+            # owns_instance_profile: ownership has to survive persistence or
+            # cleanup silently skips what it is responsible for.
+            "script_bucket": self._script_bucket,
+            "script_key": self._script_key,
+            "owns_script_bucket": self._owns_script_bucket,
         }
 
         try:
@@ -2088,6 +2446,11 @@ if __name__ == '__main__':
                     "bastion_host_type", self.bastion_host_type
                 )
                 self.stack_name = state.get("stack_name", self.stack_name)
+                self._script_bucket = state.get("script_bucket", self._script_bucket)
+                self._script_key = state.get("script_key", self._script_key)
+                self._owns_script_bucket = state.get(
+                    "owns_script_bucket", self._owns_script_bucket
+                )
 
                 # Check if spot interruption handling was previously enabled
                 previous_spot_handling = state.get("spot_interruption_handling", False)

--- a/tests/integration/test_substrate_modes.py
+++ b/tests/integration/test_substrate_modes.py
@@ -23,11 +23,19 @@ SPDX-License-Identifier: Apache-2.0
 SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
 """
 
+import base64
 import os
+import re
+import urllib.request
 import uuid
 
 import pytest
 
+from parsl_ephemeral_provider.constants import (
+    BASTION_SCRIPT_URL_TTL,
+    MAX_CFN_PARAMETER_BYTES,
+    MAX_EC2_USER_DATA_BYTES,
+)
 from parsl_ephemeral_provider.modes.detached import DetachedMode
 from parsl_ephemeral_provider.modes.serverless import ServerlessMode
 from parsl_ephemeral_provider.modes.standard import StandardMode
@@ -199,6 +207,127 @@ class TestDetachedModeSubstrate:
         assert mode.bastion_id is None
         # Again, the caller's network outlives the mode.
         assert mode.vpc_id == substrate_network["vpc_id"]
+
+    def test_the_bastion_script_is_staged_and_fetchable(
+        self, substrate_session, substrate_network, temp_state_store, provider_id
+    ):
+        """The staged script really is retrievable by the URL in UserData (#227).
+
+        This is the assertion that needed an emulator rather than a mock. The
+        init script is ~32 KB against a 4,096 B CloudFormation parameter limit
+        and a 16,384 B EC2 UserData limit, so it is uploaded to S3 and UserData
+        carries only a presigned fetch. A unit test can show that ``put_object``
+        was *called*; only a real S3 and a real HTTP GET show that the URL the
+        bastion is handed actually returns the script.
+
+        It caught a defect a mock could not: botocore's presigner emits SigV2 by
+        default even when the client reports ``s3v4``, and a SigV2 URL is
+        rejected by every region created after 2014 (substrate answers 501).
+        """
+        mode = self._mode(
+            substrate_session, substrate_network, temp_state_store, provider_id
+        )
+
+        # This test needs the bucket *absent*, so that the mode creates it and
+        # therefore owns it. The name derives from ``provider_id[:8]``, which
+        # truncates to a shared ``test-pro`` across the file, so a bucket left by
+        # a sibling test would make the mode a non-owner and the cleanup
+        # assertions below would fail for the wrong reason.
+        s3 = substrate_session.client("s3")
+        leftover = f"parsl-bastion-script-{mode.provider_id[:8]}"
+        try:
+            for obj in s3.list_objects_v2(Bucket=leftover).get("Contents", []):
+                s3.delete_object(Bucket=leftover, Key=obj["Key"])
+            s3.delete_bucket(Bucket=leftover)
+        except s3.exceptions.NoSuchBucket:
+            pass
+
+        try:
+            user_data = mode._prepare_bastion_user_data()
+            assert mode._owns_script_bucket is True
+
+            # UserData is a fetch, not the program.
+            assert len(user_data.encode()) < MAX_EC2_USER_DATA_BYTES
+            assert len(base64.b64encode(user_data.encode())) < MAX_CFN_PARAMETER_BYTES
+            assert "parsl-bastion-manager.py" not in user_data
+
+            # The object exists where the mode says it staged it.
+            s3 = substrate_session.client("s3")
+            staged = s3.get_object(Bucket=mode._script_bucket, Key=mode._script_key)[
+                "Body"
+            ].read()
+            assert b"parsl-bastion-manager.py" in staged
+            assert len(staged) > MAX_EC2_USER_DATA_BYTES
+
+            # And the URL embedded in UserData serves it, unauthenticated --
+            # which is the whole reason for a presigned URL: the direct path
+            # attaches no instance profile, so the bastion has no credentials
+            # of its own to fetch with.
+            match = re.search(r"'(https?://[^']+)'", user_data)
+            assert match is not None, "no fetch URL found in UserData"
+            with urllib.request.urlopen(match.group(1), timeout=30) as response:
+                assert response.read() == staged
+
+            # A SigV4 URL, not the SigV2 one botocore's presigner emits by
+            # default. That default is what substrate answers 501 to, and what
+            # post-2014 regions reject outright.
+            assert "X-Amz-Algorithm=AWS4-HMAC-SHA256" in match.group(1)
+            assert f"X-Amz-Expires={BASTION_SCRIPT_URL_TTL}" in match.group(1)
+        finally:
+            mode.preserve_bastion = False
+            mode.cleanup_infrastructure()
+
+        # Cleanup removes the object and the bucket the mode created, so a
+        # bastion's script does not outlive it.
+        assert mode._script_key is None
+        assert mode._script_bucket is None
+
+    def test_a_caller_supplied_script_bucket_survives_cleanup(
+        self, substrate_session, substrate_network, temp_state_store, provider_id
+    ):
+        """Cleanup deletes only a bucket this mode created.
+
+        The ownership gate, same hazard class as the serverless security-group
+        deletion fixed in #100: an existing bucket is reused, and
+        ``_owns_script_bucket`` stays False, which is what keeps it.
+        """
+        mode = self._mode(
+            substrate_session, substrate_network, temp_state_store, provider_id
+        )
+
+        s3 = substrate_session.client("s3")
+        bucket = f"parsl-bastion-script-{mode.provider_id[:8]}"
+        create_args = {"Bucket": bucket}
+        if substrate_session.region_name != "us-east-1":
+            create_args["CreateBucketConfiguration"] = {
+                "LocationConstraint": substrate_session.region_name
+            }
+        # Tolerated because the bucket name is what is under test: the mode
+        # derives it from ``provider_id[:8]``, and the ``provider_id`` fixture's
+        # value truncates to a shared ``test-pro`` for every test in the file --
+        # the same "put the random part first" trap the module docstring records
+        # for job IDs. Pre-existing is precisely the state this test wants.
+        try:
+            s3.create_bucket(**create_args)
+        except s3.exceptions.BucketAlreadyExists:
+            pass
+        except s3.exceptions.BucketAlreadyOwnedByYou:
+            pass
+
+        try:
+            mode._prepare_bastion_user_data()
+            assert mode._script_bucket == bucket
+            assert mode._owns_script_bucket is False
+
+            mode.preserve_bastion = False
+            mode.cleanup_infrastructure()
+
+            # The bucket is still there; only the object went.
+            s3.head_bucket(Bucket=bucket)
+        finally:
+            for obj in s3.list_objects_v2(Bucket=bucket).get("Contents", []):
+                s3.delete_object(Bucket=bucket, Key=obj["Key"])
+            s3.delete_bucket(Bucket=bucket)
 
     def test_submit_job_and_status(
         self, substrate_session, substrate_network, temp_state_store, provider_id

--- a/tests/integration/test_substrate_modes.py
+++ b/tests/integration/test_substrate_modes.py
@@ -30,6 +30,7 @@ import urllib.request
 import uuid
 
 import pytest
+from botocore.exceptions import ClientError
 
 from parsl_ephemeral_provider.constants import (
     BASTION_SCRIPT_URL_TTL,
@@ -328,6 +329,149 @@ class TestDetachedModeSubstrate:
             for obj in s3.list_objects_v2(Bucket=bucket).get("Contents", []):
                 s3.delete_object(Bucket=bucket, Key=obj["Key"])
             s3.delete_bucket(Bucket=bucket)
+
+    def test_the_bucket_is_resolved_once_per_mode(
+        self, substrate_session, substrate_network, temp_state_store, provider_id
+    ):
+        """A second staging call reuses the resolved bucket rather than re-creating.
+
+        The memoized return matters for ownership, not for the API call count:
+        ``create_bucket`` on a bucket you already own answers
+        ``BucketAlreadyOwnedByYou``, which the except branch treats as "reusing
+        an existing bucket" -- so a second pass through it would clear the
+        ownership flag this mode needs to delete what it created.
+        """
+        mode = self._mode(
+            substrate_session, substrate_network, temp_state_store, provider_id
+        )
+
+        s3 = substrate_session.client("s3")
+        bucket = f"parsl-bastion-script-{mode.provider_id[:8]}"
+        try:
+            for obj in s3.list_objects_v2(Bucket=bucket).get("Contents", []):
+                s3.delete_object(Bucket=bucket, Key=obj["Key"])
+            s3.delete_bucket(Bucket=bucket)
+        except s3.exceptions.NoSuchBucket:
+            pass
+
+        try:
+            first = mode._ensure_script_bucket()
+            assert mode._owns_script_bucket is True
+
+            assert mode._ensure_script_bucket() == first
+            assert mode._owns_script_bucket is True
+        finally:
+            mode.preserve_bastion = False
+            mode.cleanup_infrastructure()
+
+    def test_an_unexpected_bucket_error_is_not_swallowed(
+        self, substrate_session, substrate_network, temp_state_store, provider_id
+    ):
+        """Only "already exists" is tolerated; anything else propagates.
+
+        The except branch exists to make a restart or a rebuilt bastion
+        idempotent, and it would be easy to write as a bare ``except
+        ClientError: pass`` -- which would report a bucket that was never
+        created and leave the bastion fetching from nowhere. ``InvalidBucketName``
+        is a real S3 error code, raised here by an uppercase provider ID: bucket
+        names must be lowercase.
+        """
+        mode = self._mode(
+            substrate_session,
+            substrate_network,
+            temp_state_store,
+            f"UPPER-{uuid.uuid4().hex[:8]}",
+        )
+
+        with pytest.raises(ClientError) as excinfo:
+            mode._ensure_script_bucket()
+        assert excinfo.value.response["Error"]["Code"] == "InvalidBucketName"
+
+        # And nothing was recorded, so cleanup has nothing to chase.
+        assert mode._script_bucket is None
+        assert mode._owns_script_bucket is False
+
+    def test_cleanup_empties_a_bucket_holding_another_bastions_script(
+        self, substrate_session, substrate_network, temp_state_store, provider_id
+    ):
+        """Leftover objects are swept, since S3 refuses to delete a full bucket.
+
+        The mode deletes its own ``_script_key`` first, so on the ordinary path
+        the bucket is already empty by the time it is removed. This exercises the
+        case that is not ordinary: a script staged by an earlier bastion whose
+        cleanup never ran -- exactly the leak this bucket's teardown exists to
+        catch. Without the sweep, ``delete_bucket`` answers ``BucketNotEmpty``
+        and the bucket outlives every provider that used it.
+        """
+        mode = self._mode(
+            substrate_session, substrate_network, temp_state_store, provider_id
+        )
+
+        s3 = substrate_session.client("s3")
+        bucket = f"parsl-bastion-script-{mode.provider_id[:8]}"
+        try:
+            for obj in s3.list_objects_v2(Bucket=bucket).get("Contents", []):
+                s3.delete_object(Bucket=bucket, Key=obj["Key"])
+            s3.delete_bucket(Bucket=bucket)
+        except s3.exceptions.NoSuchBucket:
+            pass
+
+        mode._prepare_bastion_user_data()
+        assert mode._owns_script_bucket is True
+
+        # A script from a bastion that never got collected.
+        s3.put_object(
+            Bucket=bucket, Key="bastion-init-orphaned.sh", Body=b"#!/bin/bash\n"
+        )
+
+        mode.preserve_bastion = False
+        mode.cleanup_infrastructure()
+
+        assert mode._script_bucket is None
+        with pytest.raises(ClientError) as excinfo:
+            s3.head_bucket(Bucket=bucket)
+        assert excinfo.value.response["Error"]["Code"] in ("404", "NoSuchBucket")
+
+    def test_cleanup_survives_a_bucket_deleted_underneath_it(
+        self, substrate_session, substrate_network, temp_state_store, provider_id
+    ):
+        """A staged script already gone must not break teardown.
+
+        Cleanup runs on the failure path too, so it has to tolerate the state it
+        finds. Here the bucket is removed behind the mode's back -- an operator
+        sweeping leftovers, or a lifecycle rule -- and both the object delete and
+        the bucket delete raise ``NoSuchBucket``. The mode must log and finish:
+        raising would mask whatever error triggered the cleanup, and would leave
+        the bastion and the caller's network uncollected.
+        """
+        mode = self._mode(
+            substrate_session, substrate_network, temp_state_store, provider_id
+        )
+
+        s3 = substrate_session.client("s3")
+        bucket = f"parsl-bastion-script-{mode.provider_id[:8]}"
+        try:
+            for obj in s3.list_objects_v2(Bucket=bucket).get("Contents", []):
+                s3.delete_object(Bucket=bucket, Key=obj["Key"])
+            s3.delete_bucket(Bucket=bucket)
+        except s3.exceptions.NoSuchBucket:
+            pass
+
+        mode._prepare_bastion_user_data()
+        assert mode._owns_script_bucket is True
+        staged_key = mode._script_key
+
+        # Pull the bucket out from under it.
+        s3.delete_object(Bucket=bucket, Key=staged_key)
+        s3.delete_bucket(Bucket=bucket)
+
+        mode.preserve_bastion = False
+        mode.cleanup_infrastructure()
+
+        # Cleared regardless, so a retry does not chase a bucket that is gone.
+        assert mode._script_key is None
+        assert mode._script_bucket is None
+        assert mode._owns_script_bucket is False
 
     def test_submit_job_and_status(
         self, substrate_session, substrate_network, temp_state_store, provider_id

--- a/tests/unit/test_detached_mode.py
+++ b/tests/unit/test_detached_mode.py
@@ -6,6 +6,7 @@ SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
 
 import pytest
 from unittest.mock import MagicMock, patch
+import base64
 import boto3
 import time
 import json
@@ -15,9 +16,13 @@ from parsl_ephemeral_provider.modes.detached import DetachedMode
 from parsl_ephemeral_provider.state.base import STATE_KEY_MODE
 from parsl_ephemeral_provider.exceptions import (
     OperatingModeError,
+    ResourceCreationError,
     ResourceNotFoundError,
 )
 from parsl_ephemeral_provider.constants import (
+    MAX_CFN_PARAMETER_BYTES,
+    MAX_EC2_USER_DATA_B64_BYTES,
+    MAX_EC2_USER_DATA_BYTES,
     RESOURCE_TYPE_BASTION,
     STATUS_INTERRUPTED,
     STATUS_PENDING,
@@ -684,3 +689,255 @@ class TestDetachedMode:
         assert "update_job_status" in manager_script
         assert "launch_instance" in manager_script
         assert "main()" in manager_script  # Has entry point
+
+
+class TestBastionUserDataSize:
+    """The bastion UserData must fit the mechanism that delivers it (#227).
+
+    Detached mode was wholly non-functional because the init script — a ~32 KB
+    program — was passed as UserData: 10.4x CloudFormation's 4,096 B parameter
+    limit and 2.0x EC2's 16,384 B limit. Nothing in-tree rendered the script and
+    measured it, and substrate enforces neither limit, so the failure only ever
+    appeared against live AWS, at provider *construction*.
+
+    These tests are that missing measurement, and they are **arithmetic on
+    rendered strings** — no session, no emulator, nothing faked. Whether staging
+    actually works is a different question, answered against substrate by
+    ``tests/integration/test_substrate_modes.py::TestDetachedModeSubstrate``,
+    which uploads the script and fetches the URL over HTTP. Asserting
+    ``put_object`` call args against a mock here would duplicate that while
+    proving only that this code calls a method.
+    """
+
+    # Longest presigned URL measured against live AWS: 175 B with static keys,
+    # 1,064 B under a session token (the token alone is ~664 B). The URL is the
+    # one part of the shim whose size is not ours to control, so the budget is
+    # set against the worst case.
+    LONGEST_PRESIGNED_URL = 1064
+
+    @pytest.fixture
+    def mode(self):
+        """A DetachedMode used only to render strings; no AWS call is made."""
+        session = MagicMock(spec=boto3.Session)
+        session.region_name = "us-east-1"
+        return DetachedMode(
+            provider_id="test-provider",
+            session=session,
+            state_store=MagicMock(),
+            workflow_id="test-workflow",
+            vpc_id="vpc-12345",
+            subnet_id="subnet-12345",
+            security_group_id="sg-12345",
+        )
+
+    def test_the_shim_fits_every_delivery_limit(self, mode):
+        """The shim clears all three limits even with the longest URL possible.
+
+        The URL is substituted at its worst-case measured length rather than
+        left to a fixture's short example: a caller using assume-role or
+        session-token credentials gets a URL ~6x longer, and a budget calibrated
+        on static keys would pass here and fail for them.
+        """
+        shim = mode._render_bastion_shim(
+            "https://x/" + "u" * self.LONGEST_PRESIGNED_URL
+        )
+
+        raw = len(shim.encode())
+        encoded = len(base64.b64encode(shim.encode()))
+
+        assert raw < MAX_EC2_USER_DATA_BYTES
+        assert encoded < MAX_EC2_USER_DATA_B64_BYTES
+        # The tightest limit by far, and the one that made the default
+        # bastion_host_type impossible.
+        assert encoded < MAX_CFN_PARAMETER_BYTES
+        assert encoded < MAX_CFN_PARAMETER_BYTES * 3 // 4, (
+            f"shim base64 is {encoded} B against a {MAX_CFN_PARAMETER_BYTES} B "
+            "CloudFormation parameter limit — it is meant to stay a fetch, not "
+            "accumulate logic"
+        )
+
+    def test_the_init_script_itself_would_not_have_fit(self, mode):
+        """Guard the premise: the script really is too big to send inline.
+
+        Without this, the test above could keep passing for the wrong reason —
+        if the script ever shrank below the limits, staging would look like
+        unnecessary machinery and the assertions above would prove nothing.
+        """
+        init_script = mode._prepare_bastion_init_script()
+
+        assert len(init_script.encode()) > MAX_EC2_USER_DATA_BYTES
+        assert len(base64.b64encode(init_script.encode())) > MAX_CFN_PARAMETER_BYTES
+
+    def test_the_shim_fetches_rather_than_carries(self, mode):
+        """UserData downloads the script; it does not contain it."""
+        shim = mode._render_bastion_shim("https://example.test/staged.sh?sig=abc")
+
+        assert shim.startswith("#!/bin/bash")
+        assert "curl" in shim
+        assert "https://example.test/staged.sh?sig=abc" in shim
+        # The script's own content must not have travelled along with it.
+        assert "parsl-bastion-manager.py" not in shim
+        assert "systemd" not in shim
+
+    def test_the_shim_records_failure_instead_of_aborting_silently(self, mode):
+        """A failed fetch must leave evidence, not a mystery.
+
+        The lesson of #225: an instance whose UserData died still reaches
+        ``running`` and still reports CREATE_COMPLETE, so failure has to be
+        written down somewhere to be noticed at all.
+        """
+        shim = mode._render_bastion_shim("https://example.test/staged.sh")
+
+        assert "parsl-bastion-bootstrap.status" in shim
+        assert "FAILED: could not download bastion init script" in shim
+        assert "--retry" in shim  # a transient 5xx should not strand the bastion
+
+    def test_an_oversized_shim_is_refused_at_render_time(self, mode):
+        """The size check fails loudly rather than deferring to AWS.
+
+        This is the regression gate: #227 was a live-only failure precisely
+        because nothing checked before the API call.
+        """
+        with (
+            patch.object(
+                mode,
+                "_stage_bastion_init_script",
+                return_value="https://example.test/staged.sh",
+            ),
+            patch.object(
+                mode,
+                "_render_bastion_shim",
+                return_value="x" * (MAX_EC2_USER_DATA_BYTES + 1),
+            ),
+        ):
+            with pytest.raises(ResourceCreationError, match="over the"):
+                mode._prepare_bastion_user_data()
+
+
+class TestBastionInitScriptShell:
+    """The init script's shell must survive first boot on Amazon Linux 2023.
+
+    #225: the script ran `set -e` and then installed `awscli`, for which AL2023
+    — the default AMI family — has no package. UserData aborted at that line, so
+    the manager script, its service, and the idle-shutdown cron were never
+    installed. The instance still reached `running` and the stack still reported
+    CREATE_COMPLETE, which is why a bastion that orchestrated nothing looked
+    healthy from every angle.
+
+    Every assertion below pins a fact established by booting a real AL2023
+    bastion and reading its logs, not by reasoning about the shell. Each one
+    corresponds to a defect that a passing unit suite did not catch: the package
+    set is the third revision.
+    """
+
+    @pytest.fixture
+    def init_script(self):
+        session = MagicMock(spec=boto3.Session)
+        session.region_name = "us-east-1"
+        session.client.return_value = MagicMock()
+        mode = DetachedMode(
+            provider_id="test-provider",
+            session=session,
+            state_store=MagicMock(),
+            workflow_id="test-workflow",
+            vpc_id="vpc-12345",
+            subnet_id="subnet-12345",
+            security_group_id="sg-12345",
+        )
+        return mode._prepare_bastion_init_script()
+
+    def test_no_awscli_package_install(self, init_script):
+        """AL2023 has no `awscli` package; CLI v2 is preinstalled."""
+        assert "awscli" not in init_script
+
+    def test_package_install_dispatches_on_the_available_manager(self, init_script):
+        """`apt-get || yum` failed on AL2023, where apt-get does not exist."""
+        assert "command -v dnf" in init_script
+        assert "apt-get install -y python3 python3-pip jq awscli" not in init_script
+
+    def test_boto3_comes_from_the_distro_not_pip(self, init_script):
+        """boto3 must be the system package, and pip must not be installed.
+
+        Verified live: `dnf install python3-pip` pulls in **python3.11** and
+        repoints /usr/bin/python3 at it, which breaks `dnf` itself and AWS CLI v2
+        — both python3.9 scripts — with `ModuleNotFoundError: No module named
+        'dnf'`. AL2023 packages boto3 for the system 3.9, so no pip is needed.
+
+        `python3` is likewise absent from the install list: it is already there,
+        and naming it invites the same substitution.
+        """
+        assert "python3-boto3" in init_script
+        assert "python3-pip" not in init_script
+        assert "pip install" not in init_script
+        assert 'python3 -c "import boto3"' in init_script
+
+    def test_a_cron_daemon_is_installed(self, init_script):
+        """AL2023 ships no cron daemon, so `crontab -` was a no-op.
+
+        The idle-shutdown timer is the only thing that reads `idle_timeout`, so
+        without this the option cannot work — a bastion would run until someone
+        reclaimed it, and with `preserve_bastion=True` (the default) nothing
+        ever does.
+        """
+        assert "cronie" in init_script
+        assert "crond" in init_script
+        # The prerequisite check must catch a daemon that is not *running*.
+        # `crontab` being on PATH proved nothing: it is the client, and the
+        # /etc/cron.d drop-in is read only by the daemon.
+        prerequisites = init_script.split("# Verify prerequisites")[1]
+        assert "systemctl is-active crond" in prerequisites
+
+    def test_the_idle_timer_is_registered_somewhere_cron_will_read(self, init_script):
+        """The timer goes in /etc/cron.d, not through `crontab -`.
+
+        Verified live: `(crontab -l 2>/dev/null; echo '...') | crontab -` left
+        /var/spool/cron/root at **0 bytes** on a fresh bastion. `crontab -l` has
+        nothing to list and exits non-zero there, so the subshell contributed
+        nothing and the append landed nowhere — while every command in the
+        pipeline exited 0. So `idle_timeout` was registered on no schedule even
+        after #225 installed cronie.
+
+        A /etc/cron.d file has no read-modify-write step and so no empty-input
+        case. cron ignores such a file unless it is mode 0644, root-owned, and
+        has no dot in its name, and its lines carry a user field.
+
+        Confirmed on the fixed bastion, which is the only evidence that counts
+        here — the drop-in existing proves nothing about cron reading it::
+
+            CROND[25601]: (root) CMD (/usr/local/bin/parsl-idle-shutdown.sh)
+            CROND[25600]: (root) CMDEND (/usr/local/bin/parsl-idle-shutdown.sh)
+            -rw-r--r--. 1 root root 11 /var/run/parsl-last-activity
+
+        The activity file is the script's own output, so it ran, not merely got
+        scheduled.
+        """
+        assert "| crontab -" not in init_script
+
+        assert "/etc/cron.d/parsl-idle-shutdown" in init_script
+        assert "." not in "parsl-idle-shutdown"
+        assert (
+            "*/5 * * * * root /usr/local/bin/parsl-idle-shutdown.sh" in init_script
+        ), "system crontab format requires a user field"
+        assert "chmod 0644 /etc/cron.d/parsl-idle-shutdown" in init_script
+        assert "chown root:root /etc/cron.d/parsl-idle-shutdown" in init_script
+
+        # Written after the script it schedules, or the first firing finds
+        # nothing to run.
+        assert init_script.index(
+            "chmod +x /usr/local/bin/parsl-idle-shutdown.sh"
+        ) < init_script.index("/etc/cron.d/parsl-idle-shutdown")
+
+    def test_the_script_signals_completion(self, init_script):
+        """A sentinel is the only positive evidence UserData ran to the end.
+
+        Instance state, status checks, and stack status are all indifferent to
+        UserData, which is how #225 stayed invisible.
+        """
+        assert "touch /var/run/parsl_bastion_ready" in init_script
+        # After the parts that would have been skipped by the #225 abort.
+        assert init_script.index("parsl-bastion-manager.service") < init_script.index(
+            "parsl_bastion_ready"
+        )
+        assert init_script.index("parsl-idle-shutdown.sh") < init_script.index(
+            "parsl_bastion_ready"
+        )


### PR DESCRIPTION
Detached mode could not create a bastion, in either of its two paths. Fixing
that surfaced two further defects in the init script itself, and one more that
needs its own issue (#229).

## #227 — the init script does not fit in any delivery mechanism

The script is a whole program: ~32 KB of shell wrapping an ~850-line embedded
Python orchestrator. Measured against the limits it was being pushed through:

| | size | limit | |
|---|---|---|---|
| CloudFormation parameter | 42,740 B (base64) | 4,096 B | **10.4x** |
| `RunInstances` UserData | 32,435 B | 16,384 B | **2.0x** |

So `create_stack` rejected the parameter outright and EC2 refused the direct
path. gzip does not rescue it — 34 KB compresses to 8,333 B, inside EC2's limit
and still double CloudFormation's.

**Fix:** upload the script to S3, and put only a fetch shim in UserData. The URL
is **presigned** rather than an `aws s3 cp` against the instance's own role,
because the direct path attaches no instance profile at all (#229) — a
credentialed fetch would have rescued only the CloudFormation bastion. One
mechanism now fixes both.

Two things follow the ownership pattern #100 established for the serverless
security group:

- The staging bucket is provider-scoped, created on first use, and deleted on
  cleanup **only if this mode created it**. A caller-supplied bucket is reused
  and kept.
- Staged-script cleanup is gated on `preserve_bastion` alone, not on the bastion
  having been created. A script staged for a bastion whose creation then failed
  is still collected — that was a real leak the first draft had, caught by the
  integration test asserting `_script_key is None`.

Both limits are now asserted at render time, so a future edit to the script
cannot silently reintroduce this: substrate enforces neither limit, so the
failure would otherwise appear only against live AWS.

## #225 — the script aborted on its first install line

It ran under `set -e` and then:

```sh
apt-get install -y python3 python3-pip jq awscli || yum install -y ...
```

On Amazon Linux 2023 — the default AMI family — `apt-get` does not exist, so the
left side failed; and `awscli` is not an installable package there (CLI v2 ships
preinstalled, the v1 package was dropped), so the right side failed too. `set -e`
aborted, and the manager script, its systemd service and the idle-shutdown timer
were never installed. The instance still reached `running` and the stack still
reported `CREATE_COMPLETE`.

The install now dispatches on the available package manager. The package list is
**three corrections deep**, each found by booting a bastion rather than by
reading the shell:

- **`python3-boto3`, not `pip install boto3`.** The manager imports boto3 at
  module scope and no AMI ships it, so the original line could not have produced
  a working bastion even had every package in it resolved. But installing via pip
  means first installing pip, and `dnf install python3-pip` pulls in
  **python3.11** and repoints `/usr/bin/python3` at it — which breaks `dnf`
  itself and AWS CLI v2, both python3.9 scripts, with `ModuleNotFoundError: No
  module named 'dnf'`. AL2023 packages boto3 for the system 3.9.
- **`cronie`.** AL2023 installs no cron daemon.
- **no `python3` in the list.** Already present, and naming it invites the same
  3.11 substitution.

Prerequisites are now verified by *outcome* rather than by installer exit status
— the pip failure was an installer that succeeded and left the system unable to
run its own tools. And the script ends by touching
`/var/run/parsl_bastion_ready`: that sentinel is the only positive evidence
UserData ran to the end, since instance state, status checks and stack status are
all indifferent to it. That indifference is exactly why this went unnoticed.

## #225 (second defect) — the idle timer was registered on no schedule

Even with cronie installed:

```sh
(crontab -l 2>/dev/null; echo '...') | crontab -
```

left `/var/spool/cron/root` at **0 bytes** on a fresh bastion. `crontab -l` has
nothing to list there and exits non-zero, so the subshell contributed nothing and
the append landed nowhere — while every command in the pipeline exited 0. So
`idle_timeout` could not work, and with the default `preserve_bastion=True`
nothing else reclaims a bastion.

Now an `/etc/cron.d/parsl-idle-shutdown` drop-in, which has no read-modify-write
step and so no empty-input case. The prerequisite check now requires a *running*
daemon (`systemctl is-active crond`) rather than the `crontab` client being on
`PATH` — the client's presence said nothing about whether the drop-in would ever
be read.

## Verification

**Against real AWS** (`us-east-1`, account `942542972736`), which is the only
thing that could prove any of this — the limits are enforced nowhere else:

- A bastion stack reached `CREATE_COMPLETE`, from a UserData shim under 4,096 B.
- A direct-path bastion launched (`i-00d0e5d844dbb24aa`, `i-03b164844d451a4a1`).
- The two E2E tests that previously errored during construction now pass:
  `test_cleanup_removes_the_bastion_when_not_preserving` (198.98 s) and
  `test_cleanup_keeps_the_bastion_when_preserving` (213.59 s).
- On the fixed bastion: bootstrap status `OK`, sentinel present, python3 3.9.25
  intact, boto3 1.40.31, `aws-cli/2.33.15` intact, `dnf 4.14.0` intact, `crond`
  active, and **`parsl-bastion-manager.service` active** — the orchestrator loop
  starting for the first time.
- The cron drop-in **fired**, which the drop-in merely existing does not prove:

  ```
  CROND[25601]: (root) CMD (/usr/local/bin/parsl-idle-shutdown.sh)
  CROND[25600]: (root) CMDEND (/usr/local/bin/parsl-idle-shutdown.sh)
  -rw-r--r--. 1 root root 11 /var/run/parsl-last-activity
  ```

  The activity file is the script's own output, so it ran rather than merely got
  scheduled.

**Against substrate**, which caught a defect a mock could not: botocore's
*presigner* emits SigV2 even when `client.meta.config.signature_version` reports
`s3v4`. A SigV2 URL is rejected by every region created after 2014, and substrate
answers **501**. `Config(signature_version="s3v4")` is now passed explicitly. The
integration test does a real `put_object` and then a real
`urllib.request.urlopen` of the URL extracted from UserData, asserting the body
matches — that HTTP GET is the assertion that needed an emulator.

A second real defect came from the same rewrite: the size assertion assumed a
**175 B** presigned URL, the length with static keys. Under session-token
credentials it is **1,064 B** (the token alone ~664 B). Measured, then the
assertion rewritten against the worst case — otherwise it would have passed in
development and failed for anyone using a role.

Unit tests are pure rendering arithmetic (no session, no fake AWS): they pin what
the shim contains and that it fits, and each shell assertion records the live
finding it corresponds to.

Suites: **1253 unit passed / 2 skipped**, **136 integration passed**, ruff clean,
mypy **59 errors** (under the 76 baseline).

Live resources from this work were swept: zero `parsl-*` stacks, buckets,
instances, `parsl-ephemeral-ssm-role-*` and `parsl-bastion*` roles remain.

## Filed, not fixed here

**#229** — the direct path attaches no instance profile, so
`parsl-bastion-manager.py` crash-loops on `NoCredentialsError` every 10 s
(`Restart=always`). Verified on both live bastions: `IamInstanceProfile` is
`null` and IMDS returns 404 for `iam/security-credentials/`. Three signals read
healthy — `systemctl is-active` says `active` between crashes, the UserData
sentinel is present, and SSM says `Online` (this account has Default Host
Management Configuration set, which registers instances with *no* profile). So
the bastion is reachable over SSM while unable to make a single AWS call of its
own. The staged-script fix here is deliberately unaffected, since a presigned URL
needs no instance credentials; what has never worked is the manager loop after
boot, which has no live coverage.

closes #227
closes #225
