### PR TITLE
feat: reverse-tunnel HTEX workers over EICE (closes #134)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,77 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   constructor parameter has fallen out of the sample set altogether.
 
 ### Added
+- **`instance_connect_endpoint_id` and three `tunnel_*` options on
+  `EphemeralProvider`, for `mode="standard"`** (#134). This is the answer to "my
+  driver is a laptop behind NAT". HTEX workers connect *outbound* to the
+  interchange, so the driver has to accept inbound TCP on 54000–55000, which a
+  laptop behind home or office NAT cannot do. The project's only answer until now
+  was detached mode — paying for a bastion to work around a network topology
+  problem. Set `instance_connect_endpoint_id` to a pre-provisioned EC2 Instance
+  Connect Endpoint and the provider opens an SSH reverse tunnel to each worker,
+  putting the interchange on the worker's **own loopback**. Give HTEX
+  `address="127.0.0.1"`; no driver address needs to be routable, and the subnet
+  needs neither a public IP nor a NAT gateway.
+
+  The issue's proposed mechanism does not work, and correcting it shaped the
+  design. `aws ec2-instance-connect open-tunnel --remote-port` is a **forward**
+  tunnel: `--remote-port` is the port to connect to *on the instance*. Pointing it
+  at 54000–55000 forwards driver-side connections to ports on the worker where
+  nothing is listening. What works is to use EICE for the one thing it does —
+  reach port 22 — and let `ssh -R` carry the reverse forward. Verified live
+  against a `t3.micro` with no public IP in a subnet with no NAT: a `zmq.DEALER`
+  on the worker completed a full round trip to a `zmq.ROUTER` bound to driver
+  loopback, which is exactly HTEX's socket pair on exactly its port range.
+
+  Four API constraints, each confirmed against the live service, are why this is a
+  supervised subprocess rather than a config flag:
+
+  - a single tunnel is capped at **3600 seconds** — `--max-tunnel-duration 3601`
+    is rejected before the call is even made, and the CLI's own message ("must be
+    greater than 1 and less than 3600") is off by one, since 3600 itself is
+    accepted — so a background thread recycles each tunnel before AWS closes it;
+    a tunnel torn down at the ceiling drops whatever is in flight. The duration
+    is clamped a second under the ceiling, so it does not matter which of the
+    message and the behaviour is wrong;
+  - the reconnect budget is HTEX's 120-second `heartbeat_threshold`, so
+    reconnects are checked against it;
+  - `send-ssh-public-key` authorises for roughly **60 seconds**, so the key is
+    re-pushed immediately before *every* connect, not once per instance;
+  - endpoint creation takes several minutes, so the endpoint is caller-supplied
+    per #69 and never created. It joins the VPC/subnet/SG in `_verify_resources`,
+    so a typo fails in `initialize()` rather than surfacing minutes later as an
+    `ssh` process exiting for no visible reason.
+
+  Ordering is load-bearing and asserted in both suites: the tunnel is opened
+  *before* the command is dispatched, because a worker connects as soon as it
+  starts; closed when a dispatch fails or resources are cleaned up; and the
+  supervisor and any generated key material are torn down first in
+  `cleanup_infrastructure()`. Leave `tunnel_private_key_path` and
+  `tunnel_public_key_path` unset and an ephemeral pair is generated per provider
+  and removed at shutdown; setting one without the other raises.
+
+  Two tunnel-lifecycle races were caught during development and are covered by
+  regression tests, because both leak an `ssh` process that nothing can reap —
+  unbounded on a long-lived driver. The submit path and the supervision thread
+  both start and stop tunnels, so `EICETunnel` serialises its own lifecycle:
+  without it, two concurrent starts each passed the liveness check, each spawned
+  `ssh`, and the second overwrote the first handle. And because a supervision pass
+  iterates a snapshot, `remove()`/`shutdown()` mark a tunnel retired rather than
+  merely stopping it — otherwise a pass already in flight reconnects a tunnel to
+  an instance being terminated, after the supervisor has dropped its reference.
+
+  Two costs worth naming. This is the only part of the package that shells out —
+  it needs an `ssh` binary and AWS CLI v2 on the driver, because `open-tunnel` has
+  no boto3 equivalent (`ec2-instance-connect` exposes only `SendSSHPublicKey` and
+  `SendSerialConsoleSSHPublicKey`), and both are checked up front. And it needs
+  inbound TCP 22 from the endpoint on the worker security group, in exchange for
+  dropping the client-facing 54000–55000 rule entirely.
+  `network.eice_iam_statements()` returns the driver's grant, scoped with two
+  conditions that IAM's own evaluator is asked to confirm: `OpenTunnel` on
+  `remotePort == 22` alone, and `SendSSHPublicKey` on `ec2:osuser == ec2-user`.
+  All four options join the standard-mode guard — detached mode has its own answer
+  to the same problem, so accepting an endpoint ID there would read as a cheaper
+  alternative that silently did nothing.
 - **`distribute_certificates` on `EphemeralProvider`, for `mode="standard"`**
   (#62). Parsl's `HighThroughputExecutor` encrypts the worker/interchange channel
   with CurveZMQ by default, generating the certificates in the driver's `run_dir`

--- a/docs/network-prerequisites.md
+++ b/docs/network-prerequisites.md
@@ -29,6 +29,63 @@ PyPI/package mirrors).  No inbound rules are required by the provider itself.
 | Egress | TCP | 54000–55000 | interchange IP/32 | Parsl ZMQ interchange |
 | Egress | All | All | 0.0.0.0/0 | (permissive alternative) |
 
+The egress rule for 54000–55000 assumes the interchange is reachable from EC2.
+If your driver is behind NAT it is not — see
+[Optional: an EC2 Instance Connect Endpoint](#optional-an-ec2-instance-connect-endpoint),
+which removes that rule entirely.
+
+---
+
+## Optional: an EC2 Instance Connect Endpoint
+
+Needed only for `instance_connect_endpoint_id`, which lets workers reach an
+interchange on a driver that has no routable address — a laptop behind home or
+office NAT
+([#134](https://github.com/scttfrdmn/parsl-ephemeral-provider/issues/134)). See
+[Reverse tunnels](operating_modes.md#reverse-tunnels) for what it does and when
+to use it.
+
+Like the VPC, subnet, and security group, the endpoint is **caller-supplied and
+never created by the provider**: creation takes several minutes, which is not
+something to discover inside `initialize()`. A bad ID fails there anyway,
+alongside the other three, rather than surfacing later as an `ssh` process
+exiting for no visible reason.
+
+One endpoint serves every instance in its subnet, so this is a one-off.
+
+```bash
+aws ec2 create-instance-connect-endpoint \
+  --subnet-id subnet-0def5678 \
+  --security-group-ids sg-09ab0000 \
+  --region us-east-1
+# wait for State=create-complete, then:
+aws ec2 describe-instance-connect-endpoints \
+  --query 'InstanceConnectEndpoints[].{Id:InstanceConnectEndpointId,State:State}'
+```
+
+Terraform:
+
+```hcl
+resource "aws_ec2_instance_connect_endpoint" "parsl" {
+  subnet_id          = aws_subnet.parsl_public.id
+  security_group_ids = [aws_security_group.parsl_workers.id]
+}
+
+output "parsl_eice_id" { value = aws_ec2_instance_connect_endpoint.parsl.id }
+```
+
+The security group needs **inbound TCP 22 from the endpoint** — that is the only
+port the tunnel ever opens, and the ZMQ ports ride inside the SSH session:
+
+| Direction | Protocol | Port | Source | Purpose |
+|-----------|----------|------|--------|---------|
+| Ingress | TCP | 22 | the endpoint's SG, or the VPC CIDR | EICE reaches sshd |
+
+With a tunnel in use the **egress rule for 54000–55000 is not needed at all**:
+the interchange arrives on the worker's own loopback, so nothing leaves the VPC
+for it. The subnet does not need a public IP or a NAT gateway either, which is
+the configuration this was verified against.
+
 ---
 
 ## Minimum IAM Permissions
@@ -56,6 +113,26 @@ creates a launch template, so it needed `ssm:GetParameter`,
 `ec2:CreateLaunchTemplate`, `ec2:DescribeInstanceTypes`, `ec2:DescribeVpcs`, and
 `sts:GetCallerIdentity` — none of which it granted
 ([#195](https://github.com/scttfrdmn/parsl-ephemeral-provider/issues/195)).
+
+If you use a reverse tunnel, the driver needs three more actions, which
+`minimum_iam_policy()` does not include because the feature is opt-in. Generate
+them the same way rather than copying:
+
+```python
+import json
+
+from parsl_ephemeral_provider.network import eice_iam_statements
+
+print(json.dumps(eice_iam_statements(endpoint_id="eice-0abc1234"), indent=2))
+```
+
+The grant is `ec2-instance-connect:OpenTunnel` **conditioned on
+`remotePort == 22`**, `SendSSHPublicKey` conditioned on
+`ec2:osuser == ec2-user`, and describe. Both conditions are load-bearing and
+IAM's own evaluator is asked to confirm them in
+`tests/aws/test_eice_tunnel_e2e.py`: unconditioned, `OpenTunnel` reaches any port
+on any instance the holder can name, and `SendSSHPublicKey` authorises a key for
+any OS user including root.
 
 The **workers** are separate and need much less: attaching the AWS-managed
 `AmazonSSMManagedInstanceCore` to the instance profile is the whole requirement,

--- a/docs/operating_modes.md
+++ b/docs/operating_modes.md
@@ -65,8 +65,9 @@ architecture is resolved from AWS's public SSM parameters, so x86_64 and arm64
 
 Workers connect *outbound* to the Parsl interchange, so the client has to accept
 inbound TCP on the HTEX port range (54000–55000 by default). A laptop behind
-home or office NAT cannot do this without port forwarding or a VPN — use detached
-mode instead.
+home or office NAT cannot do this without port forwarding or a VPN — set
+`instance_connect_endpoint_id` (see [Reverse tunnels](#reverse-tunnels)) or use
+detached mode instead.
 
 Set `encrypted=False` on `HighThroughputExecutor` when the interchange and its
 workers share a VPC — Parsl's CurveZMQ certificates live in the client's
@@ -114,6 +115,10 @@ These are implemented by `StandardMode` alone, and the provider raises
 | `baked_ami_id` | `None` | Use an already-baked AMI instead of baking one. |
 | `one_shot` | `False` | Dispatch a single command per instance over SSM; no HTEX. |
 | `distribute_certificates` | `False` | Ship HTEX's CurveZMQ certificates to workers via Parameter Store, so `encrypted=True` works with no shared network boundary. |
+| `instance_connect_endpoint_id` | `None` | Tunnel the interchange onto each worker's loopback, so the driver needs no routable address. Setting it enables tunnelling. |
+| `tunnel_os_user` | `ec2-user` | Remote user the tunnel authenticates as. |
+| `tunnel_private_key_path` | `None` | SSH private key for the tunnel; an ephemeral pair is generated per provider when unset. |
+| `tunnel_public_key_path` | `None` | Matching public key, authorised on each instance. Must be set together with the private key. |
 
 `warm_pool_size > 0` and `one_shot=True` both dispatch over SSM, so each requires
 either `auto_create_instance_profile=True` or an explicit
@@ -127,6 +132,64 @@ Warm instances are held **Running** and bill at the full instance rate for up to
 `warm_pool_ttl` seconds per idle period, which is why `warm_pool_size` is capped.
 Migrating to native ASG warm pools, which hold instances Stopped or Hibernated,
 is [#130](https://github.com/scttfrdmn/parsl-ephemeral-provider/issues/130).
+
+### Reverse tunnels
+
+This is the answer to *"my driver is a laptop behind NAT."* Set
+`instance_connect_endpoint_id` and the provider opens an SSH reverse tunnel to
+every worker through an [EC2 Instance Connect
+Endpoint](network-prerequisites.md#optional-an-ec2-instance-connect-endpoint),
+putting the interchange on the worker's **own loopback**:
+
+```python
+provider = EphemeralProvider(
+    region="us-east-1",
+    instance_type="t3.small",
+    vpc_id="vpc-0abc1234",
+    subnet_id="subnet-0def5678",
+    security_group_id="sg-09ab0000",
+    auto_create_instance_profile=True,
+    instance_connect_endpoint_id="eice-0abc1234",
+)
+```
+
+Then give HTEX loopback, not a routable address — the point is that no driver
+address is involved:
+
+```python
+HighThroughputExecutor(provider=provider, address="127.0.0.1")
+```
+
+If you leave `address_by_query()` in place, HTEX offers the worker both that
+address and loopback, and may win the probe with the unroutable one; the provider
+logs a warning when it sees a non-loopback `-a`.
+
+Because the worker talks to loopback, this also composes better with
+`encrypted=True` than a public IP does — see
+[Encryption in transit](security.md#encryption-in-transit).
+
+**What it costs.** This is the only feature that shells out: it needs an `ssh`
+binary and AWS CLI v2 on the driver (`open-tunnel` has no boto3 equivalent).
+Both are checked up front. It adds three IAM actions, listed in
+[Minimum IAM Permissions](network-prerequisites.md#minimum-iam-permissions).
+
+**Why it is supervised.** A single EICE tunnel is capped at 3600 seconds by the
+API, so a background thread recycles each tunnel before AWS closes it and
+re-establishes any that die. Reconnects complete well inside HTEX's 120-second
+`heartbeat_threshold`, so the interchange does not give up on the manager. The
+SSH key is re-pushed before every connect, because `SendSSHPublicKey` authorises
+it for only about a minute.
+
+**Ordering.** The tunnel is opened *before* the command is dispatched, closed
+when a dispatch fails or resources are cleaned up, and the supervisor plus any
+generated key material is torn down first at `cleanup_infrastructure()`. A worker
+connects as soon as it starts, so a tunnel opened afterwards would race the
+connection it exists to carry. `one_shot=True` and `warm_pool_size > 0` dispatch
+over SSM and get that ordering strictly; on the default UserData path the command
+is already on the instance, so the tunnel and the worker start together.
+
+Nothing here is durable: if the driver dies the tunnels die with it, which is
+correct — the interchange they forward to died too.
 
 ## Detached Mode
 
@@ -397,7 +460,7 @@ standard or detached mode now raises rather than being ignored.
 | Consideration | Standard | Detached | Serverless |
 |---------------|----------|----------|------------|
 | **Client connectivity** | Must stay reachable | Can disconnect | Can disconnect |
-| **Client behind NAT** | No | Yes | Yes |
+| **Client behind NAT** | With `instance_connect_endpoint_id` | Yes | Yes |
 | **Workflow duration** | Minutes to hours | Hours to days | Seconds to hours |
 | **Task duration** | Any | Any | Lambda: <15 min<br>Fargate: any |
 | **Scaling** | Moderate | Moderate | Rapid, massive |
@@ -415,8 +478,10 @@ standard or detached mode now raises rather than being ignored.
   get the two-minute EventBridge warning
 - Set `min_blocks`/`max_blocks` deliberately — `max_blocks` also caps concurrent
   submissions, and a job past that limit raises rather than queueing
-- Run the client on an EC2 instance in the same VPC; a NAT'd laptop will not work
-- Leave `use_public_ips=True` unless you have a VPN or Direct Connect path
+- Run the client on an EC2 instance in the same VPC, or set
+  `instance_connect_endpoint_id` and `address="127.0.0.1"` if it is a NAT'd laptop
+- Leave `use_public_ips=True` unless you have a VPN or Direct Connect path — or a
+  reverse tunnel, which needs neither a public IP nor a NAT gateway
 
 ### Detached mode
 - Use `state_store_type="parameter_store"` so the bastion and client share state
@@ -453,7 +518,10 @@ configuration carries over.
 - Bootstrap output is in `/var/log/cloud-init-output.log` on the instance
 - Worker stdout/stderr is in Parsl's `runinfo/` directory on the client
 - If workers launch but never register, the client is almost certainly not
-  accepting inbound connections on the interchange ports
+  accepting inbound connections on the interchange ports — see
+  [Workers never register](troubleshooting.md#workers-launch-but-never-register)
+- With a reverse tunnel, `ps` for the `ssh` children: one per instance, each
+  holding `-R 127.0.0.1:<port>`. None means the tunnel never opened
 
 ### Detached mode
 - SSM to the bastion and read the orchestrator's journal

--- a/docs/security.md
+++ b/docs/security.md
@@ -84,6 +84,31 @@ and `iam:PassedToService: ec2.amazonaws.com` on `iam:PassRole`.
 }
 ```
 
+**Reverse tunnels (`instance_connect_endpoint_id`)** — generate rather than copy,
+because the conditions are the point:
+
+```python
+import json
+
+from parsl_ephemeral_provider.network import eice_iam_statements
+
+print(json.dumps(eice_iam_statements(endpoint_id="eice-0abc1234"), indent=2))
+```
+
+Two conditions carry the whole least-privilege claim, and IAM's own evaluator is
+asked to confirm both in `tests/aws/test_eice_tunnel_e2e.py`:
+
+- `ec2-instance-connect:OpenTunnel` is scoped to **`remotePort == 22`**. This
+  design only ever tunnels to sshd and carries the ZMQ ports *inside* that SSH
+  session, so those ports never appear in the policy. Unconditioned, the grant
+  reaches any port on any instance the holder can name.
+- `SendSSHPublicKey` is scoped to **`ec2:osuser == ec2-user`**. Unconditioned, it
+  authorises a key for any OS user on the instance, including root.
+
+Passing `endpoint_id` scopes `OpenTunnel` to one endpoint as well. These are
+permissions for the **driver's** principal; the worker needs nothing extra, since
+the tunnel terminates at its own sshd.
+
 **Serverless mode (Lambda)**:
 
 ```json
@@ -282,6 +307,27 @@ Instances then need a NAT gateway, or VPC endpoints for `ssm`, `ssmmessages`,
 `ec2messages`, and `s3`, to reach AWS APIs and register with SSM. The provider
 does not create either.
 
+### Reverse tunnels instead of an inbound rule
+
+`instance_connect_endpoint_id` removes the client-facing inbound rule entirely.
+The interchange arrives on each worker's own loopback, so the security group needs
+no ingress for 54000–55000 from your client — and the worker needs no route to
+your client at all. Verified against a subnet with no public IP and no NAT
+gateway.
+
+What it adds is narrower: **inbound TCP 22 from the endpoint's security group**.
+That is worth weighing honestly. It is a real SSH listener reachable from the
+endpoint, where before there was none, and the exposure is bounded by three
+things: the endpoint is inside your VPC and reachable only through
+`ec2-instance-connect:OpenTunnel` (an IAM-authorised, CloudTrail-logged call); the
+authorised key is ephemeral, generated per provider, valid for about 60 seconds
+per push, and removed at shutdown; and the driver's grant is conditioned to port
+22 and one OS user (see
+[Additional permissions by mode](#additional-permissions-by-mode)).
+
+If you already run the client on an EC2 instance in the same VPC, the tunnel buys
+nothing — keep the plain outbound arrangement above.
+
 ## Data security
 
 ### Encryption in transit
@@ -302,6 +348,13 @@ the two certificate files a worker actually opens to a Parameter Store
 `SecureString`, and the worker fetches them at boot with `ssm:GetParameter`. Use
 this when the interchange and workers share no network boundary: cross-VPC,
 cross-account, or over the internet.
+
+A third arrangement is worth knowing about: with
+`instance_connect_endpoint_id` the worker connects to its **own loopback**, so the
+ZMQ traffic never crosses a network at all — it rides inside an SSH session. That
+is a stronger transport story than `encrypted=False` over a VPC, and the two
+compose: set both and the CurveZMQ handshake happens over the tunnel. See
+[Reverse tunnels](operating_modes.md#reverse-tunnels).
 
 ```python
 provider = EphemeralProvider(

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -110,11 +110,20 @@ can inject the session, state store, and resolved AMI.
 
 ### `warm_pool_size ... is supported only by mode='standard'`
 
-`warm_pool_size`, `warm_pool_ttl`, `bake_ami`, `baked_ami_id`, `one_shot`, and
-`distribute_certificates` are implemented by `StandardMode` alone. Setting the
-warm-pool ones on another mode used to leak instances no mode would reclaim
-(#80); `distribute_certificates` would leak nothing but would silently deliver
-workers that die on a missing certificate directory. Both are now rejected.
+`warm_pool_size`, `warm_pool_ttl`, `bake_ami`, `baked_ami_id`, `one_shot`,
+`distribute_certificates`, and the four `instance_connect_endpoint_id` /
+`tunnel_*` options are implemented by `StandardMode` alone. Setting the warm-pool
+ones on another mode used to leak instances no mode would reclaim (#80);
+`distribute_certificates` would leak nothing but would silently deliver workers
+that die on a missing certificate directory. An endpoint ID on detached mode would
+read as a cheaper alternative to the bastion while doing nothing at all. All are
+now rejected.
+
+### `tunnel_private_key_path and tunnel_public_key_path must be set together`
+
+The public key is authorised on the instance and the private key authenticates
+the tunnel, so one without the other cannot connect. Leave both unset to have an
+ephemeral pair generated per provider and removed at shutdown.
 
 ### `warm_pool_size > 0 requires ...`
 
@@ -143,9 +152,14 @@ ever connecting.
    that allows inbound 54000–55000 from the worker security group. Note the
    default VPC security group allows inbound only from itself, so if workers use a
    different group you need an explicit rule.
-2. **Use detached mode** — a bastion owns the worker lifecycle, and the client
+2. **Set `instance_connect_endpoint_id`** and `address="127.0.0.1"`. A reverse
+   tunnel through an EC2 Instance Connect Endpoint puts the interchange on each
+   worker's own loopback, so no client address needs to be routable and no
+   inbound rule is needed. See
+   [Reverse tunnels](operating_modes.md#reverse-tunnels).
+3. **Use detached mode** — a bastion owns the worker lifecycle, and the client
    need not be reachable at all.
-3. **Use one-shot mode** for independent commands; it bypasses HTEX entirely and
+4. **Use one-shot mode** for independent commands; it bypasses HTEX entirely and
    works from anywhere.
 
 **Also check the certificates.** With encryption on, Parsl generates CurveZMQ
@@ -182,6 +196,81 @@ endpoint.
 interface; only the private IP is. Use `address_by_route()` for a same-VPC
 deployment. `address_by_query()` returns the NAT/router WAN address, which nothing
 in the VPC can connect back to.
+
+## Reverse tunnels
+
+### `No usable ssh executable` / `No usable aws executable`
+
+This is the only feature that shells out. `open-tunnel` has no boto3 equivalent —
+the `ec2-instance-connect` API exposes only `SendSSHPublicKey` and
+`SendSerialConsoleSSHPublicKey` — so it needs an `ssh` binary and AWS CLI v2 on
+the **driver**. Install them, or pass explicit paths as `ssh_binary` / `aws_cli`.
+The check runs up front so a missing binary is a configuration error rather than
+a worker that mysteriously never registers.
+
+### `ResourceNotFoundError: instance_connect_endpoint_id eice-... is not usable`
+
+Raised in `initialize()`, alongside the VPC/subnet/SG checks, for the same
+reason: the endpoint is caller-supplied and never created, so a typo would
+otherwise surface at the first submit as an `ssh` process exiting for no visible
+reason, minutes in, after an instance had been billed. Check the ID and the
+region. An endpoint in `create-in-progress` accepts tunnel calls and fails them,
+so wait for `create-complete`.
+
+### `Could not open an EICE reverse tunnel to i-... within 300s`
+
+"Running" is not "sshd is accepting connections" — the `instance_running` waiter
+clears well before the OS finishes booting, so the first few attempts are
+*expected* to fail and are retried. Reaching the deadline means something else:
+
+- the security group has no **inbound TCP 22 from the endpoint**. That rule is the
+  one prerequisite the tunnel adds; see
+  [network prerequisites](network-prerequisites.md#optional-an-ec2-instance-connect-endpoint).
+- the endpoint is in a different subnet from the instance.
+- `tunnel_os_user` does not exist on the AMI. It defaults to `ec2-user`, which is
+  right for Amazon Linux; Ubuntu images want `ubuntu`.
+- the driver's principal lacks `ec2-instance-connect:OpenTunnel` or
+  `SendSSHPublicKey`. The error text carries the underlying `ssh` stderr.
+
+### The tunnel opens, but the worker still never registers
+
+Check the address HTEX gave the worker. With a tunnel the interchange is on the
+worker's **own** loopback, so `address="127.0.0.1"` is correct; leave
+`address_by_query()` in place and HTEX offers both addresses, may win the probe
+with the unroutable one, and the tunnel goes unused. The provider logs a warning
+when the command names a non-loopback `-a`.
+
+### `Permission denied (publickey)` on a reconnect
+
+`send-ssh-public-key` authorises a key for roughly 60 seconds, which is why the
+provider re-pushes it before *every* connect. Seeing this means a connect used a
+stale authorisation — worth reporting, since the supervisor is supposed to make
+it impossible.
+
+### Warnings about reconnecting during cleanup
+
+Expected only if the tunnel outlives the instance. Cleanup closes tunnels before
+terminating anything precisely so the supervisor is not fighting the teardown; a
+run of reconnect warnings during ordinary shutdown means that ordering broke.
+
+### An `ssh` process outlives the run
+
+There should be exactly one `ssh` child per supervised instance and none after
+`shutdown()`. A stray one — reparented to PID 1, holding a forward to an instance
+that no longer exists — means a tunnel was started by something that no longer
+held a reference to it. Two ways that could happen were fixed in #134 (concurrent
+starts overwriting each other's process handle, and a supervision pass reviving a
+tunnel removed after its snapshot), so a survivor now is worth reporting. Find
+them with `ps` for `open-tunnel`; they are safe to `kill`.
+
+### A single tunnel does not survive an hour
+
+By design. The API caps one tunnel at 3600 seconds, so the supervisor recycles
+each one before AWS closes it — a tunnel torn down at the ceiling drops whatever
+was in flight. Reconnects complete well inside HTEX's 120-second
+`heartbeat_threshold`. Nothing is durable across a driver restart: if the driver
+dies the tunnels die with it, which is correct, because the interchange they
+forward to died too.
 
 ## Instance launch failures
 

--- a/parsl_ephemeral_provider/constants.py
+++ b/parsl_ephemeral_provider/constants.py
@@ -437,6 +437,22 @@ DEFAULT_ONE_SHOT = False  # each instance runs one command then terminates
 # boundary, but not something to do on a caller's behalf unasked.
 DEFAULT_DISTRIBUTE_CERTIFICATES = False
 
+# EICE reverse tunnels (#134). No default endpoint, and none is ever created:
+# creating one takes several minutes, so it belongs to the pre-provisioned
+# network the caller supplies (#69). Setting the ID is what turns tunnelling on.
+DEFAULT_INSTANCE_CONNECT_ENDPOINT_ID = None
+DEFAULT_TUNNEL_OS_USER = "ec2-user"  # matches the Amazon Linux AMIs above
+DEFAULT_TUNNEL_PRIVATE_KEY_PATH = None  # generated per-provider when unset
+DEFAULT_TUNNEL_PUBLIC_KEY_PATH = None
+
+# How long to keep retrying the first connect to a new instance. "running" is not
+# "sshd is up": the instance_running waiter clears well before the OS finishes
+# booting, so the first few attempts are expected to fail. Bounded well inside
+# HTEX's 120s heartbeat_threshold per attempt, but allowed several minutes in
+# total because a cold boot legitimately takes that long.
+TUNNEL_OPEN_TIMEOUT = 300
+TUNNEL_OPEN_RETRY_DELAY = 10
+
 # Detached-mode bastion defaults.
 #
 # Named here rather than left as literals in DetachedMode.__init__ so the

--- a/parsl_ephemeral_provider/modes/base.py
+++ b/parsl_ephemeral_provider/modes/base.py
@@ -494,6 +494,21 @@ class OperatingMode(abc.ABC):
             "GroupIds",
             ("InvalidGroup.NotFound", "InvalidGroupId.Malformed"),
         ),
+        # The EICE endpoint (#134) is verified here for the same reason as the
+        # other three: it is caller-supplied and never created, and the failure
+        # otherwise arrives at the first submit, inside a ProxyCommand, as an ssh
+        # process exiting for no visible reason. Both codes confirmed live.
+        # Optional -- absent on every mode but standard, and None there unless
+        # tunnelling was asked for, so the loop's falsy skip covers it.
+        (
+            "instance_connect_endpoint_id",
+            "describe_instance_connect_endpoints",
+            "InstanceConnectEndpointIds",
+            (
+                "InvalidInstanceConnectEndpointId.NotFound",
+                "InvalidInstanceConnectEndpointId.Malformed",
+            ),
+        ),
     )
 
     def _verify_resources(self) -> None:

--- a/parsl_ephemeral_provider/modes/standard.py
+++ b/parsl_ephemeral_provider/modes/standard.py
@@ -9,9 +9,15 @@ SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
 """
 
 import logging
+import os
+import shutil
+
+# Only ssh-keygen, at an absolute path with a fixed argv; see _ensure_tunnel_keys.
+import subprocess  # nosec B404
+import tempfile
 import time
 import uuid
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import boto3
 from botocore.exceptions import ClientError
@@ -19,6 +25,7 @@ from botocore.exceptions import ClientError
 from parsl_ephemeral_provider.constants import (
     DEFAULT_RESOURCE_CREATION_TIMEOUT,
     DEFAULT_SPOT_ALLOCATION_STRATEGY,
+    DEFAULT_TUNNEL_OS_USER,
     EC2_STATUS_MAPPING,
     IMDSV2_METADATA_OPTIONS,
     LAUNCH_TEMPLATE_NAME_PREFIX,
@@ -32,6 +39,8 @@ from parsl_ephemeral_provider.constants import (
     STATUS_RUNNING,
     STATUS_UNKNOWN,
     STATUS_WARM,
+    TUNNEL_OPEN_RETRY_DELAY,
+    TUNNEL_OPEN_TIMEOUT,
 )
 from parsl_ephemeral_provider.error_handling import RetryConfig, poll_until
 from parsl_ephemeral_provider.exceptions import (
@@ -40,6 +49,11 @@ from parsl_ephemeral_provider.exceptions import (
     SpotFleetError,
 )
 from parsl_ephemeral_provider.modes.base import OperatingMode
+from parsl_ephemeral_provider.network.eice import (
+    EICETunnelSupervisor,
+    extract_addresses,
+    extract_worker_ports,
+)
 from parsl_ephemeral_provider.security.curvezmq import (
     CurveZMQCertificateDistributor,
     extract_cert_dir,
@@ -136,6 +150,10 @@ class StandardMode(OperatingMode):
         baked_ami_id: Optional[str] = None,
         one_shot: bool = False,
         distribute_certificates: bool = False,
+        instance_connect_endpoint_id: Optional[str] = None,
+        tunnel_os_user: str = DEFAULT_TUNNEL_OS_USER,
+        tunnel_private_key_path: Optional[str] = None,
+        tunnel_public_key_path: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
         """Initialize the standard mode.
@@ -217,6 +235,25 @@ class StandardMode(OperatingMode):
             always. See :mod:`parsl_ephemeral_provider.security.curvezmq` for
             the security trade-off: the interchange's server secret key is part
             of what a worker needs, so it is published, and deleted at cleanup.
+        instance_connect_endpoint_id : Optional[str], optional
+            EC2 Instance Connect Endpoint to tunnel through, by default None
+            (no tunnelling). Setting it is what enables the reverse tunnel that
+            lets workers reach an interchange on a driver with no inbound
+            reachability -- a laptop behind NAT, which previously required
+            detached mode and a bastion. The endpoint must already exist:
+            creating one takes several minutes, so it belongs to the
+            pre-provisioned network the caller supplies (#69). See
+            :mod:`parsl_ephemeral_provider.network.eice`.
+        tunnel_os_user : str, optional
+            Remote user the tunnel authenticates as, by default ``ec2-user``
+            (correct for the Amazon Linux AMIs in ``constants.py``).
+        tunnel_private_key_path : Optional[str], optional
+            SSH private key for the tunnel, by default None -- an ephemeral
+            ed25519 pair is generated per provider and discarded at cleanup.
+        tunnel_public_key_path : Optional[str], optional
+            Matching public key, authorised on each instance for the ~60 seconds
+            ``SendSSHPublicKey`` grants, by default None. Supply both paths or
+            neither.
         """
         # Call parent __init__ with standard params
         super().__init__(
@@ -276,6 +313,34 @@ class StandardMode(OperatingMode):
         self._cert_distributor = CurveZMQCertificateDistributor(
             session=session, provider_id=provider_id
         )
+
+        # EICE reverse tunnels (#134). The endpoint is caller-supplied: creating
+        # one takes several minutes, so it belongs in the pre-provisioned network
+        # story (#69) rather than in initialize().
+        #
+        # The supervisor is built lazily, at the first submit that has a port to
+        # forward, for two reasons: the ports come out of the command rather than
+        # from configuration, and constructing it resolves `ssh`/`aws` on PATH,
+        # which should not be a hard requirement for a provider that is merely
+        # loaded from a state file.
+        self.instance_connect_endpoint_id = instance_connect_endpoint_id
+        self.tunnel_os_user = tunnel_os_user
+        self.tunnel_private_key_path = tunnel_private_key_path
+        self.tunnel_public_key_path = tunnel_public_key_path
+        self._tunnel_supervisor: Optional[EICETunnelSupervisor] = None
+        self._tunnel_key_dir: Optional[str] = None
+
+        # Half a key pair is caught here rather than at the first submit. The
+        # alternative -- generating the missing half -- would silently ignore the
+        # path the caller did give, and the failure would otherwise arrive minutes
+        # into a run, after an instance had been paid for.
+        if bool(tunnel_private_key_path) != bool(tunnel_public_key_path):
+            raise ValueError(
+                "tunnel_private_key_path and tunnel_public_key_path must be set "
+                "together: the public key is authorised on the instance and the "
+                "private key authenticates the tunnel, so one without the other "
+                "cannot connect. Leave both unset to have a pair generated."
+            )
 
         # Launch template (#85). Built in initialize() so every launch path --
         # on-demand, spot, and fleet -- shares one definition carrying IMDSv2,
@@ -1069,6 +1134,12 @@ class StandardMode(OperatingMode):
                     logger.info(
                         f"Reusing warm instance {warm_instance_id} for job {job_id}"
                     )
+                    # Before dispatch, not after: the worker connects to the
+                    # interchange as soon as it starts, so a tunnel opened
+                    # afterwards would race the connection it exists to carry.
+                    # A warm instance may already have one from its previous job,
+                    # in which case add() returns the live tunnel unchanged.
+                    self._open_reverse_tunnel(warm_instance_id, command)
                     ssm_command_id = self._dispatch_ssm_command(
                         warm_instance_id, command, job_id
                     )
@@ -1134,6 +1205,10 @@ class StandardMode(OperatingMode):
                 try:
                     self._wait_for_ssm_online(instance_id)
                     self._wait_for_worker_ready(instance_id)
+                    # The SSM paths are the ones the tunnel fits cleanly: the
+                    # command has not been delivered yet, so the tunnel is
+                    # provably up before anything tries to use it.
+                    self._open_reverse_tunnel(instance_id, command)
                     ssm_command_id = self._dispatch_ssm_command(
                         instance_id, command, job_id
                     )
@@ -1148,12 +1223,23 @@ class StandardMode(OperatingMode):
                         f"SSM dispatch failed for instance {instance_id}: {ssm_err}. "
                         "Terminating it; the command was never delivered."
                     )
+                    # The tunnel may already be open — this branch also catches a
+                    # tunnel that failed to open — and the instance it points at
+                    # is about to be terminated, so close it or the supervisor
+                    # spends the rest of the run reconnecting to nothing.
+                    self._close_reverse_tunnel(instance_id)
                     self._force_terminate(instance_id)
                     self.resources.pop(instance_id, None)
                     self.save_state()
                     raise
             else:
                 self.resources[instance_id] = resource_data
+                # UserData path: the command is already on the instance, so unlike
+                # the SSM paths this cannot be ordered before delivery. It is not
+                # a race in practice — worker_init runs first, and the worker's
+                # ZMQ DEALER reconnects on its own — but it is the reason the SSM
+                # paths are the better pairing for tunnelling.
+                self._open_reverse_tunnel(instance_id, command)
 
             # Save state
             self.save_state()
@@ -1258,6 +1344,173 @@ class StandardMode(OperatingMode):
 
         self._cert_distributor.publish(job_id, cert_dir)
         return self._cert_distributor.fetch_script(job_id, cert_dir)
+
+    # ------------------------------------------------------------------
+    # EICE reverse tunnels (#134)
+    # ------------------------------------------------------------------
+
+    def _ensure_tunnel_keys(self) -> Tuple[str, str]:
+        """Return (private, public) key paths, generating an ephemeral pair if needed.
+
+        A generated key lives in a 0700 temporary directory for the life of the
+        provider and is never persisted. That is deliberate: the key authorises
+        SSH as ``tunnel_os_user``, and ``send-ssh-public-key`` re-authorises it
+        for only about a minute at a time, so there is nothing to gain by keeping
+        it and something to lose by writing it where another process can read it.
+        """
+        if self.tunnel_private_key_path and self.tunnel_public_key_path:
+            return self.tunnel_private_key_path, self.tunnel_public_key_path
+
+        if self._tunnel_key_dir is None:
+            self._tunnel_key_dir = tempfile.mkdtemp(prefix="parsl-eice-")
+            os.chmod(self._tunnel_key_dir, 0o700)
+            private = os.path.join(self._tunnel_key_dir, "tunnel_key")
+            keygen = shutil.which("ssh-keygen")
+            if keygen is None:
+                raise OperatingModeError(
+                    "instance_connect_endpoint_id is set but ssh-keygen is not on "
+                    "PATH, so no tunnel keypair can be generated. Install OpenSSH "
+                    "or supply tunnel_private_key_path and tunnel_public_key_path."
+                )
+            # ed25519 rather than RSA: smaller, and generated in milliseconds,
+            # which matters because this runs on the submit path.
+            # Absolute path from shutil.which, fixed argv, no shell.
+            subprocess.run(  # noqa: S603 # nosec B603 B607
+                [
+                    keygen,
+                    "-t",
+                    "ed25519",
+                    "-N",
+                    "",
+                    "-q",
+                    "-f",
+                    private,
+                    "-C",
+                    f"parsl-ephemeral-{self.provider_id}",
+                ],
+                check=True,
+                stdin=subprocess.DEVNULL,
+            )
+            self.tunnel_private_key_path = private
+            self.tunnel_public_key_path = f"{private}.pub"
+            logger.debug(
+                f"Generated an ephemeral tunnel keypair in {self._tunnel_key_dir}"
+            )
+
+        if not self.tunnel_private_key_path or not self.tunnel_public_key_path:
+            # Unreachable via either branch above, but raising beats returning a
+            # None that would surface as an ssh argv built from the string "None".
+            raise OperatingModeError(
+                "No tunnel keypair is available after key resolution; set "
+                "tunnel_private_key_path and tunnel_public_key_path explicitly."
+            )
+        return self.tunnel_private_key_path, self.tunnel_public_key_path
+
+    def _open_reverse_tunnel(self, instance_id: str, command: str) -> None:
+        """Open a reverse tunnel so *instance_id* can reach the interchange.
+
+        Called after the instance is running. The ports come from the command,
+        because the provider is never told where the interchange bound -- HTEX
+        interpolates ``--port=`` into the launch command and that is the only
+        record the provider sees.
+
+        Does nothing when tunnelling is off, or when the command names no port
+        (a caller-supplied command that is not an HTEX worker pool has nothing to
+        forward).
+        """
+        endpoint_id = self.instance_connect_endpoint_id
+        if not endpoint_id:
+            return
+
+        ports = extract_worker_ports(command)
+        if not ports:
+            logger.debug(
+                f"instance_connect_endpoint_id is set but job command for "
+                f"{instance_id} names no --port, so there is nothing to forward. "
+                "This is expected for a command that is not an HTEX worker pool."
+            )
+            return
+
+        addresses = extract_addresses(command)
+        if addresses and addresses not in ("127.0.0.1", "localhost"):
+            # Worth a warning rather than a rewrite: the command is the caller's,
+            # and HTEX probes every address it was given. If a routable one is in
+            # the list it may win the probe and the tunnel goes unused -- which
+            # looks like the tunnel not working.
+            logger.warning(
+                f"The worker command names addresses {addresses!r}, but a reverse "
+                "tunnel puts the interchange on the worker's own loopback. Set "
+                "the executor's address='127.0.0.1' so the probe uses the "
+                "tunnel; otherwise HTEX may prefer an address that is not "
+                "reachable from the worker."
+            )
+
+        if self._tunnel_supervisor is None:
+            private_key, public_key = self._ensure_tunnel_keys()
+            self._tunnel_supervisor = EICETunnelSupervisor(
+                session=self.session,
+                endpoint_id=endpoint_id,
+                ports=ports,
+                private_key_path=private_key,
+                public_key_path=public_key,
+                os_user=self.tunnel_os_user,
+                region=self.session.region_name,
+            )
+        elif set(ports) - set(self._tunnel_supervisor.ports):
+            # Each executor gets its own interchange port, so a second executor
+            # sharing this provider needs its ports added. Existing tunnels do
+            # not pick them up until they are recycled, which is why this warns.
+            logger.warning(
+                f"Job on {instance_id} needs ports {ports}, but the supervisor "
+                f"was built for {self._tunnel_supervisor.ports}. Existing tunnels "
+                "forward only their original ports."
+            )
+
+        # Retried, because "running" is not "sshd is accepting connections" --
+        # the waiter clears well before the OS finishes booting. Each attempt
+        # re-pushes the key, which is required anyway: the authorisation from the
+        # previous attempt has a ~60s life.
+        deadline = time.time() + TUNNEL_OPEN_TIMEOUT
+        attempt = 0
+        while True:
+            attempt += 1
+            try:
+                self._tunnel_supervisor.add(instance_id)
+                break
+            except Exception as exc:
+                if time.time() >= deadline:
+                    raise OperatingModeError(
+                        f"Could not open an EICE reverse tunnel to {instance_id} "
+                        f"within {TUNNEL_OPEN_TIMEOUT}s ({attempt} attempts): "
+                        f"{exc}. Without the tunnel the worker cannot reach the "
+                        "interchange, so the job would never run."
+                    ) from exc
+                logger.debug(
+                    f"Tunnel attempt {attempt} for {instance_id} failed ({exc}); "
+                    f"retrying in {TUNNEL_OPEN_RETRY_DELAY}s"
+                )
+                time.sleep(TUNNEL_OPEN_RETRY_DELAY)
+
+        logger.info(
+            f"Opened an EICE reverse tunnel to {instance_id}, forwarding "
+            f"{ports} from driver loopback"
+        )
+
+    def _close_reverse_tunnel(self, instance_id: str) -> None:
+        """Close the tunnel to *instance_id*, if one is open."""
+        if self._tunnel_supervisor is not None:
+            self._tunnel_supervisor.remove(instance_id)
+
+    def _shutdown_tunnels(self) -> None:
+        """Close every tunnel and remove any generated key material."""
+        if self._tunnel_supervisor is not None:
+            self._tunnel_supervisor.shutdown()
+            self._tunnel_supervisor = None
+        if self._tunnel_key_dir is not None:
+            shutil.rmtree(self._tunnel_key_dir, ignore_errors=True)
+            self._tunnel_key_dir = None
+            self.tunnel_private_key_path = None
+            self.tunnel_public_key_path = None
 
     # ------------------------------------------------------------------
     # SSM dispatch helpers (shared by the warm pool and one-shot mode)
@@ -2171,6 +2424,12 @@ class StandardMode(OperatingMode):
         if not resource_ids:
             return
 
+        # Close tunnels first. Ordered before termination so the supervisor is not
+        # reconnecting to an instance that is shutting down: that would surface as
+        # a run of alarming reconnect warnings during ordinary cleanup.
+        for resource_id in resource_ids:
+            self._close_reverse_tunnel(resource_id)
+
         ec2 = self.session.client("ec2")
 
         # Group IDs by resource type
@@ -2230,6 +2489,12 @@ class StandardMode(OperatingMode):
         This cleans up the VPC, subnet, and security group if they were created by the provider.
         """
         logger.info("Cleaning up infrastructure")
+
+        # Stop the tunnel supervisor before anything is terminated (#134). Its
+        # thread reconnects tunnels it finds dead, so leaving it running through
+        # termination would have it fighting the cleanup, and its thread and
+        # generated key material have to go regardless of what follows fails.
+        self._shutdown_tunnels()
 
         # Collect EC2 instance IDs before cleanup so we can wait for termination.
         # cleanup_all() sends terminate requests but does not wait; instances remain

--- a/parsl_ephemeral_provider/network/__init__.py
+++ b/parsl_ephemeral_provider/network/__init__.py
@@ -1,0 +1,29 @@
+"""Network connectivity helpers.
+
+SPDX-License-Identifier: Apache-2.0
+SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+"""
+
+from parsl_ephemeral_provider.network.eice import (
+    DEFAULT_INSTANCE_OS_USER,
+    EICE_TUNNEL_MAX_DURATION,
+    EICETunnel,
+    EICETunnelSupervisor,
+    eice_iam_statements,
+    extract_addresses,
+    extract_worker_ports,
+    resolve_aws_cli,
+    resolve_ssh_binary,
+)
+
+__all__ = [
+    "DEFAULT_INSTANCE_OS_USER",
+    "EICE_TUNNEL_MAX_DURATION",
+    "EICETunnel",
+    "EICETunnelSupervisor",
+    "eice_iam_statements",
+    "extract_addresses",
+    "extract_worker_ports",
+    "resolve_aws_cli",
+    "resolve_ssh_binary",
+]

--- a/parsl_ephemeral_provider/network/eice.py
+++ b/parsl_ephemeral_provider/network/eice.py
@@ -1,0 +1,834 @@
+"""Reverse tunnels to HTEX workers over EC2 Instance Connect Endpoints (#134).
+
+Why a *reverse* tunnel
+----------------------
+HTEX's workers connect **outbound** to the interchange: ``DEFAULT_LAUNCH_CMD``
+hands the worker ``-a {addresses} --port={worker_port}``, and the interchange
+binds that port on the driver (``interchange.py``, ``bind_to_random_port`` over
+``worker_port_range``, default ``54000-55000``). The driver must therefore accept
+*inbound* TCP from EC2. From a laptop behind home or office NAT that cannot work,
+and the project's answer until now was "use detached mode" -- pay for a bastion to
+work around a network topology problem.
+
+#134 proposed ``aws ec2-instance-connect open-tunnel --remote-port`` to carry the
+interchange ports. That does not work, and the reason is worth stating because it
+shapes everything here: ``--remote-port`` is "the remote port to connect to *on
+the instance*" and ``--local-port`` is "the local port to listen on". It is a
+**forward** tunnel, driver to worker. Pointing it at 54000-55000 forwards
+driver-side connections to ports on the worker where nothing is listening.
+
+What works, and was verified live against a ``t3.micro`` in a subnet with no
+public IP and no NAT, is to use EICE for the one thing it does -- reach port 22 --
+and let SSH carry the reverse forward::
+
+    ssh -o ProxyCommand="aws ec2-instance-connect open-tunnel --instance-id <id>" \\
+        -R <port>:127.0.0.1:<port> ec2-user@<id>
+
+A ``zmq.DEALER`` on the worker then completes a full round trip to a
+``zmq.ROUTER`` bound to driver loopback -- exactly HTEX's socket pair, on exactly
+its port range. ZMTP does a bidirectional greeting, so this is a stronger check
+than raw TCP: a forward that only half-works fails it.
+
+The consequence for configuration is pleasant: because the reverse forward makes
+the interchange appear on the worker's *own* loopback, the worker's ``-a`` should
+be ``127.0.0.1`` and **no driver address needs to be routable at all**. It also
+composes with #62 -- a worker talking to loopback is a better story for
+``encrypted=True`` than one talking to a public IP.
+
+The constraints, all confirmed against the live API
+--------------------------------------------------
+* **A tunnel is capped at 3600 seconds.** Anything above it is rejected with
+  ``ParamValidation: Value must be greater than 1 and less than 3600``. That
+  message is off by one -- 3600 itself is accepted and 3601 is not -- so the cap
+  is inclusive. Either way a tunnel cannot outlive an hour, which is why this is
+  a *supervised*, reconnecting design rather than a fire-and-forget one.
+* **The reconnect budget is HTEX's ``heartbeat_threshold``, default 120s**
+  (``heartbeat_period`` 30s). Reconnect must complete well inside that or the
+  interchange declares the manager lost and reschedules its tasks.
+* **``send-ssh-public-key`` grants roughly a 60-second window.** A key pushed at
+  submit time is useless on a reconnect twenty minutes later, which fails with
+  ``Permission denied (publickey)``. So the key is re-pushed immediately before
+  *every* connect attempt, not once per instance.
+* **Endpoint creation takes several minutes** (~4.5 in testing). The endpoint is
+  therefore caller-supplied, per the pre-provisioned-network model of #69, and is
+  never created here.
+
+Dependencies
+------------
+This is the only part of the package that shells out: it needs an ``ssh`` binary
+and the AWS CLI v2 (for the ``open-tunnel`` ProxyCommand, which has no boto3
+equivalent -- ``ec2-instance-connect`` exposes only ``SendSSHPublicKey`` and
+``SendSerialConsoleSSHPublicKey`` in the API). Both are checked up front, because
+a missing binary should be a clear configuration error rather than a worker that
+mysteriously never registers.
+
+SPDX-License-Identifier: Apache-2.0
+SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+"""
+
+import logging
+import os
+import re
+import shutil
+
+# The ssh and aws argv are built in this module, never from caller strings;
+# see ssh_command() and proxy_command().
+import subprocess  # nosec B404
+import threading
+import time
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+from botocore.exceptions import ClientError
+
+from parsl_ephemeral_provider.exceptions import (
+    ProviderConfigurationError,
+    ResourceCreationError,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    import boto3
+
+logger = logging.getLogger(__name__)
+
+#: The hard ceiling the API enforces on a single tunnel, in seconds. Verified
+#: live: 3600 is accepted and 3601 is rejected by ParamValidation before the call
+#: is made, despite the error saying "less than 3600".
+EICE_TUNNEL_MAX_DURATION = 3600
+
+#: How long before the cap to voluntarily recycle a tunnel. A tunnel torn down by
+#: AWS at the ceiling drops mid-message; one recycled early is replaced while the
+#: old one still works, so the gap is a reconnect rather than a failure.
+DEFAULT_RECYCLE_MARGIN = 300
+
+#: Default OS user for Amazon Linux, matching the AMIs in ``constants.py``.
+DEFAULT_INSTANCE_OS_USER = "ec2-user"
+
+#: Seconds to wait for SSH to establish before giving up on an attempt. Generous
+#: because it covers the websocket handshake through the endpoint as well.
+DEFAULT_CONNECT_TIMEOUT = 60
+
+#: ``send-ssh-public-key`` authorises the key for about a minute, so pushing it
+#: earlier than this before connecting is pointless.
+KEY_VALIDITY_S = 60
+
+#: How long to watch a freshly started ``ssh`` before calling it established.
+#: With ``ExitOnForwardFailure=yes`` a bind failure is an immediate exit, so this
+#: only has to outlast process startup plus the websocket handshake.
+DEFAULT_SETTLE_TIMEOUT = 5
+
+#: Grace given to ``ssh`` after SIGTERM before escalating to SIGKILL.
+DEFAULT_TERMINATE_TIMEOUT = 10
+
+
+#: HTEX writes ``--port={worker_port}`` into the launch command (see
+#: ``DEFAULT_LAUNCH_CMD``). Both ``=`` and whitespace are accepted for the same
+#: reason ``extract_cert_dir`` accepts both: the format string is upstream's and
+#: a caller may supply their own ``launch_cmd``.
+_WORKER_PORT_RE = re.compile(r"--port[=\s]+(?P<port>\d+)")
+
+#: The interchange also hands workers ``-a <addresses>``. Matched so the mode can
+#: warn when the command names an address the tunnel makes irrelevant.
+_ADDRESSES_RE = re.compile(r"(?:^|\s)-a[=\s]+(?P<addresses>[^\s]+)")
+
+
+def extract_worker_ports(command: str) -> List[int]:
+    """Return the interchange ports named by *command*, for reverse forwarding.
+
+    The provider is never told where the interchange is listening; it reads the
+    port out of the command HTEX interpolated, exactly as
+    :func:`~parsl_ephemeral_provider.security.curvezmq.extract_cert_dir` reads
+    ``--cert_dir``. There is normally exactly one: the interchange binds a single
+    ``ROUTER`` for workers via ``bind_to_random_port`` over ``worker_port_range``.
+
+    Parameters
+    ----------
+    command : str
+        The command the executor asked the provider to run.
+
+    Returns
+    -------
+    List[int]
+        Ports to forward, in the order found, deduplicated. Empty when the
+        command names none -- which means the caller passed a command that is not
+        an HTEX worker pool, and there is nothing to tunnel.
+    """
+    ports: List[int] = []
+    for match in _WORKER_PORT_RE.finditer(command):
+        port = int(match.group("port"))
+        if port not in ports:
+            ports.append(port)
+    return ports
+
+
+def extract_addresses(command: str) -> Optional[str]:
+    """Return the ``-a`` addresses in *command*, if any.
+
+    Used only to tell the caller when their configuration is self-defeating: with
+    a reverse tunnel the interchange arrives on the worker's own loopback, so an
+    ``address`` naming a public IP means HTEX will try that first and the tunnel
+    buys nothing.
+    """
+    match = _ADDRESSES_RE.search(command)
+    return match.group("addresses") if match else None
+
+
+def resolve_ssh_binary(ssh_binary: Optional[str] = None) -> str:
+    """Locate the ``ssh`` executable, or explain what is missing.
+
+    Parameters
+    ----------
+    ssh_binary : Optional[str], optional
+        Explicit path, by default None (search ``PATH``).
+
+    Returns
+    -------
+    str
+        Absolute path to an ``ssh`` executable.
+
+    Raises
+    ------
+    ProviderConfigurationError
+        If no usable ``ssh`` is found.
+    """
+    candidate = ssh_binary or shutil.which("ssh")
+    if candidate and os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+        return candidate
+    raise ProviderConfigurationError(
+        f"No usable ssh executable ({ssh_binary or 'ssh not on PATH'}). The EICE "
+        "reverse tunnel shells out to ssh, because EC2 Instance Connect only "
+        "forwards *into* an instance and the reverse forward has to come from "
+        "somewhere. Install OpenSSH or pass ssh_binary."
+    )
+
+
+def resolve_aws_cli(aws_cli: Optional[str] = None) -> str:
+    """Locate the AWS CLI, which supplies the tunnel ProxyCommand.
+
+    ``open-tunnel`` is a CLI-only feature: the ``ec2-instance-connect`` API model
+    exposes only ``SendSSHPublicKey`` and ``SendSerialConsoleSSHPublicKey``, so
+    there is no boto3 call to use instead.
+
+    Parameters
+    ----------
+    aws_cli : Optional[str], optional
+        Explicit path, by default None (search ``PATH``).
+
+    Returns
+    -------
+    str
+        Absolute path to the ``aws`` executable.
+
+    Raises
+    ------
+    ProviderConfigurationError
+        If no usable ``aws`` is found.
+    """
+    candidate = aws_cli or shutil.which("aws")
+    if candidate and os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+        return candidate
+    raise ProviderConfigurationError(
+        f"No usable aws executable ({aws_cli or 'aws not on PATH'}). The tunnel "
+        "uses `aws ec2-instance-connect open-tunnel` as an SSH ProxyCommand; it "
+        "has no boto3 equivalent. Install AWS CLI v2 or pass aws_cli."
+    )
+
+
+class EICETunnel:
+    """One reverse tunnel to one instance, held open by a child ``ssh`` process.
+
+    A tunnel is a *process*, not a request. Nothing here is durable: if the
+    driver dies the tunnel dies with it, which is correct -- the interchange it
+    forwards to died too.
+
+    Parameters
+    ----------
+    session : boto3.Session
+        Session used to push the SSH key.
+    instance_id : str
+        Instance to tunnel to.
+    endpoint_id : str
+        Caller-supplied EC2 Instance Connect Endpoint ID.
+    ports : List[int]
+        Driver-side ports to expose on the worker's loopback. Each becomes an
+        ``ssh -R port:127.0.0.1:port``.
+    public_key_path : str
+        Public key to authorise via ``send-ssh-public-key``.
+    private_key_path : str
+        Matching private key for ``ssh -i``.
+    os_user : str, optional
+        Remote user, by default ``ec2-user``.
+    region : Optional[str], optional
+        Region for the CLI call, by default the session's.
+    profile_name : Optional[str], optional
+        Profile for the CLI call, by default None. The ProxyCommand runs in a
+        separate process and does not inherit a boto3 session, so a profile the
+        session was built from has to be passed through explicitly.
+    ssh_binary : Optional[str], optional
+        Path to ``ssh``, by default resolved from ``PATH``.
+    aws_cli : Optional[str], optional
+        Path to ``aws``, by default resolved from ``PATH``.
+    connect_timeout : int, optional
+        Seconds to allow for the connection, by default 60.
+    max_duration : int, optional
+        Tunnel lifetime requested of AWS, by default 3600 (the ceiling).
+    settle_timeout : int, optional
+        Seconds to watch a new ``ssh`` before calling it established, by default
+        5. Exposed so tests need not spend it; there is no reason to change it
+        in production.
+    terminate_timeout : int, optional
+        Seconds after SIGTERM before escalating to SIGKILL, by default 10.
+    """
+
+    def __init__(
+        self,
+        session: "boto3.Session",
+        instance_id: str,
+        endpoint_id: str,
+        ports: List[int],
+        public_key_path: str,
+        private_key_path: str,
+        os_user: str = DEFAULT_INSTANCE_OS_USER,
+        region: Optional[str] = None,
+        profile_name: Optional[str] = None,
+        ssh_binary: Optional[str] = None,
+        aws_cli: Optional[str] = None,
+        connect_timeout: int = DEFAULT_CONNECT_TIMEOUT,
+        max_duration: int = EICE_TUNNEL_MAX_DURATION,
+        settle_timeout: int = DEFAULT_SETTLE_TIMEOUT,
+        terminate_timeout: int = DEFAULT_TERMINATE_TIMEOUT,
+    ) -> None:
+        if not ports:
+            raise ProviderConfigurationError(
+                "An EICE reverse tunnel needs at least one port to forward. "
+                "Pass the interchange's worker port."
+            )
+        if max_duration >= EICE_TUNNEL_MAX_DURATION:
+            # Clamp rather than raise: asking for "as long as possible" is
+            # reasonable. Landing a second under the ceiling rather than on it
+            # because the API's own error message claims the boundary is
+            # exclusive when it is not -- one of the two is wrong, and this way
+            # it does not matter which.
+            max_duration = EICE_TUNNEL_MAX_DURATION - 1
+
+        self.session = session
+        self.instance_id = instance_id
+        self.endpoint_id = endpoint_id
+        self.ports = list(ports)
+        self.public_key_path = public_key_path
+        self.private_key_path = private_key_path
+        self.os_user = os_user
+        self.region = region or session.region_name
+        self.profile_name = profile_name
+        self.ssh_binary = resolve_ssh_binary(ssh_binary)
+        self.aws_cli = resolve_aws_cli(aws_cli)
+        self.connect_timeout = connect_timeout
+        self.max_duration = max_duration
+        self.settle_timeout = settle_timeout
+        self.terminate_timeout = terminate_timeout
+
+        self._process: Optional[subprocess.Popen] = None
+        self._started_at: Optional[float] = None
+        # start() and stop() are reached from two threads: the submit path calls
+        # them through the supervisor's add()/remove(), and the supervision thread
+        # calls them from _supervise_once(). Without this, two concurrent start()s
+        # both pass the is_alive() check, both spawn ssh, and the second
+        # assignment to _process orphans the first process for good -- an ssh that
+        # nothing holds a handle to and no shutdown can reap.
+        self._lifecycle_lock = threading.Lock()
+        # Set once the tunnel is deliberately retired, so a supervision pass that
+        # picked it up before the removal cannot start it again. Without it,
+        # closing a tunnel because the instance is being terminated is undone by
+        # whichever pass was already in flight.
+        self._retired = False
+
+    # ------------------------------------------------------------------
+    # Command construction
+    # ------------------------------------------------------------------
+
+    def proxy_command(self) -> str:
+        """Return the ``ProxyCommand`` string that opens the websocket tunnel.
+
+        ``%h`` is not used: the instance is named by ID rather than by hostname,
+        because that is what ``open-tunnel`` takes and it avoids depending on DNS
+        inside a private subnet.
+        """
+        parts = [
+            self.aws_cli,
+            "ec2-instance-connect",
+            "open-tunnel",
+            "--instance-id",
+            self.instance_id,
+            "--instance-connect-endpoint-id",
+            self.endpoint_id,
+            "--region",
+            str(self.region),
+            "--max-tunnel-duration",
+            str(self.max_duration),
+        ]
+        if self.profile_name:
+            parts += ["--profile", self.profile_name]
+        return " ".join(parts)
+
+    def ssh_command(self) -> List[str]:
+        """Return the full ``ssh`` argv for the reverse tunnel.
+
+        ``-N`` (no remote command) and ``-T`` (no TTY) because this process
+        exists only to hold forwards open. ``ExitOnForwardFailure=yes`` is the
+        load-bearing option: without it ssh reports success while the forward
+        silently did not bind, and the failure would surface much later as a
+        worker that never registers.
+        """
+        argv = [
+            self.ssh_binary,
+            "-N",
+            "-T",
+            "-o",
+            f"ProxyCommand={self.proxy_command()}",
+            "-o",
+            "StrictHostKeyChecking=no",
+            # A fresh instance's host key is genuinely unknown, and every
+            # instance is ephemeral, so a known_hosts file would only accumulate
+            # entries and eventually produce spurious mismatches.
+            "-o",
+            "UserKnownHostsFile=/dev/null",
+            "-o",
+            "ExitOnForwardFailure=yes",
+            "-o",
+            "BatchMode=yes",
+            "-o",
+            f"ConnectTimeout={self.connect_timeout}",
+            # Notice a dead tunnel in ~60s rather than waiting on TCP timeouts,
+            # so the supervisor can reconnect inside the 120s heartbeat budget.
+            "-o",
+            "ServerAliveInterval=20",
+            "-o",
+            "ServerAliveCountMax=3",
+            "-i",
+            self.private_key_path,
+        ]
+        for port in self.ports:
+            # Bind the worker end to loopback explicitly: the default would make
+            # the forwarded port reachable from elsewhere in the VPC if the
+            # instance had GatewayPorts on, and only the worker needs it.
+            argv += ["-R", f"127.0.0.1:{port}:127.0.0.1:{port}"]
+        argv.append(f"{self.os_user}@{self.instance_id}")
+        return argv
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def push_key(self) -> None:
+        """Authorise the public key on the instance for the next ~60 seconds.
+
+        Raises
+        ------
+        ResourceCreationError
+            If the key could not be pushed.
+        """
+        with open(self.public_key_path, "r") as handle:
+            public_key = handle.read().strip()
+
+        client = self.session.client("ec2-instance-connect")
+        try:
+            client.send_ssh_public_key(
+                InstanceId=self.instance_id,
+                InstanceOSUser=self.os_user,
+                SSHPublicKey=public_key,
+            )
+        except ClientError as exc:
+            raise ResourceCreationError(
+                f"Could not authorise an SSH key on {self.instance_id}: {exc}. "
+                "The tunnel needs ec2-instance-connect:SendSSHPublicKey."
+            ) from exc
+        logger.debug(
+            f"Authorised SSH key on {self.instance_id} for user {self.os_user} "
+            f"(valid ~{KEY_VALIDITY_S}s)"
+        )
+
+    def start(self) -> None:
+        """Push the key and start the ``ssh`` process holding the forwards.
+
+        The key push is deliberately immediately before the connect: it is only
+        valid for about a minute, so any gap here is a gap that fails.
+
+        Serialized against ``stop()`` and against another ``start()``: the submit
+        path and the supervision thread both reach this, and a lost race leaks an
+        ssh process nothing can reap.
+
+        Raises
+        ------
+        ResourceCreationError
+            If ssh exits immediately, which means the forward never bound.
+        """
+        with self._lifecycle_lock:
+            self._start_locked()
+
+    def _start_locked(self) -> None:
+        """``start()`` proper, with ``_lifecycle_lock`` already held."""
+        if self.is_alive():
+            return
+        if self._retired:
+            # Retired means the instance is going away, so a start here would be
+            # a tunnel to nothing -- and it would be invisible, because the
+            # supervisor has already dropped its reference.
+            logger.debug(
+                f"Not starting a retired tunnel to {self.instance_id}; the "
+                "instance is no longer supervised."
+            )
+            return
+
+        self.push_key()
+        argv = self.ssh_command()
+        logger.debug(f"Opening EICE reverse tunnel: {' '.join(argv)}")
+        # stdin closed: BatchMode already forbids prompting, and an inherited
+        # stdin would let ssh consume the parent's input.
+        self._process = subprocess.Popen(  # noqa: S603 # nosec B603
+            argv,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        self._started_at = time.time()
+
+        # ExitOnForwardFailure makes a bind failure an immediate exit, so a short
+        # wait distinguishes "established" from "failed" without polling ZMQ.
+        try:
+            self._process.wait(timeout=self.settle_timeout)
+        except subprocess.TimeoutExpired:
+            logger.info(
+                f"EICE reverse tunnel to {self.instance_id} established, "
+                f"forwarding {self.ports} to driver loopback"
+            )
+            return
+
+        stderr = b""
+        if self._process.stderr is not None:
+            stderr = self._process.stderr.read() or b""
+        rc = self._process.returncode
+        self._process = None
+        raise ResourceCreationError(
+            f"The EICE reverse tunnel to {self.instance_id} exited immediately "
+            f"(rc={rc}): {stderr.decode(errors='replace').strip()}. With "
+            "ExitOnForwardFailure=yes this means the forward never bound, so no "
+            "worker would have reached the interchange."
+        )
+
+    def is_alive(self) -> bool:
+        """Whether the tunnel process is still running."""
+        return self._process is not None and self._process.poll() is None
+
+    def age(self) -> float:
+        """Seconds since the tunnel started, or 0 if it never did."""
+        return 0.0 if self._started_at is None else time.time() - self._started_at
+
+    def needs_recycle(self, margin: int = DEFAULT_RECYCLE_MARGIN) -> bool:
+        """Whether the tunnel is close enough to the 3600s cap to replace.
+
+        Replacing early is the whole reason this is supervised: a tunnel AWS
+        tears down at the ceiling drops whatever was in flight.
+        """
+        return self.age() >= max(0, self.max_duration - margin)
+
+    def stop(self) -> None:
+        """Terminate the tunnel process, escalating to kill if needed."""
+        with self._lifecycle_lock:
+            self._stop_locked()
+
+    def _stop_locked(self) -> None:
+        """``stop()`` proper, with ``_lifecycle_lock`` already held."""
+        if self._process is None:
+            return
+        if self._process.poll() is None:
+            self._process.terminate()
+            try:
+                self._process.wait(timeout=self.terminate_timeout)
+            except subprocess.TimeoutExpired:
+                logger.warning(
+                    f"ssh for {self.instance_id} ignored SIGTERM; killing it"
+                )
+                self._process.kill()
+                try:
+                    self._process.wait(timeout=5)
+                except subprocess.TimeoutExpired:  # pragma: no cover - defensive
+                    logger.error(f"Could not reap ssh for {self.instance_id}")
+        # Popen holds two pipes; closing them keeps a long-running driver from
+        # leaking file descriptors one tunnel at a time.
+        for stream in (self._process.stdout, self._process.stderr):
+            if stream is not None:
+                try:
+                    stream.close()
+                except Exception:  # nosec B110 # pragma: no cover - defensive
+                    pass
+        logger.debug(f"Closed EICE reverse tunnel to {self.instance_id}")
+        self._process = None
+        self._started_at = None
+
+    def restart(self) -> None:
+        """Replace the tunnel process, holding the lock across both halves.
+
+        The supervisor's stop-then-start has to be atomic: with two separate
+        acquisitions a concurrent ``remove()`` can land in the gap, and the start
+        then revives a tunnel to an instance that is already being terminated.
+        """
+        with self._lifecycle_lock:
+            self._stop_locked()
+            self._start_locked()
+
+    def retire(self) -> None:
+        """Close the tunnel for good, so no later ``start()`` can revive it.
+
+        This is what ``remove()`` and ``shutdown()`` want rather than ``stop()``.
+        ``_supervise_once()`` iterates a snapshot, so a pass already in flight
+        holds a reference to a tunnel the caller has just dropped; a plain
+        ``stop()`` is undone by that pass, leaving an ssh process pointed at an
+        instance the provider is terminating and no longer tracked by anything.
+        """
+        with self._lifecycle_lock:
+            self._retired = True
+            self._stop_locked()
+
+
+class EICETunnelSupervisor:
+    """Keeps one tunnel per instance alive for as long as the job needs it.
+
+    The supervisor exists because of the 3600-second cap. A single background
+    thread re-establishes tunnels that died and pre-emptively recycles ones
+    approaching the ceiling, which is what turns a one-hour ceiling into a
+    reconnect concern rather than a workflow-length limit.
+
+    Parameters
+    ----------
+    session : boto3.Session
+        Session for key pushes.
+    endpoint_id : str
+        Caller-supplied endpoint ID, shared by every tunnel.
+    ports : List[int]
+        Driver-side ports to forward.
+    public_key_path, private_key_path : str
+        Key pair to authorise and use.
+    poll_interval : int, optional
+        Seconds between health checks, by default 20. Must stay well under
+        HTEX's 120s ``heartbeat_threshold`` so a dead tunnel is noticed and
+        replaced before the interchange gives up on the manager.
+    **tunnel_kwargs
+        Passed to each :class:`EICETunnel`.
+    """
+
+    def __init__(
+        self,
+        session: "boto3.Session",
+        endpoint_id: str,
+        ports: List[int],
+        public_key_path: str,
+        private_key_path: str,
+        poll_interval: int = 20,
+        **tunnel_kwargs: Any,
+    ) -> None:
+        self.session = session
+        self.endpoint_id = endpoint_id
+        self.ports = list(ports)
+        self.public_key_path = public_key_path
+        self.private_key_path = private_key_path
+        self.poll_interval = poll_interval
+        self.tunnel_kwargs = tunnel_kwargs
+
+        self._tunnels: Dict[str, EICETunnel] = {}
+        self._lock = threading.Lock()
+        self._stop_event = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+
+    @property
+    def instance_ids(self) -> List[str]:
+        """Instances currently supervised."""
+        with self._lock:
+            return list(self._tunnels)
+
+    def add(self, instance_id: str) -> EICETunnel:
+        """Open a tunnel to *instance_id* and supervise it.
+
+        Returns
+        -------
+        EICETunnel
+            The tunnel, already started.
+        """
+        with self._lock:
+            existing = self._tunnels.get(instance_id)
+            if existing is not None and existing.is_alive():
+                return existing
+            tunnel = EICETunnel(
+                session=self.session,
+                instance_id=instance_id,
+                endpoint_id=self.endpoint_id,
+                ports=self.ports,
+                public_key_path=self.public_key_path,
+                private_key_path=self.private_key_path,
+                **self.tunnel_kwargs,
+            )
+
+        # Started outside the lock: it blocks for up to five seconds, and the
+        # supervisor thread must not be stalled behind an unrelated connect.
+        # Registered only once it is up, so the supervision thread -- already
+        # running if this is not the first instance -- cannot find a tunnel that
+        # has never been started, read that as "died", and reconnect it
+        # underneath this call. EICETunnel serialises its own lifecycle, so that
+        # race no longer orphans an ssh process, but it would still mean two
+        # key pushes and a connect nobody asked for.
+        tunnel.start()
+        with self._lock:
+            self._tunnels[instance_id] = tunnel
+        self.start()
+        return tunnel
+
+    def remove(self, instance_id: str) -> None:
+        """Stop supervising *instance_id* and close its tunnel."""
+        with self._lock:
+            tunnel = self._tunnels.pop(instance_id, None)
+        if tunnel is not None:
+            # retire(), not stop(): a supervision pass that snapshotted this
+            # tunnel before the pop would otherwise reconnect it.
+            tunnel.retire()
+
+    def start(self) -> None:
+        """Start the supervision thread if it is not already running."""
+        if self._thread is not None and self._thread.is_alive():
+            return
+        self._stop_event.clear()
+        self._thread = threading.Thread(
+            target=self._supervise,
+            name="parsl-eice-tunnel-supervisor",
+            daemon=True,
+        )
+        self._thread.start()
+        logger.debug("Started EICE tunnel supervisor")
+
+    def _supervise_once(self) -> None:
+        """Run one health-check pass over every supervised tunnel.
+
+        Split out of the loop so it can be driven directly: a test that had to
+        wait ``poll_interval`` to observe a reconnect would either be slow or be
+        tuned so short that it raced the ssh process it was checking.
+        """
+        with self._lock:
+            items = list(self._tunnels.items())
+
+        for instance_id, tunnel in items:
+            if self._stop_event.is_set():
+                return
+            try:
+                if tunnel.needs_recycle():
+                    logger.info(
+                        f"Recycling the tunnel to {instance_id} after "
+                        f"{int(tunnel.age())}s, before AWS closes it at "
+                        f"{EICE_TUNNEL_MAX_DURATION}s"
+                    )
+                    tunnel.restart()
+                elif not tunnel.is_alive():
+                    logger.warning(
+                        f"The tunnel to {instance_id} died after "
+                        f"{int(tunnel.age())}s; reconnecting. The worker "
+                        "cannot reach the interchange until it is back."
+                    )
+                    tunnel.restart()
+            except Exception as exc:
+                # A reconnect failure must not kill the supervisor: the other
+                # tunnels are still worth keeping, and this one may recover on
+                # the next pass (the instance may simply be terminating).
+                logger.warning(
+                    f"Could not re-establish the tunnel to {instance_id}: "
+                    f"{exc}. Retrying in {self.poll_interval}s."
+                )
+
+    def _supervise(self) -> None:
+        """Re-establish dead tunnels and recycle ones nearing the cap."""
+        while not self._stop_event.is_set():
+            self._supervise_once()
+            self._stop_event.wait(self.poll_interval)
+
+    def shutdown(self) -> None:
+        """Stop supervising and close every tunnel."""
+        self._stop_event.set()
+        if self._thread is not None and self._thread.is_alive():
+            self._thread.join(timeout=self.poll_interval + 10)
+        self._thread = None
+        with self._lock:
+            tunnels = list(self._tunnels.values())
+            self._tunnels.clear()
+        for tunnel in tunnels:
+            try:
+                tunnel.retire()
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning(f"Error closing a tunnel during shutdown: {exc}")
+        logger.debug("EICE tunnel supervisor shut down")
+
+
+def eice_iam_statements(
+    port_range: Optional[tuple] = None,
+    endpoint_id: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Return least-privilege IAM statements for the driver side of the tunnel.
+
+    These are for the *driver's* principal, not the worker's -- the worker needs
+    nothing, since the tunnel terminates at its sshd.
+
+    ``ec2-instance-connect:OpenTunnel`` is conditionable on
+    ``ec2-instance-connect:remotePort``, so the grant can be scoped to port 22
+    alone: this design only ever tunnels to sshd, and the reverse forward rides
+    inside that SSH session. A grant open to any remote port would let the holder
+    reach any service on any instance they can name.
+
+    Parameters
+    ----------
+    port_range : Optional[tuple], optional
+        Unused, and accepted only to make the shape of the mistake obvious: the
+        forwarded ZMQ ports never appear in this policy, because they are never
+        an EICE ``remotePort``. Kept as an explicit parameter so a caller who
+        expects to pass them finds this note rather than silently wrong policy.
+    endpoint_id : Optional[str], optional
+        Restrict to one endpoint, by default None (any).
+
+    Returns
+    -------
+    List[Dict[str, Any]]
+        Statements for an IAM policy document.
+    """
+    if port_range is not None:
+        logger.debug(
+            "eice_iam_statements ignores port_range: the ZMQ ports are forwarded "
+            "inside the SSH session, so only port 22 is an EICE remotePort."
+        )
+
+    tunnel_resource = (
+        f"arn:aws:ec2:*:*:instance-connect-endpoint/{endpoint_id}"
+        if endpoint_id
+        else "*"
+    )
+    return [
+        {
+            "Sid": "ParslEphemeralOpenTunnelToSshOnly",
+            "Effect": "Allow",
+            "Action": ["ec2-instance-connect:OpenTunnel"],
+            "Resource": [tunnel_resource],
+            "Condition": {"NumericEquals": {"ec2-instance-connect:remotePort": "22"}},
+        },
+        {
+            "Sid": "ParslEphemeralAuthoriseEphemeralSshKey",
+            "Effect": "Allow",
+            "Action": ["ec2-instance-connect:SendSSHPublicKey"],
+            "Resource": ["arn:aws:ec2:*:*:instance/*"],
+            "Condition": {
+                "StringEquals": {
+                    "ec2:osuser": DEFAULT_INSTANCE_OS_USER,
+                }
+            },
+        },
+        {
+            "Sid": "ParslEphemeralDescribeForTunnelling",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeInstances",
+                "ec2:DescribeInstanceConnectEndpoints",
+            ],
+            "Resource": ["*"],
+        },
+    ]

--- a/parsl_ephemeral_provider/provider.py
+++ b/parsl_ephemeral_provider/provider.py
@@ -31,6 +31,7 @@ from parsl_ephemeral_provider.constants import (
     DEFAULT_ECS_CONTAINER_IMAGE,
     DEFAULT_ECS_CPU,
     DEFAULT_ECS_MEMORY,
+    DEFAULT_INSTANCE_CONNECT_ENDPOINT_ID,
     DEFAULT_INSTANCE_TYPE,
     DEFAULT_LAMBDA_MEMORY,
     DEFAULT_LAMBDA_RUNTIME,
@@ -43,6 +44,9 @@ from parsl_ephemeral_provider.constants import (
     DEFAULT_PRESERVE_BASTION,
     DEFAULT_REGION,
     DEFAULT_SPOT_ALLOCATION_STRATEGY,
+    DEFAULT_TUNNEL_OS_USER,
+    DEFAULT_TUNNEL_PRIVATE_KEY_PATH,
+    DEFAULT_TUNNEL_PUBLIC_KEY_PATH,
     DEFAULT_WARM_POOL_SIZE,
     DEFAULT_WARM_POOL_TTL,
     DEFAULT_WORKER_INIT,
@@ -367,12 +371,51 @@ class EphemeralProvider(ExecutionProvider, RepresentationMixin):
         ``server.key_secret``.  Anyone able to read the parameter can therefore
         impersonate the interchange to a worker.  The parameter is encrypted at
         rest, scoped to this provider's ID, and deleted on ``shutdown()``.
+    instance_connect_endpoint_id : str, optional
+        EC2 Instance Connect Endpoint ID to tunnel through.  Default is None,
+        which disables tunnelling; setting it turns it on.  ``mode="standard"``
+        only.
+
+        This is the answer to "my driver is a laptop behind NAT".  HTEX workers
+        connect *outbound* to the interchange, so the driver must accept inbound
+        TCP on 54000–55000 — which a home or office NAT does not permit, and the
+        project's only previous answer was detached mode: pay for a bastion to
+        work around a network topology problem.  With an endpoint set, the
+        provider holds an ``ssh -R`` reverse forward open to each worker through
+        the endpoint, so the interchange appears on the worker's own loopback and
+        **no driver address needs to be routable** (#134).
+
+        Set the executor's ``address="127.0.0.1"`` to match; a routable address
+        left in the list may win HTEX's probe and leave the tunnel unused.
+
+        The endpoint must already exist — creating one takes several minutes, so
+        it is part of the pre-provisioned network the caller supplies (#69).
+        This is also the one feature that shells out: it needs an ``ssh`` binary
+        and AWS CLI v2 on the driver, because ``open-tunnel`` has no boto3
+        equivalent.  The driver's principal needs
+        ``ec2-instance-connect:OpenTunnel`` and ``SendSSHPublicKey``; see
+        :func:`~parsl_ephemeral_provider.network.eice.eice_iam_statements` for a
+        least-privilege policy scoped to port 22.
+    tunnel_os_user : str, optional
+        Remote user the tunnel authenticates as.  Default is ``"ec2-user"``,
+        correct for the Amazon Linux AMIs this provider selects.
+        ``mode="standard"`` only.
+    tunnel_private_key_path : str, optional
+        SSH private key for the tunnel.  Default is None, which generates an
+        ephemeral ed25519 pair per provider and discards it at cleanup.
+        ``mode="standard"`` only.
+    tunnel_public_key_path : str, optional
+        Matching public key, authorised on each instance for the ~60 seconds
+        ``SendSSHPublicKey`` grants.  Default is None.  Supply both key paths or
+        neither.  ``mode="standard"`` only.
 
     Raises
     ------
     ProviderConfigurationError
         If ``warm_pool_size``, ``warm_pool_ttl``, ``bake_ami``,
-        ``baked_ami_id``, ``one_shot``, or ``distribute_certificates`` is set on
+        ``baked_ami_id``, ``one_shot``, ``distribute_certificates``,
+        ``instance_connect_endpoint_id``, ``tunnel_os_user``,
+        ``tunnel_private_key_path``, or ``tunnel_public_key_path`` is set on
         any mode other than ``"standard"`` — no other mode implements them.
 
         If ``idle_timeout``, ``preserve_bastion``, ``bastion_host_type``,
@@ -446,6 +489,12 @@ class EphemeralProvider(ExecutionProvider, RepresentationMixin):
         baked_ami_id: Optional[str] = None,
         one_shot: bool = DEFAULT_ONE_SHOT,
         distribute_certificates: bool = DEFAULT_DISTRIBUTE_CERTIFICATES,
+        instance_connect_endpoint_id: Optional[
+            str
+        ] = DEFAULT_INSTANCE_CONNECT_ENDPOINT_ID,
+        tunnel_os_user: str = DEFAULT_TUNNEL_OS_USER,
+        tunnel_private_key_path: Optional[str] = DEFAULT_TUNNEL_PRIVATE_KEY_PATH,
+        tunnel_public_key_path: Optional[str] = DEFAULT_TUNNEL_PUBLIC_KEY_PATH,
         cores_per_node: Optional[int] = None,
         mem_per_node: Optional[float] = None,
         **kwargs: Any,
@@ -572,6 +621,10 @@ class EphemeralProvider(ExecutionProvider, RepresentationMixin):
         self.baked_ami_id = baked_ami_id
         self.one_shot = one_shot
         self.distribute_certificates = distribute_certificates
+        self.instance_connect_endpoint_id = instance_connect_endpoint_id
+        self.tunnel_os_user = tunnel_os_user
+        self.tunnel_private_key_path = tunnel_private_key_path
+        self.tunnel_public_key_path = tunnel_public_key_path
 
         # Guard: network IDs are required (provider no longer creates VPC/subnet/SG).
         # Lambda-only serverless is the one exception: functions run in the
@@ -601,6 +654,12 @@ class EphemeralProvider(ExecutionProvider, RepresentationMixin):
         # encryption and deliver workers that die on a missing certificate
         # directory -- an option that looks configured and is not, which is the
         # class of failure #136 and #155 exist to eliminate.
+        #
+        # The four tunnel options (#134) are the same case again: only
+        # StandardMode opens, supervises, and closes tunnels. Detached mode has
+        # its own answer to the same problem -- a bastion -- so accepting an
+        # endpoint ID there would look like a cheaper alternative that silently
+        # did nothing.
         standard_only = [
             name
             for name, value, default in (
@@ -613,6 +672,22 @@ class EphemeralProvider(ExecutionProvider, RepresentationMixin):
                     "distribute_certificates",
                     distribute_certificates,
                     DEFAULT_DISTRIBUTE_CERTIFICATES,
+                ),
+                (
+                    "instance_connect_endpoint_id",
+                    instance_connect_endpoint_id,
+                    DEFAULT_INSTANCE_CONNECT_ENDPOINT_ID,
+                ),
+                ("tunnel_os_user", tunnel_os_user, DEFAULT_TUNNEL_OS_USER),
+                (
+                    "tunnel_private_key_path",
+                    tunnel_private_key_path,
+                    DEFAULT_TUNNEL_PRIVATE_KEY_PATH,
+                ),
+                (
+                    "tunnel_public_key_path",
+                    tunnel_public_key_path,
+                    DEFAULT_TUNNEL_PUBLIC_KEY_PATH,
                 ),
             )
             if value != default
@@ -1189,6 +1264,10 @@ class EphemeralProvider(ExecutionProvider, RepresentationMixin):
                 baked_ami_id=self.baked_ami_id,
                 one_shot=self.one_shot,
                 distribute_certificates=self.distribute_certificates,
+                instance_connect_endpoint_id=self.instance_connect_endpoint_id,
+                tunnel_os_user=self.tunnel_os_user,
+                tunnel_private_key_path=self.tunnel_private_key_path,
+                tunnel_public_key_path=self.tunnel_public_key_path,
                 **common_params,
             )
         elif self.mode_type == OperatingModeType.DETACHED:

--- a/tests/aws/test_eice_tunnel_e2e.py
+++ b/tests/aws/test_eice_tunnel_e2e.py
@@ -1,0 +1,821 @@
+"""Real-AWS end-to-end tests for EICE reverse tunnels (issue #134).
+
+The unit suite covers command construction, the supervisor's reconnect and
+recycle logic, and the mode wiring, with a stub standing in for ``ssh``. What it
+cannot cover is the only claim that matters:
+
+    a worker on an instance with no public IP, in a subnet with no NAT, can reach
+    a socket bound to the driver's **loopback**
+
+-- because that is a statement about EC2 Instance Connect, sshd, and a websocket
+tunnel, and a stub ``ssh`` agrees with any claim you make about the network. So
+the central test binds a real ``zmq.ROUTER`` on driver loopback, exactly as
+HTEX's interchange does, and has the *worker* drive a ``zmq.DEALER`` through the
+tunnel and back. ZMTP greets in both directions, so a forward that only
+half-works fails it -- unlike a raw TCP connect.
+
+The four constraints that shaped the design are each asserted here rather than
+taken on trust, because each was discovered live and each would fail silently:
+
+* ``--max-tunnel-duration`` is rejected at 3600, so the module clamps to 3599.
+* ``send-ssh-public-key`` authorises for roughly a minute, so a key pushed once
+  is not enough. ``test_a_stale_key_is_refused`` shows the failure the re-push
+  exists to avoid.
+* ``ec2-instance-connect:OpenTunnel`` is conditionable on ``remotePort``, so the
+  documented policy scopes to port 22 alone -- checked against IAM's own
+  evaluator, not by reading the JSON.
+* endpoint creation takes minutes, so it is caller-supplied and never created
+  here. It is verified in ``initialize()`` alongside the VPC/subnet/SG.
+
+Requires an EC2 Instance Connect Endpoint in ``AWS_TEST_SUBNET_ID`` (see
+``eice_endpoint_id``), plus ``ssh`` and AWS CLI v2 on the machine running the
+tests. Each is skipped for, not failed on.
+
+Run with::
+
+    AWS_TEST_REGION=us-east-1 AWS_TEST_VPC_ID=vpc-xxx \\
+    AWS_TEST_SUBNET_ID=subnet-xxx AWS_TEST_SG_ID=sg-xxx \\
+    AWS_TEST_EICE_ID=eice-xxx \\
+    AWS_PROFILE=aws pytest tests/aws/test_eice_tunnel_e2e.py -m aws --no-cov -v
+
+SPDX-License-Identifier: Apache-2.0
+SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+"""
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+import time
+
+import pytest
+from parsl.jobs.states import JobState
+
+from parsl_ephemeral_provider.constants import (
+    TUNNEL_OPEN_RETRY_DELAY,
+    TUNNEL_OPEN_TIMEOUT,
+)
+from parsl_ephemeral_provider.network.eice import (
+    EICE_TUNNEL_MAX_DURATION,
+    EICETunnel,
+    eice_iam_statements,
+)
+from parsl_ephemeral_provider.provider import EphemeralProvider
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [pytest.mark.aws, pytest.mark.slow]
+
+AWS_TEST_PROFILE = "aws"
+
+POLL_INTERVAL_S = 15
+#: SSM registration plus worker_init on real iron, matching the one-shot suite.
+MAX_WAIT_S = 900
+
+#: The driver-side port the fake interchange binds. Inside HTEX's default
+#: ``worker_port_range`` (54000-55000) so this exercises the range the provider
+#: will really see, but fixed rather than random so a leaked forward is
+#: identifiable.
+INTERCHANGE_PORT = 54321
+
+#: pyzmq on the worker, which Amazon Linux 2023 does not ship. Installed rather
+#: than the whole of Parsl because the round trip is the point and Parsl would
+#: add minutes to every boot.
+#:
+#: ``python3-pip`` first: AL2023 ships python3 without pip, so
+#: ``python3 -m pip`` on a bare instance fails with "No module named pip" --
+#: and it fails in ``worker_init``, whose output goes to cloud-init's log and
+#: never reaches the test. The probe reinstalls below for the same reason: a
+#: failure there lands in the SSM invocation output, where it is visible.
+E2E_WORKER_INIT = (
+    "dnf install -y python3-pip >/dev/null 2>&1 || true\n"
+    "python3 -m pip install --quiet pyzmq\n"
+)
+
+
+# ---------------------------------------------------------------------------
+# The worker-side probe
+# ---------------------------------------------------------------------------
+
+#: Runs on the instance. A DEALER through the tunnel to the driver's ROUTER,
+#: which is HTEX's own socket pair. Kept as a module constant so the shell
+#: quoting has one home.
+#:
+#: ``__PORT__`` rather than ``%d``/``{}``: the body has its own ``%r`` and its own
+#: braces, so both ``%`` formatting and ``str.format`` misfire on it.
+_PROBE_BODY = """
+import sys
+import zmq
+
+context = zmq.Context()
+sock = context.socket(zmq.DEALER)
+sock.setsockopt(zmq.LINGER, 0)
+sock.setsockopt_string(zmq.IDENTITY, "parsl-e2e-worker")
+# 127.0.0.1 on the *worker*: the reverse forward is what puts the driver's
+# interchange on the worker's own loopback. Nothing routable is involved, which
+# is the whole point of #134.
+sock.connect("tcp://127.0.0.1:__PORT__")
+
+sock.send(b"PARSL_TUNNEL_PROBE")
+
+poller = zmq.Poller()
+poller.register(sock, zmq.POLLIN)
+if not poller.poll(60000):
+    print("no reply from the interchange through the tunnel")
+    sys.exit(1)
+
+reply = sock.recv()
+if reply != b"PARSL_TUNNEL_ACK":
+    print("wrong reply through the tunnel: %r" % reply)
+    sys.exit(1)
+
+print("round trip through the reverse tunnel completed")
+"""
+
+
+def _probe_command(port: int) -> str:
+    """A command that fails unless the tunnel carries a full ZMQ round trip.
+
+    Shaped so the provider sees a ``--port`` exactly where HTEX would put one:
+    the provider is never told where the interchange is, it reads the port out of
+    the command string. The ``:`` no-op carries the flag without needing a
+    ``process_worker_pool.py`` on the instance, and ``-a 127.0.0.1`` is the
+    address a tunnelled worker should be given.
+    """
+    return "\n".join(
+        [
+            f": -a 127.0.0.1 --port={port}",
+            # Belt and braces on the dependency. worker_init installs it, but if
+            # that failed the reason went to cloud-init's log on the instance,
+            # and the test would report only "nothing arrived at the socket" --
+            # blaming the tunnel for a missing module. Here the output is the
+            # SSM invocation's, which the test can read.
+            "python3 -c 'import zmq' 2>/dev/null || {",
+            "  dnf install -y python3-pip >/dev/null 2>&1 || true",
+            "  python3 -m pip install --quiet pyzmq || {",
+            "    echo 'could not install pyzmq; this is not a tunnel failure' >&2",
+            "    exit 2",
+            "  }",
+            "}",
+            "python3 - <<'PARSL_E2E_PROBE'",
+            _PROBE_BODY.replace("__PORT__", str(port)),
+            "PARSL_E2E_PROBE",
+        ]
+    )
+
+
+def _poll_until_terminal(provider, job_id: str, timeout: int = MAX_WAIT_S):
+    """Poll ``status()`` until *job_id* leaves PENDING/RUNNING."""
+    non_terminal = (JobState.PENDING, JobState.RUNNING)
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        statuses = provider.status([job_id])
+        if statuses and statuses[0].state not in non_terminal:
+            return statuses[0].state
+        time.sleep(POLL_INTERVAL_S)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def local_tunnel_binaries():
+    """Skip unless ``ssh`` and the AWS CLI are present.
+
+    This is the only part of the package that shells out, so their absence is a
+    genuine "cannot test here" rather than a failure. Checked once per session.
+    """
+    missing = [name for name in ("ssh", "aws") if shutil.which(name) is None]
+    if missing:
+        pytest.skip(f"EICE tunnels need {', '.join(missing)} on PATH")
+
+
+@pytest.fixture(scope="session")
+def eice_endpoint_id(network_ids):
+    """Return a usable EC2 Instance Connect Endpoint in the test subnet.
+
+    Taken from ``AWS_TEST_EICE_ID`` when set, otherwise discovered in the test
+    VPC. Never created: creation took about four and a half minutes in testing,
+    which is why the design treats the endpoint as pre-provisioned network per
+    #69, and a fixture that created one would both be slow and hide that.
+
+    The state is checked because a ``create-in-progress`` endpoint accepts
+    ``open-tunnel`` calls and fails them.
+    """
+    import boto3
+
+    region = os.environ.get("AWS_TEST_REGION", "us-west-2")
+    ec2 = boto3.Session(profile_name=AWS_TEST_PROFILE, region_name=region).client("ec2")
+
+    explicit = os.environ.get("AWS_TEST_EICE_ID")
+    if explicit:
+        try:
+            found = ec2.describe_instance_connect_endpoints(
+                InstanceConnectEndpointIds=[explicit]
+            )["InstanceConnectEndpoints"]
+        except Exception as exc:
+            pytest.fail(f"AWS_TEST_EICE_ID={explicit} is not usable in {region}: {exc}")
+        if found[0]["State"] != "create-complete":
+            pytest.skip(f"{explicit} is {found[0]['State']}, not create-complete")
+        return explicit
+
+    candidates = ec2.describe_instance_connect_endpoints(
+        Filters=[{"Name": "subnet-id", "Values": [network_ids["subnet_id"]]}]
+    )["InstanceConnectEndpoints"]
+    usable = [c for c in candidates if c["State"] == "create-complete"]
+    if not usable:
+        pytest.skip(
+            f"No create-complete EC2 Instance Connect Endpoint in "
+            f"{network_ids['subnet_id']}. Create one (it takes ~5 minutes) or set "
+            "AWS_TEST_EICE_ID."
+        )
+    return usable[0]["InstanceConnectEndpointId"]
+
+
+@pytest.fixture
+def interchange_socket():
+    """A real ``zmq.ROUTER`` on driver loopback, echoing one probe.
+
+    Bound to 127.0.0.1 deliberately: if this listened on 0.0.0.0 the worker
+    might reach it by some other route and the test would pass without the
+    tunnel doing anything. Loopback is unreachable from EC2 by construction, so
+    a round trip proves the forward carried it.
+    """
+    zmq = pytest.importorskip("zmq")
+
+    context = zmq.Context()
+    router = context.socket(zmq.ROUTER)
+    router.setsockopt(zmq.LINGER, 0)
+    router.bind(f"tcp://127.0.0.1:{INTERCHANGE_PORT}")
+
+    class Interchange:
+        """The socket plus a one-shot echo. A wrapper because ``zmq.Socket``
+        turns attribute assignment into a socket-option set and rejects
+        anything it does not recognise."""
+
+        socket = router
+
+        @staticmethod
+        def serve(timeout_s: int) -> bool:
+            """Reply to one probe, returning whether one arrived."""
+            poller = zmq.Poller()
+            poller.register(router, zmq.POLLIN)
+            deadline = time.time() + timeout_s
+            while time.time() < deadline:
+                if poller.poll(1000):
+                    identity, payload = router.recv_multipart()
+                    logger.info("interchange received %r from %r", payload, identity)
+                    router.send_multipart([identity, b"PARSL_TUNNEL_ACK"])
+                    return True
+            return False
+
+    yield Interchange
+
+    router.close()
+    context.term()
+
+
+@pytest.fixture
+def tunnel_provider(
+    tmp_path,
+    test_run_id,
+    aws_region,
+    network_ids,
+    eice_endpoint_id,
+    local_tunnel_binaries,
+):
+    """A one-shot provider that tunnels.
+
+    One-shot rather than the default UserData path for two reasons: it reports
+    the command's exit code, which is what lets the worker's own verdict on the
+    tunnel reach the test, and it dispatches over SSM *after* the tunnel is up,
+    which is the ordering the mode guarantees on that path.
+
+    What makes the proof airtight is the interchange binding 127.0.0.1, not the
+    subnet: the shared test subnet has an internet gateway and assigns public IPs,
+    so the worker *can* route out. It still cannot route to the driver's loopback
+    by any path other than the reverse forward, which is the claim under test.
+    """
+    provider = EphemeralProvider(
+        region=aws_region,
+        instance_type="t3.micro",
+        mode="standard",
+        one_shot=True,
+        auto_create_instance_profile=True,
+        instance_connect_endpoint_id=eice_endpoint_id,
+        worker_init=E2E_WORKER_INIT,
+        state_store_type="file",
+        state_file_path=str(tmp_path / f"eice-{test_run_id}.json"),
+        profile_name=AWS_TEST_PROFILE,
+        additional_tags={"E2ETestRunId": test_run_id, "AutoCleanup": "true"},
+        waiter_delay=15,
+        waiter_max_attempts=40,
+        debug=True,
+        **network_ids,
+    )
+
+    yield provider
+
+    try:
+        provider.shutdown()
+    except Exception as exc:
+        logger.warning("Provider shutdown raised (best-effort): %s", exc)
+
+
+@pytest.fixture
+def live_instance(aws_provider, test_run_id):
+    """A *booted* instance to tunnel to, without a provider that tunnels.
+
+    Used by the tests that drive :class:`EICETunnel` directly. ``aws_provider``
+    is the shared standard-mode fixture, so its own teardown terminates this.
+
+    ``instance_status_ok``, not ``instance_running``: "running" is not "sshd is
+    accepting connections", and the difference is not academic. A tunnel started
+    against a merely-running instance fails with ``Websocket Closure Reason:
+    Unable to connect to target``, which is exactly why
+    ``_open_reverse_tunnel`` retries for ``TUNNEL_OPEN_TIMEOUT``. These tests
+    bypass that retry to exercise ``EICETunnel`` directly, so they have to wait
+    here instead.
+    """
+    job_id = aws_provider.submit("sleep 900", tasks_per_node=1)
+    instance_id = aws_provider.job_map[job_id]["resource_id"]
+
+    ec2 = aws_provider.session.client("ec2")
+    ec2.get_waiter("instance_status_ok").wait(
+        InstanceIds=[instance_id], WaiterConfig={"Delay": 15, "MaxAttempts": 40}
+    )
+    return instance_id
+
+
+def _start_with_retry(tunnel, timeout: int = TUNNEL_OPEN_TIMEOUT):
+    """Start *tunnel*, retrying the way ``_open_reverse_tunnel`` does.
+
+    Even past ``instance_status_ok`` the first connect can lose a race with
+    sshd, and each attempt re-pushes the key -- which is required anyway, since
+    the previous attempt's authorisation has a ~60s life. Sharing production's
+    budget rather than inventing one keeps this test from being more patient
+    than the provider is.
+    """
+    deadline = time.time() + timeout
+    while True:
+        try:
+            tunnel.start()
+            return
+        except Exception:
+            if time.time() >= deadline:
+                raise
+            time.sleep(TUNNEL_OPEN_RETRY_DELAY)
+
+
+# ---------------------------------------------------------------------------
+# The central test: a worker reaches driver loopback
+# ---------------------------------------------------------------------------
+
+
+class TestAWorkerReachesTheInterchange:
+    """The claim no mock can check: loopback on the driver, from a private subnet."""
+
+    def test_the_worker_completes_a_zmq_round_trip_through_the_tunnel(
+        self, tunnel_provider, interchange_socket
+    ):
+        """COMPLETED here means a DEALER on EC2 spoke to a ROUTER on this machine.
+
+        This is the whole of #134 in one assertion. The ROUTER is bound to
+        127.0.0.1, so no route exists from EC2 to it; the worker connects to
+        *its own* 127.0.0.1 and the reverse forward carries it. The probe exits
+        non-zero on a missing or wrong reply, and one-shot mode surfaces that as
+        FAILED -- so this is the worker's verdict, not the driver's hope.
+        """
+        job_id = tunnel_provider.submit(
+            _probe_command(INTERCHANGE_PORT), tasks_per_node=1
+        )
+
+        # Serve the probe while the job runs. The instance has to boot, install
+        # pyzmq, and be dispatched to, so the wait here covers the whole submit.
+        served = interchange_socket.serve(MAX_WAIT_S)
+
+        state = _poll_until_terminal(tunnel_provider, job_id)
+
+        assert served, (
+            "nothing arrived at the interchange socket, so the reverse forward "
+            "never carried a connection"
+        )
+        assert state == JobState.COMPLETED, (
+            f"the worker could not complete the round trip (state={state}); the "
+            "SSM invocation's StandardOutputContent says which step failed"
+        )
+
+    def test_the_tunnel_is_open_before_the_command_is_dispatched(
+        self, tunnel_provider, interchange_socket
+    ):
+        """Ordering is load-bearing: a worker connects as soon as it starts.
+
+        A tunnel opened after dispatch races the connection it exists to carry.
+        Checked against the live supervisor rather than by patching, because the
+        unit suite already asserts the call order and what is in question here is
+        whether a real tunnel is up by then.
+        """
+        job_id = tunnel_provider.submit(
+            _probe_command(INTERCHANGE_PORT), tasks_per_node=1
+        )
+        mode = tunnel_provider.operating_mode
+        instance_id = tunnel_provider.job_map[job_id]["resource_id"]
+
+        try:
+            assert mode._tunnel_supervisor is not None, (
+                "submit returned with no supervisor, so no tunnel was opened"
+            )
+            assert instance_id in mode._tunnel_supervisor.instance_ids
+            tunnel = mode._tunnel_supervisor._tunnels[instance_id]
+            assert tunnel.is_alive(), (
+                "the ssh process holding the forward is not running, yet the "
+                "command has already been dispatched to the worker"
+            )
+            assert tunnel.ports == [INTERCHANGE_PORT], (
+                f"the tunnel forwards {tunnel.ports}, not the port named in the "
+                "command; the worker would connect to nothing"
+            )
+        finally:
+            interchange_socket.serve(120)
+            try:
+                tunnel_provider.cancel([job_id])
+            except Exception as exc:
+                logger.warning("teardown cancel raised (ignored): %s", exc)
+
+    def test_shutdown_closes_the_tunnel_and_removes_the_key(self, tunnel_provider):
+        """The ssh process and the generated private key must not outlive the run.
+
+        A leaked ssh child holds a forward to a terminated instance and
+        reconnects forever; a leaked private key sits in ``/tmp`` authorised for
+        nothing but still readable.
+
+        The command has to name a ``--port`` even though nothing here uses the
+        forward: the provider reads the port out of the command and opens no
+        tunnel at all when there is none, so a bare ``sleep`` would leave this
+        asserting against a supervisor that was never built.
+        """
+        job_id = tunnel_provider.submit(
+            f": -a 127.0.0.1 --port={INTERCHANGE_PORT}\nsleep 60", tasks_per_node=1
+        )
+        mode = tunnel_provider.operating_mode
+        instance_id = tunnel_provider.job_map[job_id]["resource_id"]
+        tunnel = mode._tunnel_supervisor._tunnels[instance_id]
+        key_dir = mode._tunnel_key_dir
+        assert tunnel.is_alive()
+        assert key_dir and os.path.isdir(key_dir)
+
+        tunnel_provider.shutdown()
+
+        assert not tunnel.is_alive(), "the ssh process survived shutdown"
+        assert mode._tunnel_supervisor is None
+        assert not os.path.exists(key_dir), (
+            f"the generated tunnel keypair survived shutdown in {key_dir}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# The API constraints, asserted against the live API
+# ---------------------------------------------------------------------------
+
+
+class TestTheAPIConstraints:
+    """Each was discovered live and each would otherwise fail silently."""
+
+    def _tunnel(self, session, instance_id, endpoint_id, keys, **kwargs):
+        private, public = keys
+        return EICETunnel(
+            session=session,
+            instance_id=instance_id,
+            endpoint_id=endpoint_id,
+            ports=[INTERCHANGE_PORT],
+            public_key_path=public,
+            private_key_path=private,
+            profile_name=AWS_TEST_PROFILE,
+            **kwargs,
+        )
+
+    @pytest.fixture
+    def keys(self, tmp_path):
+        """A real ed25519 pair, generated the way the mode generates one."""
+        private = str(tmp_path / "tunnel_key")
+        subprocess.run(
+            ["ssh-keygen", "-t", "ed25519", "-N", "", "-q", "-f", private],
+            check=True,
+        )
+        os.chmod(private, 0o600)
+        return private, f"{private}.pub"
+
+    def test_the_duration_ceiling_is_what_the_api_enforces(
+        self, eice_endpoint_id, local_tunnel_binaries
+    ):
+        """Above the ceiling is rejected, so the module must ask for no more.
+
+        Rejection is ``ParamValidation``, raised before any call is made, which
+        is why no instance is needed here -- a malformed instance ID is enough to
+        show *which* error came first. The message says "less than 3600" and is
+        off by one: 3600 itself is accepted, 3601 is not. Both are asserted,
+        because a clamp justified by a claim nobody checks is how the claim goes
+        stale, and this notices if AWS ever moves the ceiling.
+        """
+        assert EICE_TUNNEL_MAX_DURATION == 3600
+
+        def attempt(duration):
+            return subprocess.run(  # noqa: S603 - argv is built here
+                [
+                    shutil.which("aws"),
+                    "ec2-instance-connect",
+                    "open-tunnel",
+                    "--instance-id",
+                    "i-0000000000000000",  # malformed on purpose
+                    "--instance-connect-endpoint-id",
+                    eice_endpoint_id,
+                    "--region",
+                    os.environ.get("AWS_TEST_REGION", "us-west-2"),
+                    "--profile",
+                    AWS_TEST_PROFILE,
+                    "--max-tunnel-duration",
+                    str(duration),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+
+        over = attempt(EICE_TUNNEL_MAX_DURATION + 1)
+        assert "ParamValidation" in over.stderr, (
+            f"the API accepted max-tunnel-duration={EICE_TUNNEL_MAX_DURATION + 1}, "
+            "so the clamp in EICETunnel is no longer needed: " + over.stderr
+        )
+
+        # At the ceiling the duration is fine and validation moves on to the
+        # deliberately malformed instance ID, which is how "accepted" is visible
+        # without opening a real tunnel.
+        at = attempt(EICE_TUNNEL_MAX_DURATION)
+        assert "ParamValidation" not in at.stderr, (
+            f"max-tunnel-duration={EICE_TUNNEL_MAX_DURATION} is now rejected too; "
+            "the ceiling moved: " + at.stderr
+        )
+        assert "InvalidInstanceID.Malformed" in at.stderr
+
+    def test_a_tunnel_established_this_way_carries_the_forward(
+        self, aws_session, live_instance, eice_endpoint_id, keys, local_tunnel_binaries
+    ):
+        """``EICETunnel.start()`` against a real instance, with no provider involved.
+
+        ``ExitOnForwardFailure=yes`` makes a failed bind an immediate exit, so a
+        process that is still alive after the settle window has really bound the
+        forward. That is the property ``start()`` relies on to distinguish
+        established from failed, and it is checked here against real sshd.
+        """
+        tunnel = self._tunnel(aws_session, live_instance, eice_endpoint_id, keys)
+
+        try:
+            _start_with_retry(tunnel)
+
+            assert tunnel.is_alive(), (
+                "ssh exited despite start() returning, so the settle window is "
+                "too short to distinguish established from failed"
+            )
+            assert tunnel.age() > 0
+        finally:
+            tunnel.stop()
+
+        assert not tunnel.is_alive()
+
+    def test_a_stale_key_is_refused(
+        self, aws_session, live_instance, eice_endpoint_id, keys, local_tunnel_binaries
+    ):
+        """The ~60s authorisation window is why the key is re-pushed every connect.
+
+        Without the re-push a reconnect twenty minutes later fails with
+        ``Permission denied (publickey)`` -- and because the supervisor reconnects
+        on a dead tunnel, that would turn one dropped tunnel into a worker that
+        never comes back. Rather than sleep out the window, this drives the
+        underlying ssh directly with a key that was never authorised at all,
+        which is the same server-side state.
+        """
+        tunnel = self._tunnel(aws_session, live_instance, eice_endpoint_id, keys)
+
+        # ssh_command() with no preceding push_key(): the key is valid, well
+        # formed, and unknown to the instance.
+        result = subprocess.run(  # noqa: S603 - argv is built by EICETunnel
+            tunnel.ssh_command(),
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+
+        assert result.returncode != 0, (
+            "sshd accepted an unauthorised key, so send-ssh-public-key is not "
+            "what is granting access and the re-push logic is untested"
+        )
+        assert (
+            "denied" in result.stderr.lower() or "authenticat" in result.stderr.lower()
+        )
+
+        # And the same key works once pushed, so the failure above was the
+        # authorisation and not something about the key or the endpoint.
+        try:
+            _start_with_retry(tunnel)
+            assert tunnel.is_alive()
+        finally:
+            tunnel.stop()
+
+    def test_the_supervisor_reconnects_a_killed_tunnel(
+        self, aws_session, live_instance, eice_endpoint_id, keys, local_tunnel_binaries
+    ):
+        """A dropped tunnel must come back inside HTEX's 120s heartbeat threshold.
+
+        The kill stands in for AWS closing the websocket at the ceiling, which is
+        the failure the supervisor exists for. Driving ``_supervise_once``
+        directly rather than waiting on the poll interval keeps this about the
+        reconnect and not about the timer.
+        """
+        from parsl_ephemeral_provider.network.eice import EICETunnelSupervisor
+
+        private, public = keys
+        supervisor = EICETunnelSupervisor(
+            session=aws_session,
+            endpoint_id=eice_endpoint_id,
+            ports=[INTERCHANGE_PORT],
+            public_key_path=public,
+            private_key_path=private,
+            profile_name=AWS_TEST_PROFILE,
+        )
+        try:
+            # add() starts the tunnel itself, so the first-connect race with
+            # sshd lands here; retry on the same budget the provider uses.
+            deadline = time.time() + TUNNEL_OPEN_TIMEOUT
+            while True:
+                try:
+                    tunnel = supervisor.add(live_instance)
+                    break
+                except Exception:
+                    if time.time() >= deadline:
+                        raise
+                    time.sleep(TUNNEL_OPEN_RETRY_DELAY)
+
+            first_pid = tunnel._process.pid
+            tunnel._process.kill()
+            tunnel._process.wait(timeout=30)
+            assert not tunnel.is_alive()
+
+            started = time.time()
+            supervisor._supervise_once()
+            elapsed = time.time() - started
+
+            assert tunnel.is_alive(), "the supervisor did not re-establish the tunnel"
+            assert tunnel._process.pid != first_pid, "the same process was reported"
+            assert elapsed < 120, (
+                f"the reconnect took {elapsed:.0f}s, past HTEX's 120s "
+                "heartbeat_threshold; the interchange would have given up on "
+                "the manager and rescheduled its tasks"
+            )
+        finally:
+            supervisor.shutdown()
+
+    def test_a_bad_endpoint_fails_at_initialize(
+        self, tmp_path, test_run_id, aws_region, network_ids
+    ):
+        """A typo must fail in ``initialize()``, not inside a ProxyCommand.
+
+        The endpoint joins the VPC/subnet/SG in ``_verify_resources``, so this is
+        the same class of check as the other three. Without it the failure
+        arrives at the first submit as an ssh process exiting for no visible
+        reason, minutes in, after an instance has been billed.
+        """
+        from parsl_ephemeral_provider.exceptions import ResourceNotFoundError
+
+        with pytest.raises((ResourceNotFoundError, Exception), match="eice-"):
+            EphemeralProvider(
+                region=aws_region,
+                instance_type="t3.micro",
+                mode="standard",
+                one_shot=True,
+                auto_create_instance_profile=True,
+                instance_connect_endpoint_id="eice-00000000000000000",
+                state_store_type="file",
+                state_file_path=str(tmp_path / f"bad-eice-{test_run_id}.json"),
+                profile_name=AWS_TEST_PROFILE,
+                additional_tags={"E2ETestRunId": test_run_id, "AutoCleanup": "true"},
+                **network_ids,
+            )
+
+
+# ---------------------------------------------------------------------------
+# The documented least-privilege policy, checked against IAM itself
+# ---------------------------------------------------------------------------
+
+
+class TestLeastPrivilegePolicy:
+    """``eice_iam_statements`` is advice, so IAM should be asked to confirm it.
+
+    The interesting claim is the scoping: ``OpenTunnel`` conditioned on
+    ``remotePort == 22``. This design only ever tunnels to sshd and carries the
+    ZMQ ports *inside* that session, so a grant open to any remote port would let
+    the holder reach any service on any instance they can name. A policy document
+    nobody evaluates is a plausible-looking suggestion; ``SimulateCustomPolicy``
+    is IAM's own verdict.
+    """
+
+    def _simulate(self, aws_session, statements, action, resource, context=None):
+        iam = aws_session.client("iam")
+        kwargs = {
+            "PolicyInputList": [
+                json.dumps({"Version": "2012-10-17", "Statement": statements})
+            ],
+            "ActionNames": [action],
+            "ResourceArns": [resource],
+        }
+        if context:
+            kwargs["ContextEntries"] = context
+        try:
+            response = iam.simulate_custom_policy(**kwargs)
+        except iam.exceptions.ClientError as exc:
+            pytest.skip(f"iam:SimulateCustomPolicy not permitted: {exc}")
+        return response["EvaluationResults"][0]["EvalDecision"]
+
+    def _port_context(self, port):
+        return [
+            {
+                "ContextKeyName": "ec2-instance-connect:remotePort",
+                "ContextKeyValues": [str(port)],
+                "ContextKeyType": "numeric",
+            }
+        ]
+
+    def test_it_allows_the_tunnel_to_port_22(self, aws_session, eice_endpoint_id):
+        statements = eice_iam_statements(endpoint_id=eice_endpoint_id)
+        arn = f"arn:aws:ec2:*:*:instance-connect-endpoint/{eice_endpoint_id}"
+
+        decision = self._simulate(
+            aws_session,
+            statements,
+            "ec2-instance-connect:OpenTunnel",
+            arn,
+            self._port_context(22),
+        )
+
+        assert decision == "allowed", (
+            f"the documented policy does not permit the only tunnel this design "
+            f"opens: {decision}"
+        )
+
+    def test_it_does_not_allow_a_tunnel_to_any_other_port(
+        self, aws_session, eice_endpoint_id
+    ):
+        """The condition is the only thing making this narrower than ``*``.
+
+        An unconditioned ``OpenTunnel`` grant reaches every port on every
+        instance the holder can name, which for a driver credential is a much
+        larger blast radius than "can ssh to workers".
+        """
+        statements = eice_iam_statements(endpoint_id=eice_endpoint_id)
+        arn = f"arn:aws:ec2:*:*:instance-connect-endpoint/{eice_endpoint_id}"
+
+        decision = self._simulate(
+            aws_session,
+            statements,
+            "ec2-instance-connect:OpenTunnel",
+            arn,
+            self._port_context(INTERCHANGE_PORT),
+        )
+
+        assert decision != "allowed", (
+            "the policy permits tunnelling to an arbitrary port; the remotePort "
+            "condition is not doing what it claims"
+        )
+
+    def test_it_allows_pushing_a_key_for_the_documented_user_only(self, aws_session):
+        """``ec2:osuser`` scopes the key push, so root is not reachable.
+
+        ``SendSSHPublicKey`` with no condition authorises a key for *any* OS user
+        on the instance, including root.
+        """
+        statements = eice_iam_statements()
+        arn = "arn:aws:ec2:us-east-1:942542972736:instance/i-0123456789abcdef0"
+
+        def decide(user):
+            return self._simulate(
+                aws_session,
+                statements,
+                "ec2-instance-connect:SendSSHPublicKey",
+                arn,
+                [
+                    {
+                        "ContextKeyName": "ec2:osuser",
+                        "ContextKeyValues": [user],
+                        "ContextKeyType": "string",
+                    }
+                ],
+            )
+
+        assert decide("ec2-user") == "allowed"
+        assert decide("root") != "allowed", (
+            "the policy permits authorising a key for root on any instance"
+        )

--- a/tests/unit/test_eice_tunnel.py
+++ b/tests/unit/test_eice_tunnel.py
@@ -1,0 +1,832 @@
+"""EICE reverse tunnels for workers behind NAT (#134).
+
+The subject here is a *subprocess*, so these tests are written against the argv
+and the lifecycle rather than against AWS. That is deliberate: every AWS-side
+constraint that shapes this design was already confirmed live during the spike
+(the 3600s tunnel cap, the ~60s key validity, the several-minute endpoint
+creation), and none of them can be re-checked from a unit test. What a unit test
+*can* check is the part that silently breaks -- that ``ExitOnForwardFailure``
+stays in the argv, that the key is pushed before every connect and not once, and
+that the reverse forward is ``-R`` in the direction that carries worker to
+driver rather than the ``--remote-port`` forward the issue originally proposed.
+
+``ssh`` is replaced with a stub script throughout. A real ``ssh`` would need a
+real endpoint and a real instance, which is ``tests/aws/test_eice_tunnel_e2e.py``.
+
+SPDX-License-Identifier: Apache-2.0
+SPDX-FileCopyrightText: 2025-2026 Scott Friedman and Project Contributors
+"""
+
+import os
+import stat
+import subprocess
+import threading
+from unittest.mock import MagicMock
+
+import pytest
+from botocore.exceptions import ClientError
+
+from parsl_ephemeral_provider.exceptions import (
+    ProviderConfigurationError,
+    ResourceCreationError,
+)
+from parsl_ephemeral_provider.network.eice import (
+    EICE_TUNNEL_MAX_DURATION,
+    EICETunnel,
+    EICETunnelSupervisor,
+    eice_iam_statements,
+    extract_addresses,
+    extract_worker_ports,
+    resolve_aws_cli,
+    resolve_ssh_binary,
+)
+
+pytestmark = pytest.mark.unit
+
+
+#: A real ``DEFAULT_LAUNCH_CMD`` after HTEX interpolates it. Kept verbatim rather
+#: than trimmed to the interesting flags, because the parser has to survive the
+#: whole thing -- ``--hb_period=30`` and ``-p 0`` are the sort of neighbours that
+#: break a loose regex.
+LAUNCH_CMD = (
+    "process_worker_pool.py  --max_workers_per_node=4 -a 127.0.0.1 -p 0 "
+    "-c 1 -m None --poll 10 --port=54321 "
+    "--cert_dir /home/u/runinfo/000/htex/certificates "
+    "--logdir=/x --block_id=0 --hb_period=30 --hb_threshold=120 "
+    "--drain_period=None --cpu-affinity none --mpi-launcher=mpiexec "
+    "--available-accelerators"
+)
+
+
+@pytest.fixture
+def keypair(tmp_path):
+    """A private/public path pair. The contents only have to be readable."""
+    private = tmp_path / "tunnel_key"
+    private.write_text("PRIVATE")
+    public = tmp_path / "tunnel_key.pub"
+    public.write_text("ssh-ed25519 AAAAC3Nz test\n")
+    return str(private), str(public)
+
+
+@pytest.fixture
+def fake_ssh(tmp_path):
+    """An ``ssh`` that blocks until killed, standing in for a live tunnel."""
+    script = tmp_path / "ssh-holds-open"
+    script.write_text("#!/bin/sh\nwhile true; do sleep 30; done\n")
+    script.chmod(script.stat().st_mode | stat.S_IEXEC)
+    return str(script)
+
+
+@pytest.fixture
+def failing_ssh(tmp_path):
+    """An ``ssh`` that exits at once, as ExitOnForwardFailure makes it do."""
+    script = tmp_path / "ssh-fails"
+    script.write_text(
+        "#!/bin/sh\n"
+        "echo 'Warning: remote port forwarding failed for listen port 54321' >&2\n"
+        "exit 255\n"
+    )
+    script.chmod(script.stat().st_mode | stat.S_IEXEC)
+    return str(script)
+
+
+@pytest.fixture
+def fake_aws(tmp_path):
+    """An ``aws`` binary. Never executed -- it only has to resolve."""
+    script = tmp_path / "aws"
+    script.write_text("#!/bin/sh\nexit 0\n")
+    script.chmod(script.stat().st_mode | stat.S_IEXEC)
+    return str(script)
+
+
+@pytest.fixture
+def session():
+    """A session whose ``ec2-instance-connect`` client is a mock."""
+    sess = MagicMock()
+    sess.region_name = "us-east-1"
+    client = MagicMock()
+    sess.client.return_value = client
+    return sess
+
+
+#: The two waits a stub ``ssh`` should not make a test pay. Both are production
+#: tunables (5s to watch a new process settle, 10s of SIGTERM grace) whose values
+#: only matter against a real ssh reaching a real endpoint; a stub either holds
+#: open or exits immediately, and both are decided in milliseconds.
+FAST_TIMEOUTS = {"settle_timeout": 1, "terminate_timeout": 1}
+
+
+def _tunnel(session, keypair, fake_ssh, fake_aws, **overrides):
+    private, public = keypair
+    kwargs = {
+        "session": session,
+        "instance_id": "i-0123456789abcdef0",
+        "endpoint_id": "eice-0123456789abcdef0",
+        "ports": [54321],
+        "private_key_path": private,
+        "public_key_path": public,
+        "ssh_binary": fake_ssh,
+        "aws_cli": fake_aws,
+        **FAST_TIMEOUTS,
+    }
+    kwargs.update(overrides)
+    return EICETunnel(**kwargs)
+
+
+class TestExtractWorkerPorts:
+    """The provider is never told the port; it reads it out of the command.
+
+    Same seam ``extract_cert_dir`` uses for #62, for the same reason: HTEX
+    interpolates ``--port=`` into ``launch_cmd`` before the provider sees it, and
+    that is the only record of where the interchange bound.
+    """
+
+    def test_it_finds_the_port_in_a_real_launch_command(self):
+        assert extract_worker_ports(LAUNCH_CMD) == [54321]
+
+    def test_it_accepts_a_space_instead_of_equals(self):
+        # A caller may supply their own launch_cmd; the '=' is upstream's choice.
+        assert extract_worker_ports("worker.py --port 54999 -a 1.2.3.4") == [54999]
+
+    def test_it_is_not_fooled_by_neighbouring_flags(self):
+        # -p 0 (prefetch) and --hb_period=30 are the near misses that matter.
+        assert extract_worker_ports(LAUNCH_CMD) == [54321]
+
+    def test_it_deduplicates_while_keeping_order(self):
+        command = "worker.py --port=54001 --port=54002 --port=54001"
+        assert extract_worker_ports(command) == [54001, 54002]
+
+    def test_no_port_is_not_an_error(self):
+        # A caller-supplied command that is not an HTEX worker pool has nothing
+        # to forward, and the mode treats the empty list as "skip tunnelling".
+        assert extract_worker_ports("echo hello") == []
+
+
+class TestExtractAddresses:
+    """Only used to warn, so the bar is that it reads the real shape."""
+
+    def test_it_finds_the_addresses_flag(self):
+        assert extract_addresses(LAUNCH_CMD) == "127.0.0.1"
+
+    def test_it_finds_a_comma_separated_list(self):
+        command = "worker.py -a 10.0.1.5,127.0.0.1 --port=54321"
+        assert extract_addresses(command) == "10.0.1.5,127.0.0.1"
+
+    def test_absent_is_none(self):
+        assert extract_addresses("worker.py --port=54321") is None
+
+
+class TestBinaryResolution:
+    """A missing binary must be a configuration error, not a dead tunnel.
+
+    This is the only part of the package that shells out, so "aws is not
+    installed" is a new failure mode for this project and deserves to be said
+    plainly rather than surfacing as a worker that never registers.
+    """
+
+    def test_an_explicit_ssh_path_is_used(self, fake_ssh):
+        assert resolve_ssh_binary(fake_ssh) == fake_ssh
+
+    def test_a_missing_ssh_is_a_configuration_error(self, tmp_path):
+        with pytest.raises(ProviderConfigurationError, match="No usable ssh"):
+            resolve_ssh_binary(str(tmp_path / "nope"))
+
+    def test_a_non_executable_ssh_is_a_configuration_error(self, tmp_path):
+        candidate = tmp_path / "ssh"
+        candidate.write_text("#!/bin/sh\n")
+        candidate.chmod(0o644)
+        with pytest.raises(ProviderConfigurationError, match="No usable ssh"):
+            resolve_ssh_binary(str(candidate))
+
+    def test_a_missing_aws_cli_says_why_boto3_is_not_enough(self, tmp_path):
+        with pytest.raises(ProviderConfigurationError, match="no boto3 equivalent"):
+            resolve_aws_cli(str(tmp_path / "nope"))
+
+
+class TestTunnelCommandConstruction:
+    """The argv is the design. Each assertion here is a defect that shipped once.
+
+    Nothing in this class starts a process; ``ssh_command`` and
+    ``proxy_command`` are pure.
+    """
+
+    def test_the_forward_is_reverse_and_binds_worker_loopback(
+        self, session, keypair, fake_ssh, fake_aws
+    ):
+        # The whole point. #134 proposed `open-tunnel --remote-port`, which is a
+        # *forward* tunnel and would send driver-side connections to a port on
+        # the worker where nothing listens. -R is the direction that works.
+        argv = _tunnel(session, keypair, fake_ssh, fake_aws).ssh_command()
+        assert "-R" in argv
+        assert argv[argv.index("-R") + 1] == "127.0.0.1:54321:127.0.0.1:54321"
+
+    def test_every_port_gets_its_own_forward(
+        self, session, keypair, fake_ssh, fake_aws
+    ):
+        argv = _tunnel(
+            session, keypair, fake_ssh, fake_aws, ports=[54001, 54002]
+        ).ssh_command()
+        forwards = [argv[i + 1] for i, a in enumerate(argv) if a == "-R"]
+        assert forwards == [
+            "127.0.0.1:54001:127.0.0.1:54001",
+            "127.0.0.1:54002:127.0.0.1:54002",
+        ]
+
+    def test_exit_on_forward_failure_is_set(self, session, keypair, fake_ssh, fake_aws):
+        # Load-bearing: without it ssh reports success while the forward silently
+        # did not bind, and the failure surfaces minutes later as a worker that
+        # never registers. `start()` relies on it to tell established from failed.
+        argv = _tunnel(session, keypair, fake_ssh, fake_aws).ssh_command()
+        assert "ExitOnForwardFailure=yes" in argv
+
+    def test_it_cannot_prompt(self, session, keypair, fake_ssh, fake_aws):
+        # A provider running unattended must never block on a password or a host
+        # key prompt; that would look like a hung submit.
+        argv = _tunnel(session, keypair, fake_ssh, fake_aws).ssh_command()
+        assert "BatchMode=yes" in argv
+        assert "StrictHostKeyChecking=no" in argv
+        assert "UserKnownHostsFile=/dev/null" in argv
+
+    def test_keepalives_fit_inside_the_heartbeat_budget(
+        self, session, keypair, fake_ssh, fake_aws
+    ):
+        # HTEX's heartbeat_threshold is 120s. 20s x 3 notices a dead tunnel in
+        # ~60s, leaving the supervisor time to reconnect before the interchange
+        # declares the manager lost.
+        argv = _tunnel(session, keypair, fake_ssh, fake_aws).ssh_command()
+        assert "ServerAliveInterval=20" in argv
+        assert "ServerAliveCountMax=3" in argv
+
+    def test_it_runs_no_remote_command(self, session, keypair, fake_ssh, fake_aws):
+        argv = _tunnel(session, keypair, fake_ssh, fake_aws).ssh_command()
+        assert "-N" in argv and "-T" in argv
+
+    def test_it_connects_as_the_os_user_at_the_instance_id(
+        self, session, keypair, fake_ssh, fake_aws
+    ):
+        # By ID, not hostname: that is what open-tunnel takes, and it avoids
+        # depending on DNS inside a private subnet.
+        argv = _tunnel(session, keypair, fake_ssh, fake_aws).ssh_command()
+        assert argv[-1] == "ec2-user@i-0123456789abcdef0"
+
+    def test_a_custom_os_user_is_honoured(self, session, keypair, fake_ssh, fake_aws):
+        argv = _tunnel(
+            session, keypair, fake_ssh, fake_aws, os_user="ubuntu"
+        ).ssh_command()
+        assert argv[-1] == "ubuntu@i-0123456789abcdef0"
+
+    def test_the_proxy_command_opens_the_tunnel_through_the_endpoint(
+        self, session, keypair, fake_ssh, fake_aws
+    ):
+        proxy = _tunnel(session, keypair, fake_ssh, fake_aws).proxy_command()
+        assert "ec2-instance-connect open-tunnel" in proxy
+        assert "--instance-id i-0123456789abcdef0" in proxy
+        assert "--instance-connect-endpoint-id eice-0123456789abcdef0" in proxy
+        assert "--region us-east-1" in proxy
+
+    def test_the_proxy_command_carries_the_profile(
+        self, session, keypair, fake_ssh, fake_aws
+    ):
+        # The ProxyCommand is a separate process and inherits no boto3 session,
+        # so a profile the session was built from has to be passed explicitly or
+        # the CLI falls back to default credentials.
+        proxy = _tunnel(
+            session, keypair, fake_ssh, fake_aws, profile_name="aws"
+        ).proxy_command()
+        assert "--profile aws" in proxy
+
+    def test_the_proxy_command_omits_profile_when_there_is_none(
+        self, session, keypair, fake_ssh, fake_aws
+    ):
+        assert (
+            "--profile"
+            not in _tunnel(session, keypair, fake_ssh, fake_aws).proxy_command()
+        )
+
+
+class TestDurationCeiling:
+    """3600s is an API limit, confirmed live: 3601 and up are rejected.
+
+    The CLI's own message ("must be greater than 1 and less than 3600") is off by
+    one -- 3600 itself is accepted -- so the clamp lands a second under the
+    ceiling and it does not matter which of the two is wrong.
+    ``tests/aws/test_eice_tunnel_e2e.py`` asserts both boundaries against the
+    real API.
+    """
+
+    def test_the_default_is_clamped_below_the_ceiling(
+        self, session, keypair, fake_ssh, fake_aws
+    ):
+        # Asking for "as long as possible" is reasonable, so this clamps rather
+        # than raising -- but it must land under the boundary the API rejects.
+        tunnel = _tunnel(session, keypair, fake_ssh, fake_aws)
+        assert tunnel.max_duration == EICE_TUNNEL_MAX_DURATION - 1
+        assert f"--max-tunnel-duration {EICE_TUNNEL_MAX_DURATION - 1}" in (
+            tunnel.proxy_command()
+        )
+
+    def test_an_over_ceiling_request_is_clamped_not_rejected(
+        self, session, keypair, fake_ssh, fake_aws
+    ):
+        tunnel = _tunnel(session, keypair, fake_ssh, fake_aws, max_duration=99999)
+        assert tunnel.max_duration < EICE_TUNNEL_MAX_DURATION
+
+    def test_a_shorter_request_is_left_alone(
+        self, session, keypair, fake_ssh, fake_aws
+    ):
+        tunnel = _tunnel(session, keypair, fake_ssh, fake_aws, max_duration=600)
+        assert tunnel.max_duration == 600
+
+    def test_recycling_is_due_before_aws_closes_the_tunnel(
+        self, session, keypair, fake_ssh, fake_aws
+    ):
+        tunnel = _tunnel(session, keypair, fake_ssh, fake_aws, max_duration=600)
+        tunnel._started_at = 0.0  # ancient, so age() is far past the margin
+        assert tunnel.needs_recycle(margin=300)
+
+    def test_a_young_tunnel_is_not_recycled(
+        self, session, keypair, fake_ssh, fake_aws, monkeypatch
+    ):
+        tunnel = _tunnel(session, keypair, fake_ssh, fake_aws, max_duration=3599)
+        monkeypatch.setattr(tunnel, "age", lambda: 10.0)
+        assert not tunnel.needs_recycle()
+
+    def test_a_tunnel_needs_at_least_one_port(self, session, keypair, fake_ssh):
+        with pytest.raises(ProviderConfigurationError, match="at least one port"):
+            EICETunnel(
+                session=session,
+                instance_id="i-1",
+                endpoint_id="eice-1",
+                ports=[],
+                private_key_path=keypair[0],
+                public_key_path=keypair[1],
+                ssh_binary=fake_ssh,
+            )
+
+
+class TestKeyPush:
+    """``SendSSHPublicKey`` grants roughly 60 seconds, so timing is the design."""
+
+    def test_the_key_is_pushed_for_the_configured_user(
+        self, session, keypair, fake_ssh, fake_aws
+    ):
+        tunnel = _tunnel(session, keypair, fake_ssh, fake_aws, os_user="ubuntu")
+        tunnel.push_key()
+        session.client.assert_called_with("ec2-instance-connect")
+        kwargs = session.client.return_value.send_ssh_public_key.call_args.kwargs
+        assert kwargs["InstanceId"] == "i-0123456789abcdef0"
+        assert kwargs["InstanceOSUser"] == "ubuntu"
+        assert kwargs["SSHPublicKey"] == "ssh-ed25519 AAAAC3Nz test"
+
+    def test_a_denied_push_names_the_permission_needed(
+        self, session, keypair, fake_ssh, fake_aws
+    ):
+        session.client.return_value.send_ssh_public_key.side_effect = ClientError(
+            {"Error": {"Code": "AccessDeniedException", "Message": "no"}},
+            "SendSSHPublicKey",
+        )
+        tunnel = _tunnel(session, keypair, fake_ssh, fake_aws)
+        with pytest.raises(ResourceCreationError, match="SendSSHPublicKey"):
+            tunnel.push_key()
+
+    def test_every_connect_re_pushes_the_key(
+        self, session, keypair, fake_ssh, fake_aws
+    ):
+        # The reason this is per-connect rather than per-instance: a key pushed at
+        # submit is dead by the time a tunnel recycles at ~55 minutes, and the
+        # reconnect fails with 'Permission denied (publickey)'. Observed live.
+        tunnel = _tunnel(session, keypair, fake_ssh, fake_aws)
+        try:
+            tunnel.start()
+            tunnel.stop()
+            tunnel.start()
+        finally:
+            tunnel.stop()
+        assert session.client.return_value.send_ssh_public_key.call_count == 2
+
+
+class TestTunnelLifecycle:
+    """Started, alive, stopped -- against stub ``ssh`` binaries."""
+
+    def test_a_tunnel_that_holds_open_is_alive(
+        self, session, keypair, fake_ssh, fake_aws
+    ):
+        tunnel = _tunnel(session, keypair, fake_ssh, fake_aws)
+        try:
+            tunnel.start()
+            assert tunnel.is_alive()
+        finally:
+            tunnel.stop()
+        assert not tunnel.is_alive()
+
+    def test_an_immediate_exit_is_reported_as_a_failed_forward(
+        self, session, keypair, failing_ssh, fake_aws
+    ):
+        # ExitOnForwardFailure turns a bind failure into an immediate exit, so
+        # this is the signal that no worker would have reached the interchange.
+        tunnel = _tunnel(session, keypair, failing_ssh, fake_aws)
+        with pytest.raises(ResourceCreationError, match="exited immediately"):
+            tunnel.start()
+        assert not tunnel.is_alive()
+
+    def test_the_failure_message_carries_ssh_stderr(
+        self, session, keypair, failing_ssh, fake_aws
+    ):
+        # Without this the operator sees only a return code, and 255 from ssh
+        # means everything from DNS to permissions.
+        tunnel = _tunnel(session, keypair, failing_ssh, fake_aws)
+        with pytest.raises(ResourceCreationError, match="remote port forwarding"):
+            tunnel.start()
+
+    def test_starting_an_already_live_tunnel_is_a_no_op(
+        self, session, keypair, fake_ssh, fake_aws
+    ):
+        tunnel = _tunnel(session, keypair, fake_ssh, fake_aws)
+        try:
+            tunnel.start()
+            first = tunnel._process
+            tunnel.start()
+            assert tunnel._process is first
+        finally:
+            tunnel.stop()
+
+    def test_stopping_a_tunnel_that_never_started_is_not_an_error(
+        self, session, keypair, fake_ssh, fake_aws
+    ):
+        _tunnel(session, keypair, fake_ssh, fake_aws).stop()
+
+    def test_stop_closes_the_pipes(self, session, keypair, fake_ssh, fake_aws):
+        # Popen holds two; a long-running driver that recycled tunnels hourly
+        # would otherwise leak file descriptors one tunnel at a time.
+        tunnel = _tunnel(session, keypair, fake_ssh, fake_aws)
+        tunnel.start()
+        process = tunnel._process
+        tunnel.stop()
+        assert process.stdout.closed and process.stderr.closed
+
+    def test_an_unresponsive_ssh_is_killed(self, session, keypair, tmp_path, fake_aws):
+        # SIGTERM-ignoring ssh must not hang shutdown forever.
+        script = tmp_path / "ssh-ignores-term"
+        script.write_text("#!/bin/sh\ntrap '' TERM\nwhile true; do sleep 30; done\n")
+        script.chmod(script.stat().st_mode | stat.S_IEXEC)
+        tunnel = _tunnel(session, keypair, str(script), fake_aws)
+        tunnel.start()
+        tunnel.stop()
+        assert not tunnel.is_alive()
+
+    def test_age_is_zero_before_it_starts(self, session, keypair, fake_ssh, fake_aws):
+        assert _tunnel(session, keypair, fake_ssh, fake_aws).age() == 0.0
+
+
+class TestSupervisor:
+    """One tunnel per instance, kept alive across the 3600s ceiling."""
+
+    def _supervisor(self, session, keypair, ssh, aws, **kwargs):
+        private, public = keypair
+        return EICETunnelSupervisor(
+            session=session,
+            endpoint_id="eice-0123456789abcdef0",
+            ports=[54321],
+            private_key_path=private,
+            public_key_path=public,
+            ssh_binary=ssh,
+            aws_cli=aws,
+            # A short poll interval so shutdown()'s thread join is quick. The
+            # health-check pass itself is always driven directly via
+            # _supervise_once(); nothing here waits for the loop to come round.
+            poll_interval=1,
+            **{**FAST_TIMEOUTS, **kwargs},
+        )
+
+    def test_add_starts_a_tunnel_and_tracks_it(
+        self, session, keypair, fake_ssh, fake_aws
+    ):
+        sup = self._supervisor(session, keypair, fake_ssh, fake_aws)
+        try:
+            tunnel = sup.add("i-1")
+            assert tunnel.is_alive()
+            assert sup.instance_ids == ["i-1"]
+        finally:
+            sup.shutdown()
+
+    def test_adding_the_same_instance_twice_reuses_the_live_tunnel(
+        self, session, keypair, fake_ssh, fake_aws
+    ):
+        # A warm instance re-submitted must not accumulate ssh processes, and its
+        # existing forward is already correct.
+        sup = self._supervisor(session, keypair, fake_ssh, fake_aws)
+        try:
+            first = sup.add("i-1")
+            assert sup.add("i-1") is first
+            assert sup.instance_ids == ["i-1"]
+        finally:
+            sup.shutdown()
+
+    def test_remove_closes_the_tunnel(self, session, keypair, fake_ssh, fake_aws):
+        sup = self._supervisor(session, keypair, fake_ssh, fake_aws)
+        try:
+            tunnel = sup.add("i-1")
+            sup.remove("i-1")
+            assert not tunnel.is_alive()
+            assert sup.instance_ids == []
+        finally:
+            sup.shutdown()
+
+    def test_removing_an_unknown_instance_is_not_an_error(
+        self, session, keypair, fake_ssh, fake_aws
+    ):
+        # cleanup_resources() calls this for every resource ID it is given,
+        # including ones that never had a tunnel.
+        sup = self._supervisor(session, keypair, fake_ssh, fake_aws)
+        sup.remove("i-never-existed")
+
+    def test_shutdown_closes_every_tunnel(self, session, keypair, fake_ssh, fake_aws):
+        sup = self._supervisor(session, keypair, fake_ssh, fake_aws)
+        tunnels = [sup.add(f"i-{n}") for n in range(3)]
+        sup.shutdown()
+        assert not any(t.is_alive() for t in tunnels)
+        assert sup.instance_ids == []
+
+    def test_shutdown_stops_the_thread(self, session, keypair, fake_ssh, fake_aws):
+        # A daemon thread would not block exit, but it would keep reconnecting
+        # to instances the provider has terminated.
+        sup = self._supervisor(session, keypair, fake_ssh, fake_aws)
+        sup.add("i-1")
+        thread = sup._thread
+        sup.shutdown()
+        assert thread is not None and not thread.is_alive()
+
+    def test_a_dead_tunnel_is_reconnected(self, session, keypair, fake_ssh, fake_aws):
+        # The reconnect loop is the reason this class exists. Driven directly
+        # rather than by waiting on the poll interval, which no test should do.
+        sup = self._supervisor(session, keypair, fake_ssh, fake_aws)
+        try:
+            tunnel = sup.add("i-1")
+            tunnel._process.kill()
+            tunnel._process.wait()
+            assert not tunnel.is_alive()
+
+            sup._stop_event.clear()
+            sup._supervise_once()
+            assert tunnel.is_alive()
+        finally:
+            sup.shutdown()
+
+    def test_a_tunnel_near_the_ceiling_is_recycled(
+        self, session, keypair, fake_ssh, fake_aws
+    ):
+        sup = self._supervisor(session, keypair, fake_ssh, fake_aws)
+        try:
+            tunnel = sup.add("i-1")
+            original = tunnel._process
+            tunnel._started_at = 0.0  # ancient: past the recycle margin
+            sup._supervise_once()
+            assert tunnel.is_alive()
+            assert tunnel._process is not original
+        finally:
+            sup.shutdown()
+
+    def test_a_reconnect_failure_does_not_kill_the_supervisor(
+        self, session, keypair, fake_ssh, failing_ssh, fake_aws
+    ):
+        # The other tunnels are still worth keeping, and a terminating instance
+        # legitimately refuses connections.
+        sup = self._supervisor(session, keypair, fake_ssh, fake_aws)
+        try:
+            good = sup.add("i-good")
+            bad = sup.add("i-bad")
+            bad.ssh_binary = failing_ssh
+            bad._process.kill()
+            bad._process.wait()
+
+            sup._supervise_once()  # must not raise
+            assert good.is_alive()
+            assert not bad.is_alive()
+        finally:
+            sup.shutdown()
+
+    def test_concurrent_starts_do_not_orphan_an_ssh_process(
+        self, session, keypair, fake_ssh, fake_aws
+    ):
+        """Two threads racing to start one tunnel must leave exactly one process.
+
+        Found by noticing two ``ssh`` processes with PPID 1 outliving a unit run.
+        ``start()`` is reached from the submit path and from the supervision
+        thread, and a check-then-act on ``_process`` let both spawn: the second
+        assignment overwrote the first handle, orphaning a process that no
+        ``stop()`` or ``shutdown()`` could ever reap. On a long-lived driver that
+        is an unbounded leak of ssh processes and file descriptors.
+        """
+        sup = self._supervisor(session, keypair, fake_ssh, fake_aws)
+        try:
+            tunnel = sup.add("i-1")
+            first = tunnel._process
+            tunnel._process.kill()
+            tunnel._process.wait()
+
+            seen = []
+            # Four racers plus this thread release it, so five parties.
+            barrier = threading.Barrier(5)
+
+            def racer():
+                barrier.wait(timeout=30)
+                try:
+                    tunnel.start()
+                except Exception:  # pragma: no cover - not the property tested
+                    pass
+                seen.append(tunnel._process)
+
+            threads = [threading.Thread(target=racer) for _ in range(4)]
+            for thread in threads:
+                thread.start()
+            barrier.wait(timeout=30)
+            for thread in threads:
+                thread.join(timeout=30)
+
+            # Every racer must have observed the same process, and it must be a
+            # new one: any other handle spawned would be unreachable.
+            assert tunnel.is_alive()
+            assert tunnel._process is not first
+            assert {id(p) for p in seen} == {id(tunnel._process)}
+
+            # And it is genuinely reapable, which is what an orphan is not.
+            pid = tunnel._process.pid
+            tunnel.stop()
+            with pytest.raises(OSError):
+                os.kill(pid, 0)
+        finally:
+            sup.shutdown()
+
+    def test_a_removed_tunnel_is_not_revived_by_a_pass_in_flight(
+        self, session, keypair, fake_ssh, fake_aws
+    ):
+        """``remove()`` must win against a supervision pass that already began.
+
+        ``_supervise_once()`` iterates a snapshot taken under the lock, so a pass
+        in flight still holds a reference to a tunnel that ``remove()`` has since
+        dropped. If removal only stopped the process, that pass would see it dead,
+        reconnect it, and leave an ssh pointed at an instance being terminated --
+        untracked, so nothing would ever close it. The snapshot is taken here
+        explicitly rather than raced, because the interleaving that matters is
+        deterministic and a timing-based version of this test would pass by luck.
+        """
+        sup = self._supervisor(session, keypair, fake_ssh, fake_aws)
+        try:
+            tunnel = sup.add("i-1")
+
+            # A pass that has snapshotted the tunnel, before the removal.
+            snapshot = list(sup._tunnels.items())
+            sup.remove("i-1")
+            assert not tunnel.is_alive()
+            assert sup.instance_ids == []
+
+            # Now let that stale pass run: it finds a dead tunnel and would
+            # reconnect it.
+            for _, stale in snapshot:
+                if not stale.is_alive():
+                    stale.restart()
+
+            assert not tunnel.is_alive(), (
+                "a supervision pass in flight revived a removed tunnel; the ssh "
+                "process would outlive the instance untracked"
+            )
+        finally:
+            sup.shutdown()
+
+
+class TestIAMStatements:
+    """The grant is scoped to port 22; the ZMQ ports ride inside the session."""
+
+    def test_open_tunnel_is_restricted_to_ssh(self):
+        # Validated live with iam:SimulateCustomPolicy: port 22 allowed, port
+        # 54321 implicitDeny. An unconditioned grant would let the holder reach
+        # any service on any instance they can name.
+        statements = eice_iam_statements()
+        tunnel = next(
+            s for s in statements if s["Sid"] == "ParslEphemeralOpenTunnelToSshOnly"
+        )
+        condition = tunnel["Condition"]["NumericEquals"]
+        assert condition["ec2-instance-connect:remotePort"] == "22"
+
+    def test_the_zmq_ports_never_appear_in_the_policy(self):
+        # The shape of the mistake the port_range parameter exists to catch: the
+        # forwarded ports are not EICE remotePorts and must not be granted.
+        rendered = repr(eice_iam_statements(port_range=(54000, 55000)))
+        assert "54000" not in rendered and "55000" not in rendered
+
+    def test_the_key_push_is_scoped_to_one_os_user(self):
+        # ec2:osuser is what stops the same permission authorising a key for
+        # root.  Confirmed live: root is an implicitDeny under this policy.
+        statements = eice_iam_statements()
+        push = next(
+            s
+            for s in statements
+            if s["Sid"] == "ParslEphemeralAuthoriseEphemeralSshKey"
+        )
+        assert push["Condition"]["StringEquals"]["ec2:osuser"] == "ec2-user"
+
+    def test_an_endpoint_id_narrows_the_resource(self):
+        statements = eice_iam_statements(endpoint_id="eice-0123456789abcdef0")
+        tunnel = next(
+            s for s in statements if s["Sid"] == "ParslEphemeralOpenTunnelToSshOnly"
+        )
+        assert tunnel["Resource"] == [
+            "arn:aws:ec2:*:*:instance-connect-endpoint/eice-0123456789abcdef0"
+        ]
+
+    def test_without_an_endpoint_id_it_is_any_endpoint(self):
+        statements = eice_iam_statements()
+        tunnel = next(
+            s for s in statements if s["Sid"] == "ParslEphemeralOpenTunnelToSshOnly"
+        )
+        assert tunnel["Resource"] == ["*"]
+
+    def test_every_statement_is_an_allow_with_a_sid(self):
+        for statement in eice_iam_statements():
+            assert statement["Effect"] == "Allow"
+            assert statement["Sid"].startswith("ParslEphemeral")
+
+
+class TestNoUnexpectedSubprocesses:
+    """Nothing in construction may shell out.
+
+    ``EICETunnel.__init__`` resolving binaries is a PATH lookup, not an exec; a
+    constructor that ran ``aws`` would put a network call on the submit path.
+    """
+
+    def test_construction_runs_no_process(
+        self, session, keypair, fake_ssh, fake_aws, monkeypatch
+    ):
+        def refuse(*args, **kwargs):
+            raise AssertionError(f"unexpected subprocess: {args!r}")
+
+        monkeypatch.setattr(subprocess, "Popen", refuse)
+        monkeypatch.setattr(subprocess, "run", refuse)
+        tunnel = _tunnel(session, keypair, fake_ssh, fake_aws)
+        tunnel.ssh_command()
+        tunnel.proxy_command()
+
+    def test_the_private_key_is_passed_by_path_not_content(
+        self, session, keypair, fake_ssh, fake_aws
+    ):
+        # Key material in an argv is visible in `ps` to every user on the box.
+        argv = _tunnel(session, keypair, fake_ssh, fake_aws).ssh_command()
+        assert "PRIVATE" not in " ".join(argv)
+        assert argv[argv.index("-i") + 1] == keypair[0]
+
+
+class TestGeneratedKeys:
+    """StandardMode generates a pair when the caller supplies none."""
+
+    def test_the_generated_key_directory_is_private(self, tmp_path, monkeypatch):
+        # 0700, because the private key in it authorises SSH as the OS user.
+        from parsl_ephemeral_provider.modes import standard as standard_module
+
+        mode = object.__new__(standard_module.StandardMode)
+        mode.provider_id = "prov1234"
+        mode.tunnel_private_key_path = None
+        mode.tunnel_public_key_path = None
+        mode._tunnel_key_dir = None
+        monkeypatch.setattr(
+            standard_module.tempfile,
+            "mkdtemp",
+            lambda **kwargs: str(tmp_path / "keys"),
+        )
+        (tmp_path / "keys").mkdir()
+
+        private, public = mode._ensure_tunnel_keys()
+        assert os.path.exists(private) and os.path.exists(public)
+        assert stat.S_IMODE(os.stat(mode._tunnel_key_dir).st_mode) == 0o700
+
+    def test_a_missing_ssh_keygen_is_a_configuration_error(self, tmp_path, monkeypatch):
+        """No ssh-keygen must name itself, not fail inside subprocess.
+
+        The alternative is a ``FileNotFoundError`` from ``subprocess.run`` on the
+        submit path, which says nothing about what to install or that supplying a
+        keypair avoids the problem entirely.
+        """
+        from parsl_ephemeral_provider.exceptions import OperatingModeError
+        from parsl_ephemeral_provider.modes import standard as standard_module
+
+        mode = object.__new__(standard_module.StandardMode)
+        mode.provider_id = "prov1234"
+        mode.tunnel_private_key_path = None
+        mode.tunnel_public_key_path = None
+        mode._tunnel_key_dir = None
+        monkeypatch.setattr(
+            standard_module.tempfile, "mkdtemp", lambda **kwargs: str(tmp_path)
+        )
+        monkeypatch.setattr(standard_module.shutil, "which", lambda name: None)
+
+        with pytest.raises(OperatingModeError, match="ssh-keygen is not on PATH"):
+            mode._ensure_tunnel_keys()
+
+    def test_a_supplied_pair_is_used_unchanged(self, keypair):
+        from parsl_ephemeral_provider.modes import standard as standard_module
+
+        mode = object.__new__(standard_module.StandardMode)
+        mode.provider_id = "prov1234"
+        mode.tunnel_private_key_path, mode.tunnel_public_key_path = keypair
+        mode._tunnel_key_dir = None
+        assert mode._ensure_tunnel_keys() == keypair
+        assert mode._tunnel_key_dir is None  # nothing generated, nothing to clean

--- a/tests/unit/test_globus_config_loading.py
+++ b/tests/unit/test_globus_config_loading.py
@@ -683,6 +683,10 @@ class TestEveryParameterSurvivesTheRoundTrip:
                 "warm_pool_size": 1,
                 "warm_pool_ttl": 300,
                 "distribute_certificates": True,
+                "instance_connect_endpoint_id": "eice-0123456789abcdef0",
+                "tunnel_os_user": "ubuntu",
+                "tunnel_private_key_path": "/tmp/k",
+                "tunnel_public_key_path": "/tmp/k.pub",
             },
             "detached": {
                 "bastion_instance_type": "t3.small",

--- a/tests/unit/test_provider_edge_cases.py
+++ b/tests/unit/test_provider_edge_cases.py
@@ -12,6 +12,7 @@ import tempfile
 import time
 import uuid
 import warnings
+from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -1132,6 +1133,14 @@ STANDARD_ONLY_OPTIONS = [
     # elsewhere the flag would accept a request for an encrypted channel and
     # deliver workers that die on a missing certificate directory.
     ("distribute_certificates", True),
+    # Only StandardMode opens, supervises, and closes reverse tunnels (#134).
+    # Detached mode has its own answer to the same problem -- a bastion -- so
+    # accepting an endpoint ID there would read as a cheaper alternative that
+    # silently did nothing.
+    ("instance_connect_endpoint_id", "eice-0123456789abcdef0"),
+    ("tunnel_os_user", "ubuntu"),
+    ("tunnel_private_key_path", "/tmp/tunnel-key"),
+    ("tunnel_public_key_path", "/tmp/tunnel-key.pub"),
 ]
 
 NON_STANDARD_MODES = ["detached", "serverless"]
@@ -2454,3 +2463,392 @@ class TestCertificateDistributionProviderWiring:
 
     def test_the_default_is_off(self):
         assert self._mode_kwargs()["distribute_certificates"] is False
+
+
+@pytest.mark.unit
+class TestReverseTunnelsInStandardMode:
+    """StandardMode's half of #134: when a tunnel opens, and when it closes.
+
+    The tunnel mechanism itself -- argv, key push, reconnect, the 3600s ceiling --
+    is covered in ``test_eice_tunnel.py``. What is left here is the wiring, and
+    the wiring is where this feature can go wrong quietly: a tunnel opened after
+    dispatch races the connection it exists to carry, and one left open after
+    termination has the supervisor reconnecting to a dead instance for the rest of
+    the run.
+
+    ``EICETunnelSupervisor`` is patched at the name ``standard.py`` imports, so
+    nothing here starts an ``ssh``.
+    """
+
+    #: HTEX's shape. ``-a 127.0.0.1`` is what a tunnelled executor should use:
+    #: the reverse forward puts the interchange on the worker's own loopback.
+    CMD = "process_worker_pool.py -a 127.0.0.1 --port=54321 --block_id=0"
+
+    ENDPOINT = "eice-0123456789abcdef0"
+
+    def _mode(self, tmp_path, **overrides):
+        """A StandardMode with tunnelling on and a supplied key pair.
+
+        A supplied pair rather than a generated one so no test shells out to
+        ``ssh-keygen``; key generation is covered in ``test_eice_tunnel.py``.
+        """
+        from parsl_ephemeral_provider.modes.standard import StandardMode
+
+        provider_id = overrides.pop("provider_id", f"test-{uuid.uuid4().hex[:8]}")
+        private = tmp_path / "k"
+        private.write_text("PRIVATE")
+        public = tmp_path / "k.pub"
+        public.write_text("ssh-ed25519 AAAA test\n")
+        params = dict(
+            provider_id=provider_id,
+            session=MagicMock(),
+            state_store=FileStateStore(
+                file_path=str(tmp_path / f"{provider_id}.json"),
+                provider_id=provider_id,
+            ),
+            image_id="ami-12345678",
+            vpc_id="vpc-test00001",
+            subnet_id="subnet-test001",
+            security_group_id="sg-test00001",
+            instance_connect_endpoint_id=self.ENDPOINT,
+            tunnel_private_key_path=str(private),
+            tunnel_public_key_path=str(public),
+        )
+        params.update(overrides)
+        mode = StandardMode(**params)
+        mode.initialized = True
+        return mode
+
+    @contextmanager
+    def _patched_supervisor(self):
+        with patch(
+            "parsl_ephemeral_provider.modes.standard.EICETunnelSupervisor"
+        ) as cls:
+            cls.return_value.ports = [54321]
+            yield cls
+
+    # --- when a tunnel is opened at all ---
+
+    def test_no_endpoint_means_no_tunnel(self, tmp_path):
+        """The default must not construct a supervisor.
+
+        Constructing one resolves ``ssh`` and ``aws`` on PATH, which must not
+        become a requirement for every user of this provider.
+        """
+        mode = self._mode(tmp_path, instance_connect_endpoint_id=None)
+        with self._patched_supervisor() as cls:
+            mode._open_reverse_tunnel("i-1", self.CMD)
+        cls.assert_not_called()
+        assert mode._tunnel_supervisor is None
+
+    def test_a_command_with_no_port_opens_nothing(self, tmp_path):
+        """A caller-supplied command that is not a worker pool has nothing to forward.
+
+        Refusing would be wrong -- the provider runs arbitrary commands -- so this
+        is a no-op, which is why it is asserted rather than assumed.
+        """
+        mode = self._mode(tmp_path)
+        with self._patched_supervisor() as cls:
+            mode._open_reverse_tunnel("i-1", "echo hello")
+        cls.assert_not_called()
+
+    def test_the_supervisor_is_built_from_the_command_port(self, tmp_path):
+        # The port comes out of the command, not from configuration: the provider
+        # is never told where the interchange bound.
+        mode = self._mode(tmp_path)
+        with self._patched_supervisor() as cls:
+            mode._open_reverse_tunnel("i-1", self.CMD)
+
+        kwargs = cls.call_args.kwargs
+        assert kwargs["ports"] == [54321]
+        assert kwargs["endpoint_id"] == self.ENDPOINT
+        cls.return_value.add.assert_called_once_with("i-1")
+
+    def test_the_supervisor_is_reused_across_instances(self, tmp_path):
+        # One supervisor thread for the provider, one tunnel per instance.
+        mode = self._mode(tmp_path)
+        with self._patched_supervisor() as cls:
+            mode._open_reverse_tunnel("i-1", self.CMD)
+            mode._open_reverse_tunnel("i-2", self.CMD)
+
+        assert cls.call_count == 1
+        assert [c.args[0] for c in cls.return_value.add.call_args_list] == [
+            "i-1",
+            "i-2",
+        ]
+
+    def test_a_routable_address_is_warned_about(self, tmp_path, caplog):
+        """Otherwise the tunnel looks broken when it is the config that is wrong.
+
+        HTEX probes every address it is given, so a routable one may win and the
+        tunnel goes unused. Warned rather than rewritten: the command is the
+        caller's.
+        """
+        mode = self._mode(tmp_path)
+        with self._patched_supervisor(), caplog.at_level(logging.WARNING):
+            mode._open_reverse_tunnel(
+                "i-1", "process_worker_pool.py -a 54.1.2.3 --port=54321"
+            )
+        assert "127.0.0.1" in caplog.text
+
+    def test_loopback_draws_no_warning(self, tmp_path, caplog):
+        mode = self._mode(tmp_path)
+        with self._patched_supervisor(), caplog.at_level(logging.WARNING):
+            mode._open_reverse_tunnel("i-1", self.CMD)
+        assert "address" not in caplog.text.lower()
+
+    def test_a_first_connect_is_retried_then_gives_up(self, tmp_path, monkeypatch):
+        """ "running" is not "sshd is accepting connections".
+
+        The instance_running waiter clears well before the OS finishes booting, so
+        the first attempts are expected to fail. Failing the submit on the first
+        one would make cold starts flaky; never giving up would hang it.
+        """
+        from parsl_ephemeral_provider.modes import standard as standard_module
+
+        mode = self._mode(tmp_path)
+        monkeypatch.setattr(standard_module.time, "sleep", lambda _s: None)
+        clock = iter([0.0] + [float(n) for n in range(0, 2000, 400)])
+        monkeypatch.setattr(standard_module.time, "time", lambda: next(clock))
+
+        with self._patched_supervisor() as cls:
+            cls.return_value.add.side_effect = RuntimeError("Connection refused")
+            with pytest.raises(OperatingModeError, match="Connection refused"):
+                mode._open_reverse_tunnel("i-1", self.CMD)
+
+        assert cls.return_value.add.call_count > 1
+
+    def test_a_retried_connect_that_succeeds_does_not_raise(
+        self, tmp_path, monkeypatch
+    ):
+        from parsl_ephemeral_provider.modes import standard as standard_module
+
+        mode = self._mode(tmp_path)
+        monkeypatch.setattr(standard_module.time, "sleep", lambda _s: None)
+
+        with self._patched_supervisor() as cls:
+            cls.return_value.add.side_effect = [
+                RuntimeError("Connection refused"),
+                MagicMock(),
+            ]
+            mode._open_reverse_tunnel("i-1", self.CMD)
+
+        assert cls.return_value.add.call_count == 2
+
+    # --- ordering against dispatch ---
+
+    def test_the_tunnel_precedes_the_ssm_dispatch(self, tmp_path):
+        """The ordering assertion this class exists for.
+
+        The worker connects to the interchange as soon as the command starts, so a
+        tunnel opened afterwards races the connection it carries. Recorded as a
+        call order rather than inspected per call, because the defect is precisely
+        an inversion of the two.
+        """
+        mode = self._mode(tmp_path, one_shot=True)
+        calls = []
+        with (
+            self._patched_supervisor(),
+            patch.object(mode, "_create_instance", return_value="i-1"),
+            patch.object(mode, "_wait_for_ssm_online"),
+            patch.object(mode, "_wait_for_worker_ready"),
+            patch.object(
+                mode,
+                "_open_reverse_tunnel",
+                side_effect=lambda *a: calls.append("tunnel"),
+            ),
+            patch.object(
+                mode,
+                "_dispatch_ssm_command",
+                side_effect=lambda *a: calls.append("dispatch") or "cmd-1",
+            ),
+        ):
+            mode.submit_job("job-1", self.CMD, 1)
+
+        assert calls == ["tunnel", "dispatch"]
+
+    def test_a_reused_warm_instance_gets_its_tunnel_before_dispatch(self, tmp_path):
+        # A warm instance may already have a live tunnel, in which case add() is a
+        # no-op -- but it may equally have been adopted from a state file, so this
+        # path cannot assume one exists.
+        mode = self._mode(
+            tmp_path, warm_pool_size=1, iam_instance_profile_arn=_FAKE_IAM_ARN
+        )
+        mode._warm_instances = ["i-warm"]
+        mode.resources = {"i-warm": {"type": "ec2", "status": "WARM"}}
+        calls = []
+        with (
+            self._patched_supervisor(),
+            patch.object(
+                mode,
+                "_open_reverse_tunnel",
+                side_effect=lambda *a: calls.append("tunnel"),
+            ),
+            patch.object(
+                mode,
+                "_dispatch_ssm_command",
+                side_effect=lambda *a: calls.append("dispatch") or "cmd-1",
+            ),
+        ):
+            assert mode.submit_job("job-1", self.CMD, 1) == "i-warm"
+
+        assert calls == ["tunnel", "dispatch"]
+
+    def test_a_failed_dispatch_closes_the_tunnel(self, tmp_path):
+        """The instance is about to be terminated, so the tunnel must go with it.
+
+        Otherwise the supervisor spends the rest of the run reconnecting to an
+        instance that no longer exists.
+        """
+        mode = self._mode(tmp_path, one_shot=True)
+        with (
+            self._patched_supervisor() as cls,
+            patch.object(mode, "_create_instance", return_value="i-1"),
+            patch.object(mode, "_wait_for_ssm_online"),
+            patch.object(mode, "_wait_for_worker_ready"),
+            patch.object(mode, "_force_terminate"),
+            patch.object(
+                mode, "_dispatch_ssm_command", side_effect=RuntimeError("no agent")
+            ),
+        ):
+            with pytest.raises(OperatingModeError):
+                mode.submit_job("job-1", self.CMD, 1)
+
+        cls.return_value.remove.assert_any_call("i-1")
+
+    # --- teardown ---
+
+    def test_cleanup_resources_closes_the_tunnel_first(self, tmp_path):
+        mode = self._mode(tmp_path)
+        with self._patched_supervisor() as cls:
+            mode._open_reverse_tunnel("i-1", self.CMD)
+            mode.resources = {"i-1": {"type": "ec2", "job_id": "job-1"}}
+            mode.cleanup_resources(["i-1"])
+
+        cls.return_value.remove.assert_called_once_with("i-1")
+
+    def test_cleanup_resources_tolerates_ids_that_never_had_a_tunnel(self, tmp_path):
+        # It is called with every resource ID, including ones submitted before
+        # tunnelling was ever used.
+        mode = self._mode(tmp_path)
+        mode.resources = {"i-1": {"type": "ec2", "job_id": "job-1"}}
+        mode.cleanup_resources(["i-1"])  # no supervisor exists at all
+
+    def test_cleanup_infrastructure_stops_the_supervisor(self, tmp_path):
+        """The thread must not outlive the provider.
+
+        It is a daemon, so it would not block exit -- but it would spend the
+        remaining life of the process reconnecting to terminated instances.
+        """
+        mode = self._mode(tmp_path)
+        with self._patched_supervisor() as cls:
+            mode._open_reverse_tunnel("i-1", self.CMD)
+            mode.cleanup_infrastructure()
+
+        cls.return_value.shutdown.assert_called_once()
+        assert mode._tunnel_supervisor is None
+
+    def test_generated_key_material_is_removed_at_cleanup(self, tmp_path):
+        """A generated key is never persisted, so cleanup must delete the directory.
+
+        It authorises SSH as the OS user; leaving it in ``/tmp`` after the run
+        would outlive every instance it could reach, but is still key material
+        with no reason to exist.
+        """
+        mode = self._mode(
+            tmp_path, tunnel_private_key_path=None, tunnel_public_key_path=None
+        )
+        with self._patched_supervisor():
+            mode._open_reverse_tunnel("i-1", self.CMD)
+            key_dir = mode._tunnel_key_dir
+            assert key_dir is not None and os.path.isdir(key_dir)
+            mode.cleanup_infrastructure()
+
+        assert not os.path.exists(key_dir)
+        assert mode._tunnel_key_dir is None
+
+    def test_half_a_key_pair_is_refused_at_construction(self, tmp_path):
+        """Not at the first submit, minutes and one paid instance later."""
+        with pytest.raises(ValueError, match="must be set together"):
+            self._mode(tmp_path, tunnel_public_key_path=None)
+
+    def test_the_endpoint_id_is_verified_with_the_other_network_ids(self, tmp_path):
+        """An endpoint typo must fail in initialize(), not inside a ProxyCommand.
+
+        Both error codes were confirmed against real AWS. Without this the failure
+        arrives at the first submit as an ssh process exiting for no visible
+        reason.
+        """
+        from botocore.exceptions import ClientError
+
+        from parsl_ephemeral_provider.exceptions import ResourceNotFoundError
+
+        mode = self._mode(tmp_path)
+        ec2 = mode.session.client.return_value
+        ec2.describe_instance_connect_endpoints.side_effect = ClientError(
+            {
+                "Error": {
+                    "Code": "InvalidInstanceConnectEndpointId.NotFound",
+                    "Message": "does not exist",
+                }
+            },
+            "DescribeInstanceConnectEndpoints",
+        )
+
+        with pytest.raises(ResourceNotFoundError, match=self.ENDPOINT):
+            mode._verify_resources()
+
+
+@pytest.mark.unit
+class TestReverseTunnelProviderWiring:
+    """The provider end of #134: the options reach the mode, or are refused."""
+
+    ENDPOINT = "eice-0123456789abcdef0"
+
+    def _mode_kwargs(self, **provider_kwargs):
+        """The kwargs the provider really passes to ``StandardMode``."""
+        with (
+            patch(
+                "parsl_ephemeral_provider.provider.create_session"
+            ) as mock_session_factory,
+            patch("parsl_ephemeral_provider.provider.StandardMode") as mode_cls,
+            patch.object(EphemeralProvider, "_load_state", return_value=None),
+            patch.object(
+                EphemeralProvider, "_initialize_state_store", return_value=MagicMock()
+            ),
+        ):
+            mock_session_factory.return_value = MagicMock()
+            EphemeralProvider(
+                region="us-east-1",
+                image_id="ami-12345678",
+                mode="standard",
+                vpc_id="vpc-test00001",
+                subnet_id="subnet-test001",
+                security_group_id="sg-test00001",
+                **provider_kwargs,
+            )
+        return mode_cls.call_args.kwargs
+
+    def test_the_endpoint_reaches_standard_mode(self):
+        # Forwarding is the step whose omission made ten options unreachable in
+        # #136; this asserts the call the provider makes, not a mode built here.
+        kwargs = self._mode_kwargs(instance_connect_endpoint_id=self.ENDPOINT)
+        assert kwargs["instance_connect_endpoint_id"] == self.ENDPOINT
+
+    def test_all_four_options_reach_standard_mode(self):
+        kwargs = self._mode_kwargs(
+            instance_connect_endpoint_id=self.ENDPOINT,
+            tunnel_os_user="ubuntu",
+            tunnel_private_key_path="/tmp/k",
+            tunnel_public_key_path="/tmp/k.pub",
+        )
+        assert kwargs["tunnel_os_user"] == "ubuntu"
+        assert kwargs["tunnel_private_key_path"] == "/tmp/k"
+        assert kwargs["tunnel_public_key_path"] == "/tmp/k.pub"
+
+    def test_the_default_is_no_tunnelling(self):
+        assert self._mode_kwargs()["instance_connect_endpoint_id"] is None
+
+    # Refusal on the other modes is covered by TestStandardOnlyOptionGuard,
+    # which drives every standard-only option through both of them; the four
+    # tunnel options are entries in its STANDARD_ONLY_OPTIONS list.


### PR DESCRIPTION
Closes #134.

Standard mode can now reach workers that cannot reach it. Set
`instance_connect_endpoint_id` and the provider holds an `ssh -R` reverse
forward open to every worker through an EC2 Instance Connect Endpoint, so the
interchange appears on the worker's *own* loopback. Point HTEX at
`address="127.0.0.1"` and no driver address has to be routable — a laptop
behind home or office NAT no longer has to pay for a bastion.

## The issue's mechanism does not work

Worth stating first, because correcting it shaped everything else.

#134 proposed `aws ec2-instance-connect open-tunnel --remote-port` to carry the
interchange ports. `--remote-port` is *the port to connect to on the instance*
and `--local-port` is *the port to listen on locally*: it is a **forward**
tunnel, driver → worker. Aimed at 54000–55000 it forwards driver-side
connections to worker ports where nothing is listening.

What works is EICE for the one thing it does — reach port 22 — with SSH
carrying the reverse forward:

```
ssh -o ProxyCommand="aws ec2-instance-connect open-tunnel --instance-id <id>" \
    -R <port>:127.0.0.1:<port> ec2-user@<id>
```

Verified live: a `zmq.DEALER` on a `t3.micro` completed a full round trip to a
`zmq.ROUTER` bound to driver loopback — HTEX's own socket pair on its own port
range. ZMTP greets bidirectionally, so this is a stronger check than raw TCP; a
half-working forward fails it. The corrected mechanism is recorded on the issue
and in `network/eice.py`'s module docstring.

## Four API constraints, each confirmed live

These are why this is a supervised subprocess and not a config flag:

| Constraint | Consequence |
|---|---|
| A tunnel is capped at **3600s** | `needs_recycle()` replaces it 300s early, so the gap is a reconnect and not a dropped message |
| Reconnect must fit HTEX's **120s `heartbeat_threshold`** | `ServerAliveInterval=20`/`CountMax=3` notices death in ~60s; the supervisor polls every 30s |
| `send-ssh-public-key` grants **~60s** | The key is re-pushed immediately before *every* connect, not once per instance |
| Endpoint creation takes **minutes** (~4.5 measured) | The endpoint is caller-supplied per #69 and joins `_verify_resources` |

The ceiling is inclusive and the API's own error message is off by one: 3600 is
accepted, 3601 is rejected by `ParamValidation` with *"must be … less than
3600"*. `test_the_duration_ceiling_is_what_the_api_enforces` asserts both
boundaries against the real CLI using a deliberately malformed instance ID, so
it needs no instance and notices if AWS ever moves the cap.

Also load-bearing: **`instance_running` is not "sshd is listening."** A tunnel
against a merely-running instance fails with `Websocket Closure Reason: Unable
to connect to target`, so `_open_reverse_tunnel` retries for
`TUNNEL_OPEN_TIMEOUT` (300s) and the E2E fixtures wait on `instance_status_ok`.

## Defects found and fixed during development

Both are tunnel-lifecycle races that leak an `ssh` process nothing can reap —
unbounded on a long-lived driver — and both have regression tests.

1. **Concurrent starts orphaned an `ssh` process.** Found by noticing two
   PPID-1 `ssh` processes outliving a unit run. `start()`'s `is_alive()` check
   was unlocked and `add()` registered the tunnel before starting it, so two
   `Popen`s could race and the second assignment to `_process` orphaned the
   first for good. Fixed with a `_lifecycle_lock` around start/stop/restart and
   by starting before registering. *Verified* by capturing the PID set before
   and after a clean run: identical, zero new orphans.
   → `test_concurrent_starts_do_not_orphan_an_ssh_process` (4 racing threads,
   every `barrier.wait()` bounded so a regression cannot hang the suite).

2. **A removed tunnel was revived.** `_supervise_once()` iterates a snapshot,
   so a pass already in flight restarted a tunnel `remove()` had just dropped —
   a tunnel to an instance being terminated, and invisible, because the
   supervisor no longer held a reference. Fixed with `retire()`: `remove()` and
   `shutdown()` now mark the tunnel retired so no later `start()` can revive it.
   → `test_a_removed_tunnel_is_not_revived_by_a_pass_in_flight`

`bandit` also fired for the first time on these paths (it is a changed-files
hook, so `detached.py` and `lambda_func.py` were never scanned either). Two
findings were real and are fixed rather than suppressed: `ssh-keygen` is now
resolved to an absolute path via `shutil.which`, with a named
`OperatingModeError` when it is missing instead of a bare `FileNotFoundError`
on the submit path; and two `assert`s that would have vanished under `-O` —
leaving an argv built from the string `"None"` — are now real raises.

## What is new

- `parsl_ephemeral_provider/network/eice.py` — `EICETunnel` (key push, argv
  construction, settle detection, recycle) and `EICETunnelSupervisor` (one
  tunnel per instance, a 30s supervision thread, reconnect on death or age).
  `extract_worker_ports` reads `--port=` out of the command the same way #62's
  `extract_cert_dir` reads `--cert_dir`: the provider is never *told* where the
  interchange bound.
- Four provider options — `instance_connect_endpoint_id`, `tunnel_os_user`,
  `tunnel_private_key_path`, `tunnel_public_key_path` — all standard-only, all
  in the #155 guard, all covered by the round-trip test in
  `test_globus_config_loading.py`.
- Lifecycle in `StandardMode`: a tunnel is opened *before* every dispatch and
  closed on dispatch failure, in `_cleanup_resources`, and first in
  `cleanup_infrastructure`. A generated keypair lives in a 0700 temp dir and is
  never persisted — `send-ssh-public-key` re-authorises it every minute anyway,
  so there is nothing to gain by keeping it.

## Costs, named in the docs

This is the **only part of the package that shells out**: it needs an `ssh`
binary and AWS CLI v2, because `ec2-instance-connect` exposes no `OpenTunnel` in
the API. Both are checked up front so a missing binary is a configuration error
rather than a worker that mysteriously never registers. The security-group trade
is explicit in `docs/network-prerequisites.md` and `docs/security.md`: inbound
22 from the endpoint, in exchange for dropping the client-facing 54000–55000
rule.

## Verification

| Gate | Result |
|---|---|
| Live E2E (`tests/aws/test_eice_tunnel_e2e.py`, account 942542972736) | **11/11 passed** |
| Unit + security | 1449 passed, 2 skipped |
| Integration (substrate) | 140 passed |
| `ruff check` / `format` | clean, 154 files |
| `bandit` | clean |
| `mypy` | 59 errors — baseline held |

The live suite covers the round trip, tunnel-before-dispatch, that `shutdown()`
closes the tunnel and removes the key, all four API constraints, and three
`iam:SimulateCustomPolicy` checks (`OpenTunnel` conditioned on `remotePort`,
`SendSSHPublicKey` on `ec2:osuser`).

Post-run leak audit: **0 running instances, 0 `ssh` tunnels**. The one IAM role
and one launch template still in the account are the pre-existing
`8001b08f-…` pair from an earlier session, not from this run.
