### PR TITLE
docs: re-probe the substrate pin against 0.92.0, fix a fixture leak

### DIFF
--- a/docs/substrate_testing.md
+++ b/docs/substrate_testing.md
@@ -202,16 +202,15 @@ works around.
 
 > [!IMPORTANT]
 > **The pin stays on `0.88.0`, and bumping it is blocked on
-> [substrate#560](https://github.com/scttfrdmn/substrate/issues/560).** `0.89.0` and
-> `0.90.0` between them fix all three rows below — including both defects this
-> repository filed, #544 and #545 — so the bump is wanted. It cannot land yet:
-> substrate gives a resource with no explicit physical name **the logical ID
-> verbatim**, and a logical ID is only unique within a stack while an IAM role name
-> is account-global. So a second stack from the same template collides with
-> `EntityAlreadyExists`, and 6 integration tests fail. `bastion.yml`
-> (`BastionHostRole`) and `ecs_worker.yml` (`TaskRole`, `TaskExecutionRole`) all
-> deliberately omit the name, which is the practice that makes a template
-> deployable more than once.
+> [substrate#560](https://github.com/scttfrdmn/substrate/issues/560).** `0.89.0`
+> through `0.92.0` fix all three rows below — including both defects this repository
+> filed, #544 and #545 — so the bump is wanted. It cannot land yet: substrate gives
+> a resource with no explicit physical name **the logical ID verbatim**, and a
+> logical ID is only unique within a stack while an IAM role name is account-global.
+> So a second stack from the same template collides with `EntityAlreadyExists`, and
+> 6 integration tests fail. `bastion.yml` (`BastionHostRole`) and `ecs_worker.yml`
+> (`TaskRole`, `TaskExecutionRole`) all deliberately omit the name, which is the
+> practice that makes a template deployable more than once.
 >
 > The create was *already* failing on `0.88.0` — `0.89.0`'s rollback is only what
 > made it visible, since the stack previously still reported `CREATE_COMPLETE`. So
@@ -222,6 +221,41 @@ works around.
 > `DescribeStackEvents` answers `UnsupportedOperation` ("substrate models stack
 > status, not per-resource stack events"), so the failing resource is not reachable
 > that way.
+>
+> **Re-evaluated against `0.92.0`.** Same 6 failures, and probed to be #560
+> unchanged rather than a new cause — `0.92.0` switches on IAM enforcement for a
+> stack's resource calls, so that had to be ruled out. With `DisableRollback=True`:
+>
+> ```
+> BastionHostRole             CREATE_FAILED  EntityAlreadyExists: Role with name BastionHostRole already exists.
+> BastionHostInstanceProfile  CREATE_FAILED  EntityAlreadyExists: Instance Profile BastionHostInstanceProfile already exists.
+> ```
+>
+> The new enforcement does not reach this project: `0.92.0` documents `test`/`test`
+> as resolving to no principal and therefore authorized against nothing, which is
+> what `tests/conftest.py` uses.
+>
+> Bumping now also needs **a second substrate fix**, reachable only because #518 and
+> #544 are fixed: `DeleteStack` deletes an `AWS::IAM::InstanceProfile` without
+> removing its role first, so the delete is refused —
+> `DeleteConflict: Cannot delete entity, must detach all roles first` — and the stack
+> ends `DELETE_FAILED` with the profile standing under its logical-ID name. Note the
+> inverted order in `DescribeStackResources`: `BastionHostRole` reaches
+> `DELETE_COMPLETE` while the profile referencing it fails. So even with #560 fixed
+> for roles, the profile alone would keep the collision. Not yet filed upstream.
+>
+> One unrelated gap found while probing, **pre-existing and not a `0.92.0`
+> regression** (0.88.0 fails identically): `GetFunctionConfiguration` answers
+> `InvalidAction: LambdaPlugin: unknown operation "Unknown"`, while `GetFunction`
+> on the same path prefix works and carries the same `CodeSize`. This project calls
+> neither, so it is recorded rather than blocking.
+
+All three CloudFormation rows below are **fixed upstream and still live here**,
+because the pin cannot move past `0.88.0` — see the note above. Each was re-probed
+on both versions, so the "fixed" claim is measured rather than read off an issue:
+on `0.92.0` a CFN-created bucket is deleted with its stack, `delete_stack` and
+`describe_stacks` both resolve a stack ARN, and a CFN-deployed function reports its
+true `CodeSize` (1,361 B for a zip that `0.88.0` reports as `0`).
 
 | Gap | Effect | Upstream |
 |---|---|---|

--- a/tests/integration/test_detached_mode_spot_fleet_integration.py
+++ b/tests/integration/test_detached_mode_spot_fleet_integration.py
@@ -134,6 +134,19 @@ class TestDetachedModeSpotFleetIntegration:
         try:
             yield mode
         finally:
+            # `preserve_bastion` defaults to True, so cleanup alone keeps the
+            # stack -- and its IAM role, which `bastion.yml` deliberately does
+            # not name, outlives it. substrate gives an unnamed resource its
+            # logical ID verbatim (substrate#560), and `BastionHostRole` is
+            # account-global, so the next test in the file met
+            # `EntityAlreadyExists`.
+            #
+            # This was invisible until substrate 0.92.0. Delete-by-ARN silently
+            # no-op'd (substrate#544) and DeleteStack left the stack's resources
+            # standing (substrate#518), so no teardown here removed anything and
+            # the collision was attributed entirely to #560. Both are fixed now,
+            # which makes the fixture's own omission the operative cause.
+            mode.preserve_bastion = False
             mode.cleanup_infrastructure()
 
     def test_initialize_deploys_the_bastion_stack(self, detached_mode):


### PR DESCRIPTION
substrate released `0.92.0`. This re-evaluates the pin against it, keeps the pin
where it is, and fixes a test-side leak the evaluation exposed.

## The bump still cannot land

Same 6 integration tests fail. `0.92.0` switches on IAM enforcement for a stack's
resource calls, so that had to be ruled out as a new cause before blaming the old
one. With `DisableRollback=True` plus `DescribeStackResources`:

```
BastionHostRole             CREATE_FAILED  EntityAlreadyExists: Role with name BastionHostRole already exists.
BastionHostInstanceProfile  CREATE_FAILED  EntityAlreadyExists: Instance Profile BastionHostInstanceProfile already exists.
```

That is [substrate#560](https://github.com/scttfrdmn/substrate/issues/560)
unchanged — a resource with no explicit physical name gets its logical ID verbatim,
and an IAM role name is account-global while a logical ID is unique only within a
stack.

The new enforcement does not reach this project: `0.92.0` documents `test`/`test`
as resolving to no principal and therefore authorized against nothing, which is
what `tests/conftest.py` uses.

## What 0.92.0 does fix

All three recorded CloudFormation gaps, two of them filed from this repository.
Re-probed on **both** versions rather than read off the closed issues — a closed
issue is not a released fix, and this file already records that trap:

| Gap | `0.88.0` | `0.92.0` |
|---|---|---|
| [#518](https://github.com/scttfrdmn/substrate/issues/518) CFN-created bucket after `DeleteStack` | still listed | deleted |
| [#544](https://github.com/scttfrdmn/substrate/issues/544) `delete_stack(StackName=<arn>)` | HTTP 200, stack stands | stack gone |
| [#544](https://github.com/scttfrdmn/substrate/issues/544) `describe_stacks(StackName=<arn>)` | `ValidationError` | resolves |
| [#545](https://github.com/scttfrdmn/substrate/issues/545) CFN-deployed Lambda `CodeSize` | `0` | `1361` — the true zip size |

So the bump is still wanted; it is one upstream defect short. Two, now:

## A second blocker, reachable only because #518 and #544 are fixed

`DeleteStack` deletes an `AWS::IAM::InstanceProfile` without removing its role
first, which IAM refuses:

```
BastionHostRole             DELETE_COMPLETE  None
BastionHostInstanceProfile  DELETE_FAILED    DeleteConflict: Cannot delete entity, must detach all roles first.
```

Note the inverted order — the **role** is deleted successfully and the **profile
referencing it** is then refused. Real IAM would refuse the role while it is still
in a profile, so the sequence is wrong from both directions. The stack ends
`DELETE_FAILED` with the profile standing under its logical-ID name, so even a #560
fix for roles alone would leave the collision in place. Filed upstream.

## The fixture leak this exposed

`test_detached_mode_spot_fleet_integration.py`'s fixture called
`cleanup_infrastructure()` without clearing `preserve_bastion`, which defaults to
`True` — so it kept every stack it created, and with it an IAM role that
`bastion.yml` deliberately does not name. Every other integration file that
constructs a `DetachedMode` sets the flag; this one did not.

It was invisible while #518 and #544 meant no teardown removed anything: the
collision was attributable entirely to #560, and the fixture's own omission was
masked. On `0.92.0` the fix advances the failure — the role is now reaped and only
the instance profile survives — which is how the second blocker above became
visible at all.

Correct regardless of substrate version, so it lands here rather than waiting for
the bump.

## Verification

Pins reverted to `0.88.0` in both places they appear
(`docker-compose.substrate.yml:89`, `.github/workflows/ci.yml:130` — they have
drifted before, so both were checked):

- `tests/integration` — **140 passed**
- `tests/test_substrate_emulation.py` — **5 passed**
- ruff clean, 147 files formatted

## Also recorded, not blocking

`GetFunctionConfiguration` answers `InvalidAction: LambdaPlugin: unknown operation
"Unknown"`, while `GetFunction` on the same path prefix works and carries the same
`CodeSize`. **Not a `0.92.0` regression** — `0.88.0` fails identically, so it is a
pre-existing gap that had simply never been probed. This project calls neither
operation.
