### PR TITLE
fix: reach s3_create_bucket, and run the ECS command through a shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **BREAKING: the ECS command is a shell string, not comma-separated argv** (#226).
+  `ecs_worker.yml` built the container's argv with `!Split [',', !Ref Command]`, so
+  `submit("python -c 'print(1)'")` — the form every other path accepts — arrived as
+  a single `argv[0]`, the container failed to exec, and because the stack runs an
+  ECS *Service* with a `DesiredCount` the exited task was replaced and billed on a
+  loop. Nothing distinguished that from a task that ran and finished: the task
+  definition registered, the stack reached `CREATE_COMPLETE`, the task reached
+  `STOPPED`.
+
+  The template now runs `/bin/sh -c <command>`, matching `ECSManager`'s own
+  `_register_task_definition`, Lambda's `subprocess.run(shell=True)`, and the EC2
+  fleet's generated `command.sh`. Quoting, pipes, redirection, and multi-line
+  commands work; commas are just commas. The image must have a `/bin/sh`, which
+  rules out `FROM scratch` and distroless images.
+
+  This breaks commands written for the old encoding: `"python,-c,print(1)"` now
+  reaches the shell with its commas intact and must be respaced. The issue proposed
+  comma-joining inside `ServerlessMode` instead, which would have hidden the
+  encoding without removing it — a command containing a comma would still have been
+  cut in two, and space-splitting into argv would still have mishandled quotes.
+
+  `ServerlessMode` also stopped collapsing newlines to `;` on the way to
+  CloudFormation. That served the old argv encoding and silently truncated any
+  multi-line command with a comment in it, since everything after the `#` became
+  part of the comment. CloudFormation preserves newlines in a `String` parameter,
+  verified against the live service.
 - **BREAKING: the four remaining mode-specific options are now guarded** (#155).
   `bastion_instance_type` on `mode="detached"`, and `memory_size` / `timeout` on
   `mode="serverless"`, join the guard #136 built for the other eight: setting one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   constructor parameter has fallen out of the sample set altogether.
 
 ### Added
+- **`s3_create_bucket` on `EphemeralProvider`** (#224). `S3State` has accepted
+  `create_bucket_if_not_exists` since it was written, but `_initialize_state_store`
+  never passed it, so every provider-built S3 store took the already-exists branch
+  and failed on a missing bucket. Anyone who wanted the bucket provisioned had to
+  construct `S3State` themselves, bypassing the provider. The flag now forwards.
+
+  The default is `False`, matching the store's own default and the previous
+  behaviour: a missing bucket stays an error rather than something the provider
+  quietly provisions. Unlike the mode-specific options, it does not join the
+  wrong-mode guards — the state store is chosen independently of the operating
+  mode, so `s3_create_bucket` is meaningful on all three.
 - **`bastion_instance_profile_arn` on `EphemeralProvider`** (#229), for
   `mode="detached"`. Supply an instance profile the bastion should assume and it is
   used as-is and never deleted; leave it unset — the default — and the provider

--- a/docs/operating_modes.md
+++ b/docs/operating_modes.md
@@ -315,12 +315,19 @@ back before any container starts — which looks nothing like an image problem.
 `templates/cloudformation/lambda_worker.yml`, or CloudFormation rejects the
 stack.
 
-**On ECS, the command is split on commas, not spaces.** `ecs_worker.yml` builds
-the container's argv with `!Split [',', !Ref Command]`, so pass
-`"python,-c,print(1)"` rather than `"python -c print(1)"` — a space-separated
-string arrives as a single argv[0], and the container exits without running
-anything. This applies only to `compute_type="ecs"`; Lambda and the EC2 modes take
-an ordinary shell string.
+The command is an ordinary shell string on every path, ECS included. The Fargate
+container runs it as `/bin/sh -c <command>`, so quoting, pipes, redirection, and
+multi-line commands all work — the same as Lambda (`subprocess.run(shell=True)`)
+and the EC2 modes (a generated `command.sh`). The one requirement is that the image
+has a `/bin/sh`; a `FROM scratch` or distroless image does not.
+
+Before v0.10.0, `ecs_worker.yml` built the container's argv with
+`!Split [',', !Ref Command]`, so `"python -c print(1)"` arrived as a single
+`argv[0]` and the container exited without running anything — and because the stack
+runs an ECS *Service* with a `DesiredCount`, the exited task was replaced and
+billed on a loop. Commands written for that encoding (`"python,-c,print(1)"`) now
+reach the shell with the commas intact and must be rewritten with spaces
+([#226](https://github.com/scttfrdmn/parsl-ephemeral-provider/issues/226)).
 
 These are accepted only on `mode="serverless"`; setting one on another mode
 raises `ProviderConfigurationError`. `memory_size` and `timeout` joined that

--- a/docs/state_persistence.md
+++ b/docs/state_persistence.md
@@ -78,8 +78,31 @@ provider = EphemeralProvider(
 ```
 
 `s3_bucket` is mandatory for this backend — omitting it raises
-`ProviderConfigurationError`. The bucket must already exist; the provider does not
-create it.
+`ProviderConfigurationError`. By default the bucket must already exist; a missing
+one is an error rather than something the provider quietly provisions.
+
+Pass `s3_create_bucket=True` to have the provider create it when it is absent:
+
+```python
+provider = EphemeralProvider(
+    # ... network and compute options ...
+    state_store_type="s3",
+    s3_bucket="my-parsl-state-bucket",
+    s3_create_bucket=True,
+)
+```
+
+Creation also applies a full public-access block and tags the bucket
+`ParslManagedBucket=true`, so it is identifiable later. An existing bucket is
+adopted, not recreated, which is what makes the resume path work — every restart
+constructs the store again. Requires `s3:CreateBucket`, `s3:PutBucketPublicAccessBlock`,
+and `s3:PutBucketTagging` on top of the object permissions.
+
+Note that the provider never *deletes* a bucket it created — no cleanup path calls
+`S3State.delete_bucket_if_empty()`, which exists for callers who want it
+explicitly. State outliving a run is the point of a state store, and an empty
+bucket costs nothing to keep, so the ownership-tracking that `_owns_baked_ami` does
+for AMIs would buy little here.
 
 ## Recommended store by mode
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -298,8 +298,10 @@ before v0.7.0 that message was swallowed by a `TypeError`.
 
 ### `s3_bucket is required when using 's3' state store`
 
-Pass `s3_bucket`. The provider does not create the bucket; create it yourself and
-set default encryption on it.
+Pass `s3_bucket`. By default the provider does not create the bucket — create it
+yourself and set default encryption on it, or pass `s3_create_bucket=True` to have
+the provider create it when absent (it applies a public-access block and tags, but
+not default encryption).
 
 ### State is lost or two runs fight over resources
 

--- a/parsl_ephemeral_provider/modes/serverless.py
+++ b/parsl_ephemeral_provider/modes/serverless.py
@@ -742,10 +742,17 @@ class ServerlessMode(OperatingMode):
                         "ParameterKey": "TaskMemory",
                         "ParameterValue": str(self.ecs_task_memory),
                     },
-                    {
-                        "ParameterKey": "Command",
-                        "ParameterValue": command.replace("\n", ";"),
-                    },
+                    # Passed through unaltered. The template exec's it with
+                    # /bin/sh -c since #226, so this is an ordinary shell string
+                    # like every other mode's, and a multi-line command works.
+                    # Newlines used to be collapsed to ';' here, which served the
+                    # old argv-by-comma-split encoding and silently broke any
+                    # command with a comment line -- everything after a '#'
+                    # became part of the comment. CloudFormation preserves
+                    # newlines in a String parameter verbatim; verified against
+                    # the live service by reading a parameter echo back out of a
+                    # stack output.
+                    {"ParameterKey": "Command", "ParameterValue": command},
                     {"ParameterKey": "VpcId", "ParameterValue": self.vpc_id},
                     {"ParameterKey": "SubnetIds", "ParameterValue": self.subnet_id},
                     {

--- a/parsl_ephemeral_provider/provider.py
+++ b/parsl_ephemeral_provider/provider.py
@@ -186,6 +186,10 @@ class EphemeralProvider(ExecutionProvider, RepresentationMixin):
         S3 bucket name when using 's3' state store.
     s3_key : str, optional
         S3 key name when using 's3' state store. Default is 'ephemeral_aws_state.json'.
+    s3_create_bucket : bool, optional
+        Whether to create ``s3_bucket`` if it does not exist, when using the 's3'
+        state store. Default is ``False``, so a missing bucket is an error rather
+        than something the provider quietly provisions.
     parameter_store_path : str, optional
         Parameter Store path when using 'parameter_store' state store.
         Default is '/parsl/ephemeral_aws_state'.
@@ -381,6 +385,7 @@ class EphemeralProvider(ExecutionProvider, RepresentationMixin):
         state_file_path: str = "ephemeral_aws_state.json",
         s3_bucket: Optional[str] = None,
         s3_key: str = "ephemeral_aws_state.json",
+        s3_create_bucket: bool = False,
         parameter_store_path: str = "/parsl/ephemeral_aws_state",
         use_spot: bool = False,
         spot_max_price: Optional[str] = None,
@@ -487,6 +492,7 @@ class EphemeralProvider(ExecutionProvider, RepresentationMixin):
         self.state_file_path = state_file_path
         self.s3_bucket = s3_bucket
         self.s3_key = s3_key
+        self.s3_create_bucket = s3_create_bucket
         self.parameter_store_path = parameter_store_path
         self.use_spot = use_spot
         self.spot_max_price = spot_max_price
@@ -1065,10 +1071,17 @@ class EphemeralProvider(ExecutionProvider, RepresentationMixin):
                 raise ProviderConfigurationError(
                     "s3_bucket is required when using 's3' state store"
                 )
+            # create_bucket_if_not_exists was unreachable from here until #224:
+            # the store had accepted the flag since it was written, but this call
+            # never passed it, so every provider-built S3 store took the
+            # already-exists branch and failed on a missing bucket. Anyone who
+            # wanted the bucket created had to build S3State directly, bypassing
+            # the provider.
             return S3StateStore(
                 provider=self,
                 bucket_name=self.s3_bucket,
                 key_prefix=self._s3_key_prefix(),
+                create_bucket_if_not_exists=self.s3_create_bucket,
             )
         else:
             raise ProviderConfigurationError(

--- a/parsl_ephemeral_provider/templates/cloudformation/ecs_worker.yml
+++ b/parsl_ephemeral_provider/templates/cloudformation/ecs_worker.yml
@@ -51,7 +51,11 @@ Parameters:
 
   Command:
     Type: String
-    Description: Command to run in the container
+    # Run through a shell in the container, so this is an ordinary shell string --
+    # quoting, pipes, and redirection all work, and a comma is just a comma. It
+    # used to be argv, built with !Split [',', ...], which made this the only
+    # command surface in the provider that was not a shell string (#226).
+    Description: Shell command line to run in the container
     Default: ''
 
   VpcId:
@@ -205,7 +209,18 @@ Resources:
         - Name: !Sub 'parsl-container-${WorkflowId}-${JobId}'
           Image: !Ref ContainerImage
           Essential: true
-          Command: !If [HasCommand, !Split [',', !Ref Command], !Ref 'AWS::NoValue']
+          # A shell string, exec'd by /bin/sh, matching what ECSManager's own
+          # _register_task_definition has always done (compute/ecs.py) and what
+          # Lambda (subprocess.run(shell=True)) and the EC2 fleet (a generated
+          # command.sh) do. This was !Split [',', !Ref Command] until #226, which
+          # made a plain "python -c 'print(1)'" arrive as a single argv[0]: the
+          # container failed to exec, and because the stack runs an ECS *Service*
+          # with DesiredCount, the exited task was replaced and billed on a loop.
+          # Nothing distinguished that from a task that ran and finished.
+          Command: !If
+            - HasCommand
+            - ['/bin/sh', '-c', !Ref Command]
+            - !Ref 'AWS::NoValue'
           LogConfiguration:
             LogDriver: awslogs
             Options:

--- a/tests/aws/test_unverified_options_e2e.py
+++ b/tests/aws/test_unverified_options_e2e.py
@@ -20,7 +20,9 @@ emulator reports as success:
 3. ``S3State(create_bucket_if_not_exists=True)`` against real S3. Covered under
    moto and under substrate, but never against the service: ``tests/aws``'s
    ``s3_state_bucket`` fixture pre-creates the bucket, so the provider always
-   takes the already-exists branch there.
+   takes the already-exists branch there. #224 made the flag reachable through
+   ``EphemeralProvider(s3_create_bucket=True)``; these tests still drive the store
+   directly, for the reason the class docstring gives.
 
 Run with::
 
@@ -611,13 +613,17 @@ class TestS3BucketCreation:
     sequence ``CreateBucket`` → ``PutPublicAccessBlock`` → ``PutBucketTagging``
     is where real S3 differs most from an emulator.
 
-    ``S3State`` is constructed directly, and not for convenience: **the flag is
-    not reachable from ``EphemeralProvider``**. The constructor takes
-    ``s3_bucket`` and ``s3_key``, but ``_initialize_state_store``
-    (``provider.py:1054``) builds the store with only ``provider``,
-    ``bucket_name``, and ``key_prefix`` -- so a provider always takes the
-    already-exists branch, and a caller who wants the bucket created has to build
-    the store themselves. That is arguably a wider gap than #166 describes.
+    ``S3State`` is constructed directly rather than through a provider. That used
+    to be forced: the flag was not reachable from ``EphemeralProvider`` at all,
+    because ``_initialize_state_store`` built the store with only ``provider``,
+    ``bucket_name``, and ``key_prefix``, so every provider-built store took the
+    already-exists branch. #224 added ``s3_create_bucket`` and forwards it, so a
+    provider can now reach this path -- but the direct construction stays,
+    because building a real ``EphemeralProvider`` reaches AWS and creates a launch
+    template and an IAM role, none of which this class is about. The forwarding
+    itself is pinned under unit test
+    (``test_provider_edge_cases.py::TestS3CreateBucketForwarding``); what only a
+    live run can settle is what the store then does to real S3.
     """
 
     @pytest.fixture

--- a/tests/aws/test_unverified_options_e2e.py
+++ b/tests/aws/test_unverified_options_e2e.py
@@ -240,19 +240,6 @@ class TestEcsContainerImageIsHonoured:
         except Exception as exc:
             logger.warning("ecs_provider shutdown raised (best-effort): %s", exc)
 
-    @staticmethod
-    def _argv(*parts: str) -> str:
-        """Join *parts* the way ``ecs_worker.yml`` expects to receive them.
-
-        The template passes ``Command`` through ``!Split [',', ...]`` to build the
-        container's argv, so a plain shell string arrives as a single argv[0] and
-        the container exits before running anything. Commas -- not spaces -- are
-        the separator, which is not obvious from the provider's
-        ``submit(command)`` signature and is worth stating once here rather than
-        at each call.
-        """
-        return ",".join(parts)
-
     def test_the_configured_image_is_what_runs(
         self, ecs_provider, aws_session, aws_region
     ):
@@ -263,12 +250,13 @@ class TestEcsContainerImageIsHonoured:
         would pass against ``python:3.12-slim`` too, and that is the exact
         regression -- the option silently not being forwarded.
         """
+        # A plain shell string, with quoting in it. Since #226 the template
+        # exec's Command under /bin/sh -c, so this is the same surface every other
+        # mode takes; it used to have to be comma-joined into argv, and the
+        # embedded quotes and spaces would not have survived that.
         job_id = ecs_provider.submit(
-            self._argv(
-                "python",
-                "-c",
-                "import sys; print('PARSL_E2E_PYTHON=%d.%d' % sys.version_info[:2])",
-            ),
+            "python -c \"import sys; print('PARSL_E2E_PYTHON=%d.%d' % "
+            'sys.version_info[:2])"',
             tasks_per_node=1,
         )
 
@@ -313,7 +301,7 @@ class TestEcsContainerImageIsHonoured:
         is about the first task observed to stop, not about the service settling.
         """
         job_id = ecs_provider.submit(
-            self._argv("python", "-c", "print('PARSL_E2E_RAN')"), tasks_per_node=1
+            "python -c \"print('PARSL_E2E_RAN')\"", tasks_per_node=1
         )
 
         cf = aws_session.client("cloudformation", region_name=aws_region)
@@ -366,7 +354,8 @@ class TestEcsContainerImageIsHonoured:
         assert exit_codes and all(code == 0 for code in exit_codes), (
             f"Container exit codes {exit_codes}, stoppedReason={reason!r}. A "
             "non-zero exit with no pull error is the signature of a command the "
-            "image cannot execute -- see _argv() on how ecs_worker.yml splits it."
+            "image cannot execute -- check that the image has a /bin/sh, which "
+            "ecs_worker.yml's Command relies on (#226)."
         )
 
 

--- a/tests/integration/test_serverless_mode_spot_fleet_integration.py
+++ b/tests/integration/test_serverless_mode_spot_fleet_integration.py
@@ -193,13 +193,18 @@ class TestServerlessModeSpotFleetIntegration:
         ``0.88.0``: three separate defects each returned a *successful* but empty or
         truncated container list, so a stack that deployed a broken task definition
         looked identical to one that worked. ``Command`` is the interesting field
-        because the template routes it through ``!Split`` inside
+        because the template builds it with an intrinsic inside
         ``ContainerDefinitions`` -- the exact shape of substrate#521 and #526.
+
+        The command submitted here contains a space and a comma, both of which used
+        to be destructive. Until #226 the template built argv with
+        ``!Split [',', ...]``, so this string would have arrived as the two-element
+        ``["echo hello", " world"]`` -- non-empty, which is all the previous version
+        of this test checked, and which is why it passed against the defect.
         """
         serverless_mode.initialize()
-        resource_id = serverless_mode.submit_job(
-            self._job_id("job-td"), "echo hello", 1
-        )
+        command = "echo hello, world"
+        resource_id = serverless_mode.submit_job(self._job_id("job-td"), command, 1)
         stack_name = serverless_mode.resources[resource_id]["stack_name"]
 
         outputs = {
@@ -215,7 +220,11 @@ class TestServerlessModeSpotFleetIntegration:
 
         containers = task_def["containerDefinitions"]
         assert containers, "task definition deployed with no containers"
-        assert containers[0]["command"], "the command was lost between CFN and ECS"
+        assert containers[0]["command"] == ["/bin/sh", "-c", command], (
+            f"command deployed as {containers[0]['command']!r}. The container runs "
+            "the command through a shell, so it must arrive as a single argument "
+            "and not be split (#226)."
+        )
 
     def test_submit_lambda_job_stages_a_real_zip_in_s3(self, aws_session, network):
         """A Lambda submit stages an intact archive and deploys the function.

--- a/tests/unit/test_globus_config_loading.py
+++ b/tests/unit/test_globus_config_loading.py
@@ -660,6 +660,7 @@ class TestEveryParameterSurvivesTheRoundTrip:
             "profile_name": "aws",
             "state_file_path": "s.json",
             "s3_key": "k.json",
+            "s3_create_bucket": True,
             "parameter_store_path": "/p/x",
             "spot_max_price": "0.05",
             "spot_allocation_strategy": "capacity-optimized",

--- a/tests/unit/test_provider_edge_cases.py
+++ b/tests/unit/test_provider_edge_cases.py
@@ -2086,3 +2086,108 @@ class TestFleetBlockPoll:
                     mode._create_spot_fleet_instance(self._run_args())
 
         discard.assert_called_once_with("block-1")
+
+
+class TestS3CreateBucketForwarding:
+    """``create_bucket_if_not_exists`` was unreachable from the provider (#224).
+
+    ``S3State`` had accepted the flag since it was written and acted on it, but
+    ``_initialize_state_store()`` built the store with three arguments and none of
+    them was this one. So a provider on ``state_store_type="s3"`` *always* took
+    the already-exists branch and failed if the bucket was absent, while
+    ``s3_bucket`` and ``s3_key`` sitting alongside it made the whole area look
+    configurable. Anyone who wanted the bucket created had to build ``S3State``
+    directly, bypassing the provider -- which is what the E2E suite did, with a
+    comment saying why.
+    """
+
+    def _store_kwargs(self, **provider_kwargs):
+        """The kwargs the provider really passes to ``S3StateStore``.
+
+        Patched at the class the provider imports, so the assertion is about the
+        call the provider makes rather than about a store built here.
+        """
+        with (
+            patch(
+                "parsl_ephemeral_provider.provider.create_session"
+            ) as mock_session_factory,
+            patch("parsl_ephemeral_provider.provider.S3StateStore") as store_cls,
+            patch.object(EphemeralProvider, "_load_state", return_value=None),
+            patch.object(
+                EphemeralProvider,
+                "_initialize_operating_mode",
+                return_value=MagicMock(),
+            ),
+        ):
+            mock_session_factory.return_value = MagicMock()
+            EphemeralProvider(
+                region="us-east-1",
+                image_id="ami-12345678",
+                mode="standard",
+                vpc_id="vpc-test00001",
+                subnet_id="subnet-test001",
+                security_group_id="sg-test00001",
+                state_store_type="s3",
+                s3_bucket="some-bucket",
+                **provider_kwargs,
+            )
+
+        return store_cls.call_args.kwargs
+
+    def test_the_flag_reaches_the_store(self):
+        assert self._store_kwargs(s3_create_bucket=True)["create_bucket_if_not_exists"]
+
+    def test_the_default_is_not_to_create(self):
+        """Provisioning a bucket is a side effect a caller opts into.
+
+        Flipping this default would change behaviour for every existing ``s3``
+        config, and a typo'd bucket name would silently create a second bucket
+        rather than failing.
+        """
+        assert self._store_kwargs()["create_bucket_if_not_exists"] is False
+
+    def test_the_flag_is_passed_explicitly_rather_than_omitted(self):
+        """Relying on the store's own default is what made this unreachable.
+
+        The store already defaulted to ``False``, so the old call looked correct
+        and behaved correctly for the default case -- the defect was only visible
+        when a caller wanted the other value. Asserting the key is *present*
+        pins the forwarding rather than the resulting behaviour.
+        """
+        assert "create_bucket_if_not_exists" in self._store_kwargs()
+
+    def test_it_is_accepted_on_every_mode(self):
+        """The state store is mode-agnostic, so this is not a mode-specific option.
+
+        It deliberately does *not* join the ``_reject_wrong_mode_options`` guards:
+        any mode can use the S3 backend.
+        """
+        for mode in ("standard", "detached", "serverless"):
+            with (
+                patch(
+                    "parsl_ephemeral_provider.provider.create_session"
+                ) as mock_session_factory,
+                patch.object(
+                    EphemeralProvider,
+                    "_initialize_state_store",
+                    return_value=MagicMock(),
+                ),
+                patch.object(EphemeralProvider, "_load_state", return_value=None),
+                patch.object(
+                    EphemeralProvider,
+                    "_initialize_operating_mode",
+                    return_value=MagicMock(),
+                ),
+            ):
+                mock_session_factory.return_value = MagicMock()
+                provider = EphemeralProvider(
+                    region="us-east-1",
+                    image_id="ami-12345678",
+                    mode=mode,
+                    vpc_id="vpc-test00001",
+                    subnet_id="subnet-test001",
+                    security_group_id="sg-test00001",
+                    s3_create_bucket=True,
+                )
+
+            assert provider.s3_create_bucket is True

--- a/tests/unit/test_serverless_mode.py
+++ b/tests/unit/test_serverless_mode.py
@@ -7,7 +7,10 @@ SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
 import pytest
 from unittest.mock import MagicMock, patch
 import boto3
+import re
 import time
+
+import yaml
 
 from parsl_ephemeral_provider.modes.serverless import ServerlessMode
 from parsl_ephemeral_provider.state.base import STATE_KEY_MODE
@@ -33,191 +36,195 @@ from parsl_ephemeral_provider.constants import (
 pytestmark = pytest.mark.unit
 
 
+@pytest.fixture
+def mock_session():
+    """Create a mock boto3 session."""
+    session = MagicMock(spec=boto3.Session)
+    session.region_name = "us-east-1"
+    return session
+
+
+@pytest.fixture
+def mock_state_store():
+    """Create a mock state store."""
+    store = MagicMock()
+    store.load_state.return_value = None  # Default to no state
+    return store
+
+
+@pytest.fixture
+def mock_cf_client():
+    """Create a mock CloudFormation client."""
+    client = MagicMock()
+
+    # Mock create_stack
+    client.create_stack.return_value = {"StackId": "stack-12345"}
+
+    # Mock describe_stacks
+    client.describe_stacks.return_value = {
+        "Stacks": [
+            {
+                "StackId": "stack-12345",
+                "StackName": "parsl-lambda-12345",
+                "StackStatus": "CREATE_COMPLETE",
+                "Outputs": [
+                    {
+                        "OutputKey": "LambdaFunctionName",
+                        "OutputValue": "parsl-lambda-function",
+                    },
+                    {"OutputKey": "ClusterName", "OutputValue": "parsl-cluster"},
+                    {"OutputKey": "ServiceName", "OutputValue": "parsl-service"},
+                ],
+            }
+        ]
+    }
+
+    return client
+
+
+@pytest.fixture
+def mock_ec2_client():
+    """Create a mock EC2 client."""
+    client = MagicMock()
+
+    # Mock create_vpc
+    client.create_vpc.return_value = {"Vpc": {"VpcId": "vpc-12345"}}
+
+    # Mock describe_vpcs
+    client.describe_vpcs.return_value = {"Vpcs": [{"VpcId": "vpc-12345"}]}
+
+    # Mock create_subnet
+    client.create_subnet.return_value = {"Subnet": {"SubnetId": "subnet-12345"}}
+
+    # Mock describe_subnets
+    client.describe_subnets.return_value = {"Subnets": [{"SubnetId": "subnet-12345"}]}
+
+    # Mock create_security_group
+    client.create_security_group.return_value = {"GroupId": "sg-12345"}
+
+    # Mock describe_security_groups
+    client.describe_security_groups.return_value = {
+        "SecurityGroups": [{"GroupId": "sg-12345"}]
+    }
+
+    return client
+
+
+@pytest.fixture
+def mock_lambda_client():
+    """Create a mock Lambda client."""
+    client = MagicMock()
+
+    # Mock get_function
+    client.get_function.return_value = {
+        "Configuration": {
+            "FunctionName": "parsl-lambda-function",
+            "FunctionArn": "arn:aws:lambda:us-east-1:123456789012:function:parsl-lambda-function",
+        }
+    }
+
+    # Mock invoke
+    client.invoke.return_value = {
+        "StatusCode": 200,
+        "Payload": MagicMock(
+            read=lambda: '{"statusCode": 200, "body": "Success"}'.encode()
+        ),
+    }
+
+    return client
+
+
+@pytest.fixture
+def mock_ecs_client():
+    """Create a mock ECS client."""
+    client = MagicMock()
+
+    # Mock describe_services
+    client.describe_services.return_value = {
+        "services": [
+            {
+                "serviceName": "parsl-service",
+                "desiredCount": 1,
+                "runningCount": 1,
+                "deployments": [{"status": "PRIMARY", "id": "deployment-12345"}],
+                "events": [{"message": "service has reached a steady state"}],
+            }
+        ]
+    }
+
+    # Mock list_tasks
+    client.list_tasks.return_value = {"taskArns": ["task-arn-12345"]}
+
+    # Mock describe_tasks
+    client.describe_tasks.return_value = {
+        "tasks": [
+            {
+                "taskArn": "task-arn-12345",
+                "lastStatus": "RUNNING",
+                "containers": [{"name": "worker", "lastStatus": "RUNNING"}],
+            }
+        ]
+    }
+
+    return client
+
+
+@pytest.fixture
+def serverless_mode(
+    mock_session,
+    mock_state_store,
+    mock_cf_client,
+    mock_ec2_client,
+    mock_lambda_client,
+    mock_ecs_client,
+    mock_s3_client,
+):
+    """Create a ServerlessMode instance with mocked dependencies."""
+
+    # Configure session to return mock clients
+    def get_client(service_name, **kwargs):
+        if service_name == "cloudformation":
+            return mock_cf_client
+        elif service_name == "ec2":
+            return mock_ec2_client
+        elif service_name == "lambda":
+            return mock_lambda_client
+        elif service_name == "ecs":
+            return mock_ecs_client
+        elif service_name == "s3":
+            # Lambda submits stage their zip here (#116).
+            return mock_s3_client
+        return MagicMock()
+
+    mock_session.client.side_effect = get_client
+
+    # Create mode instance with auto worker type
+    mode = ServerlessMode(
+        provider_id="test-provider",
+        session=mock_session,
+        state_store=mock_state_store,
+        worker_type=WORKER_TYPE_AUTO,
+        lambda_timeout=300,
+        lambda_memory=1024,
+        ecs_task_cpu=1024,
+        ecs_task_memory=2048,
+        region="us-east-1",
+        vpc_id="vpc-12345",
+        subnet_id="subnet-12345",
+        security_group_id="sg-12345",
+    )
+
+    # Mock LambdaManager and ECSManager
+    mode.lambda_manager = MagicMock()
+    mode.lambda_manager._generate_lambda_code.return_value = b"lambda_code_zip"
+
+    mode.ecs_manager = MagicMock()
+
+    return mode
+
+
 class TestServerlessMode:
     """Tests for the ServerlessMode class."""
-
-    @pytest.fixture
-    def mock_session(self):
-        """Create a mock boto3 session."""
-        session = MagicMock(spec=boto3.Session)
-        session.region_name = "us-east-1"
-        return session
-
-    @pytest.fixture
-    def mock_state_store(self):
-        """Create a mock state store."""
-        store = MagicMock()
-        store.load_state.return_value = None  # Default to no state
-        return store
-
-    @pytest.fixture
-    def mock_cf_client(self):
-        """Create a mock CloudFormation client."""
-        client = MagicMock()
-
-        # Mock create_stack
-        client.create_stack.return_value = {"StackId": "stack-12345"}
-
-        # Mock describe_stacks
-        client.describe_stacks.return_value = {
-            "Stacks": [
-                {
-                    "StackId": "stack-12345",
-                    "StackName": "parsl-lambda-12345",
-                    "StackStatus": "CREATE_COMPLETE",
-                    "Outputs": [
-                        {
-                            "OutputKey": "LambdaFunctionName",
-                            "OutputValue": "parsl-lambda-function",
-                        },
-                        {"OutputKey": "ClusterName", "OutputValue": "parsl-cluster"},
-                        {"OutputKey": "ServiceName", "OutputValue": "parsl-service"},
-                    ],
-                }
-            ]
-        }
-
-        return client
-
-    @pytest.fixture
-    def mock_ec2_client(self):
-        """Create a mock EC2 client."""
-        client = MagicMock()
-
-        # Mock create_vpc
-        client.create_vpc.return_value = {"Vpc": {"VpcId": "vpc-12345"}}
-
-        # Mock describe_vpcs
-        client.describe_vpcs.return_value = {"Vpcs": [{"VpcId": "vpc-12345"}]}
-
-        # Mock create_subnet
-        client.create_subnet.return_value = {"Subnet": {"SubnetId": "subnet-12345"}}
-
-        # Mock describe_subnets
-        client.describe_subnets.return_value = {
-            "Subnets": [{"SubnetId": "subnet-12345"}]
-        }
-
-        # Mock create_security_group
-        client.create_security_group.return_value = {"GroupId": "sg-12345"}
-
-        # Mock describe_security_groups
-        client.describe_security_groups.return_value = {
-            "SecurityGroups": [{"GroupId": "sg-12345"}]
-        }
-
-        return client
-
-    @pytest.fixture
-    def mock_lambda_client(self):
-        """Create a mock Lambda client."""
-        client = MagicMock()
-
-        # Mock get_function
-        client.get_function.return_value = {
-            "Configuration": {
-                "FunctionName": "parsl-lambda-function",
-                "FunctionArn": "arn:aws:lambda:us-east-1:123456789012:function:parsl-lambda-function",
-            }
-        }
-
-        # Mock invoke
-        client.invoke.return_value = {
-            "StatusCode": 200,
-            "Payload": MagicMock(
-                read=lambda: '{"statusCode": 200, "body": "Success"}'.encode()
-            ),
-        }
-
-        return client
-
-    @pytest.fixture
-    def mock_ecs_client(self):
-        """Create a mock ECS client."""
-        client = MagicMock()
-
-        # Mock describe_services
-        client.describe_services.return_value = {
-            "services": [
-                {
-                    "serviceName": "parsl-service",
-                    "desiredCount": 1,
-                    "runningCount": 1,
-                    "deployments": [{"status": "PRIMARY", "id": "deployment-12345"}],
-                    "events": [{"message": "service has reached a steady state"}],
-                }
-            ]
-        }
-
-        # Mock list_tasks
-        client.list_tasks.return_value = {"taskArns": ["task-arn-12345"]}
-
-        # Mock describe_tasks
-        client.describe_tasks.return_value = {
-            "tasks": [
-                {
-                    "taskArn": "task-arn-12345",
-                    "lastStatus": "RUNNING",
-                    "containers": [{"name": "worker", "lastStatus": "RUNNING"}],
-                }
-            ]
-        }
-
-        return client
-
-    @pytest.fixture
-    def serverless_mode(
-        self,
-        mock_session,
-        mock_state_store,
-        mock_cf_client,
-        mock_ec2_client,
-        mock_lambda_client,
-        mock_ecs_client,
-        mock_s3_client,
-    ):
-        """Create a ServerlessMode instance with mocked dependencies."""
-
-        # Configure session to return mock clients
-        def get_client(service_name, **kwargs):
-            if service_name == "cloudformation":
-                return mock_cf_client
-            elif service_name == "ec2":
-                return mock_ec2_client
-            elif service_name == "lambda":
-                return mock_lambda_client
-            elif service_name == "ecs":
-                return mock_ecs_client
-            elif service_name == "s3":
-                # Lambda submits stage their zip here (#116).
-                return mock_s3_client
-            return MagicMock()
-
-        mock_session.client.side_effect = get_client
-
-        # Create mode instance with auto worker type
-        mode = ServerlessMode(
-            provider_id="test-provider",
-            session=mock_session,
-            state_store=mock_state_store,
-            worker_type=WORKER_TYPE_AUTO,
-            lambda_timeout=300,
-            lambda_memory=1024,
-            ecs_task_cpu=1024,
-            ecs_task_memory=2048,
-            region="us-east-1",
-            vpc_id="vpc-12345",
-            subnet_id="subnet-12345",
-            security_group_id="sg-12345",
-        )
-
-        # Mock LambdaManager and ECSManager
-        mode.lambda_manager = MagicMock()
-        mode.lambda_manager._generate_lambda_code.return_value = b"lambda_code_zip"
-
-        mode.ecs_manager = MagicMock()
-
-        return mode
 
     def test_init(self, serverless_mode):
         """Test initialization of ServerlessMode."""
@@ -930,3 +937,82 @@ class TestServerlessMode:
         assert state["initialized"] is True
         assert state["resources"] == serverless_mode.resources
         assert state["worker_type"] == WORKER_TYPE_AUTO
+
+
+class TestEcsCommandIsAShellString:
+    """The ECS command surface matches every other mode's (#226).
+
+    ``ecs_worker.yml`` used to build the container's argv with
+    ``!Split [',', !Ref Command]``, and the mode collapsed newlines to ``;`` to
+    suit it. So ``submit("python -c 'print(1)'")`` -- the shape every other path
+    accepts -- arrived as a single ``argv[0]``, the container failed to exec, and
+    because the stack runs an ECS *Service* with a ``DesiredCount`` the exited task
+    was replaced and billed on a loop. Nothing about that was distinguishable from
+    a task that ran and finished: the task definition registered, the stack reached
+    ``CREATE_COMPLETE``, and the task reached ``STOPPED``.
+
+    Two seams, tested separately because they fail independently: the mode must
+    pass the command through untouched, and the template must run it under a shell.
+    """
+
+    @staticmethod
+    def _ecs_params(mode, command):
+        """Submit *command* down the ECS path and return the stack parameters."""
+        mode.worker_type = WORKER_TYPE_ECS
+        mode.initialized = True
+        resource_id = mode.submit_job("job-1", command, 1)
+        assert resource_id in mode.resources
+        return {
+            p["ParameterKey"]: p["ParameterValue"]
+            for p in mode.cf_client.create_stack.call_args[1]["Parameters"]
+        }
+
+    def test_a_shell_string_reaches_cloudformation_unaltered(self, serverless_mode):
+        """Quotes, spaces, and commas all survive.
+
+        A comma is the interesting character: under the old encoding it was the
+        argv separator, so a command that merely *mentioned* one -- a Python tuple,
+        a comma-separated ``--option`` -- was silently cut in two.
+        """
+        command = "python -c \"print('a,b', 1)\""
+        params = self._ecs_params(serverless_mode, command)
+
+        assert params["Command"] == command
+
+    def test_newlines_are_not_collapsed_into_semicolons(self, serverless_mode):
+        """A multi-line command keeps its newlines.
+
+        The mode used to send ``command.replace("\\n", ";")``. That is not merely
+        cosmetic: it makes every line after a ``#`` comment part of that comment,
+        so a script with one comment in it silently stops executing there.
+        CloudFormation preserves newlines in a ``String`` parameter, verified
+        against the live service.
+        """
+        command = "echo one\n# a comment\necho two"
+        params = self._ecs_params(serverless_mode, command)
+
+        assert params["Command"] == command
+        assert ";" not in params["Command"]
+
+    def test_the_template_execs_the_command_through_a_shell(self):
+        """``ecs_worker.yml`` wraps ``Command`` in ``/bin/sh -c``.
+
+        Asserted on the template rather than on a deployed stack because this is
+        the half the mode cannot observe: the mode's job is to hand over an
+        untouched string, and whether that string becomes ``argv`` or a shell line
+        is decided entirely here. A regression to ``!Split`` would leave both other
+        tests in this class passing.
+        """
+        # Intrinsics are stripped so safe_load can read the structure, the same
+        # way test_instance_profile.py reads bastion.yml. `!Ref Command` becomes a
+        # bare `Command` and `!If [c, a, b]` becomes the plain list [c, a, b],
+        # which is enough: what matters is that the command is the operand of a
+        # /bin/sh -c argv and not the input to a split.
+        container = yaml.safe_load(
+            re.sub(r"!\w+", "", get_cf_template("ecs_worker.yml"))
+        )["Resources"]["TaskDefinition"]["Properties"]["ContainerDefinitions"][0]
+
+        condition, present, absent = container["Command"]
+        assert condition == "HasCommand"
+        assert present == ["/bin/sh", "-c", "Command"]
+        assert absent == "AWS::NoValue"


### PR DESCRIPTION
Closes #224, closes #226. Two independent defects, both "the option was accepted
and did not do what it says".

## #224 — `s3_create_bucket` was unreachable from the provider

`S3State` has accepted `create_bucket_if_not_exists` since it was written, but
`_initialize_state_store` never passed it. Every provider-built S3 store took the
already-exists branch, so a missing bucket was an error with no way to ask for it
to be created — the caller had to construct `S3State` themselves, bypassing the
provider entirely.

The default stays `False`, matching the store and the previous behaviour: a
missing bucket is still an error, not something the provider quietly provisions.

It does **not** join the wrong-mode guards. Those exist for options a mode cannot
honour; the state store is chosen independently of the operating mode, so this is
meaningful on all three. `test_every_signature_parameter_is_covered_by_some_sample`
caught the omitted sample and it went in `mode_agnostic`.

**Verified:** four unit tests in `TestS3CreateBucketForwarding`. One of them
asserts the key is *present* in the store's kwargs rather than merely that the
resulting behaviour is right — omitting it entirely would also leave the store at
`False`, so a behavioural assertion alone would pass against the defect.

`tests/aws/test_unverified_options_e2e.py` keeps building `S3State` directly: a
real provider reaches AWS and creates a launch template and an IAM role, which
that class is not about. Only its *unreachability* claim was stale, and the class
docstring now says which half is pinned where.

## #226 — the ECS command was comma-split argv

`ecs_worker.yml` built the container's argv with `!Split [',', !Ref Command]`, so
`submit("python -c 'print(1)'")` — the form every other path accepts — arrived as
a single `argv[0]`. The container failed to exec, and because the stack runs an
ECS **Service** with a `DesiredCount`, the exited task was replaced and billed on
a loop. Nothing distinguished that from a task that ran and finished: the task
definition registered, the stack reached `CREATE_COMPLETE`, the task reached
`STOPPED`.

The template now runs `/bin/sh -c <command>`.

**I did not take the issue's recommended direction.** It proposed comma-joining
inside `ServerlessMode`, which hides the encoding without removing it: a command
merely *containing* a comma would still be cut in two, and space-splitting into
argv would still mishandle quotes. Every consumer of this string in the package
already wants a shell line — `ECSManager._register_task_definition` registers
`["/bin/sh", "-c", command]`, Lambda uses `subprocess.run(shell=True)`, the EC2
fleet writes a `command.sh` — so the template was the outlier, not the surface.

`ServerlessMode` also stopped collapsing newlines to `;`. That served the old argv
encoding and silently truncated any multi-line command with a comment in it, since
everything after the `#` became part of the comment.

**Verified:**

- Three unit tests, split by seam because the halves fail independently: the mode
  passes the command through untouched (quotes, commas, newlines), and the
  template wraps rather than splits. A regression to `!Split` leaves the first two
  passing, which is why the template assertion is separate.
- The integration test that reads the deployed task definition back out of
  substrate now submits `"echo hello, world"` and asserts the exact argv. It
  previously asserted only that the command was non-empty — which is why it passed
  against the defect, since the old split produced a non-empty two-element list.
- **Live AWS**, for the newline claim: CloudFormation preserves newlines in a
  `String` parameter verbatim, established by deploying a `WaitConditionHandle`
  stack that echoes its parameter to an output and reading the bytes back. No
  emulator settles that, and it is the fact the `;` removal rests on. Probe stack
  deleted.
- The E2E suite's `_argv()` helper existed only for this encoding and is gone. Its
  call sites now pass ordinary quoted shell strings, which is a stronger test of
  the fix than a comma-joined one would be — the embedded quotes and spaces would
  not have survived the old path.

`BREAKING CHANGE` footer on the #226 commit: commands written for the old encoding
(`"python,-c,print(1)"`) now reach the shell with their commas intact.

## Docs

`docs/state_persistence.md` and `docs/troubleshooting.md` both stated flatly that
the provider does not create the bucket — now false. `docs/operating_modes.md`
carried a paragraph *teaching* the comma encoding; it now documents the shell form
and the migration, and notes the `/bin/sh` requirement that rules out `FROM
scratch` and distroless images.

## Gates

| | |
|---|---|
| unit + security | 1293 passed, 2 skipped (was 1290) |
| integration (substrate 0.88.0) | 140 passed |
| `ruff check` / `ruff format --check` | clean |
| `mypy parsl_ephemeral_provider` | 59 errors = baseline, no new |

Note on the mypy figure: CLAUDE.md says 76. The real baseline on `main` is **59**,
confirmed by stashing and re-running there.

One incidental refactor: `tests/unit/test_serverless_mode.py`'s seven-deep mocked
fixture chain was defined as methods on `TestServerlessMode`, so a second class in
that file could not use it. The fixtures moved to module scope — no behaviour
change, and it accounts for most of that file's diff.